### PR TITLE
[SYSML-375] [Optimizer] Address Optimizer Inconsistencies Due to Casting of Doubles To Ints

### DIFF
--- a/src/main/java/com/ibm/bi/dml/hops/TernaryOp.java
+++ b/src/main/java/com/ibm/bi/dml/hops/TernaryOp.java
@@ -930,7 +930,7 @@ public class TernaryOp extends Hop
 						DataGenOp dgop = (DataGenOp) input1;
 						if( dgop.getOp() == DataGenMethod.SEQ ){
 							Hop incr = dgop.getInput().get(dgop.getParamIndex(Statement.SEQ_INCR));
-							ret = (incr instanceof LiteralOp && HopRewriteUtils.getIntValue((LiteralOp)incr)==1)
+							ret = (incr instanceof LiteralOp && HopRewriteUtils.getDoubleValue((LiteralOp)incr)==1)
 								  || dgop.getIncrementValue()==1.0; //set by recompiler
 						}
 					}
@@ -940,7 +940,7 @@ public class TernaryOp extends Hop
 						DataGenOp dgop = (DataGenOp) input2;
 						if( dgop.getOp() == DataGenMethod.SEQ ){
 							Hop incr = dgop.getInput().get(dgop.getParamIndex(Statement.SEQ_INCR));
-							ret |= (incr instanceof LiteralOp && HopRewriteUtils.getIntValue((LiteralOp)incr)==1)
+							ret |= (incr instanceof LiteralOp && HopRewriteUtils.getDoubleValue((LiteralOp)incr)==1)
 								   || dgop.getIncrementValue()==1.0; //set by recompiler;
 						}
 					}

--- a/src/main/java/com/ibm/bi/dml/hops/recompile/LiteralReplacement.java
+++ b/src/main/java/com/ibm/bi/dml/hops/recompile/LiteralReplacement.java
@@ -217,7 +217,7 @@ public class LiteralReplacement
 						ret = new LiteralOp(ival);		
 						break;
 					case CAST_AS_DOUBLE:
-						long dval = HopRewriteUtils.getIntValue(sdat);
+						double dval = HopRewriteUtils.getDoubleValue(sdat);
 						ret = new LiteralOp(dval);		
 						break;						
 					case CAST_AS_BOOLEAN:

--- a/src/main/java/com/ibm/bi/dml/hops/rewrite/HopRewriteUtils.java
+++ b/src/main/java/com/ibm/bi/dml/hops/rewrite/HopRewriteUtils.java
@@ -159,10 +159,11 @@ public class HopRewriteUtils
 	}
 	
 	/**
-	 * 
-	 * @param op
-	 * @return
-	 * @throws HopsException
+	 * Return the int value of a LiteralOp (as a long).
+	 *
+	 * Note: For comparisons, this is *only* to be used in situations
+	 * in which the value is absolutely guaranteed to be an integer.
+	 * Otherwise, a safer alternative is `getDoubleValue`.
 	 */
 	public static long getIntValue( LiteralOp op )
 		throws HopsException

--- a/src/main/java/com/ibm/bi/dml/hops/rewrite/RewriteAlgebraicSimplificationDynamic.java
+++ b/src/main/java/com/ibm/bi/dml/hops/rewrite/RewriteAlgebraicSimplificationDynamic.java
@@ -1363,7 +1363,7 @@ public class RewriteAlgebraicSimplificationDynamic extends HopRewriteRule
 			//check for sum(v^2), might have been rewritten from sum(v*v)
 			if( hi2 instanceof BinaryOp && ((BinaryOp)hi2).getOp()==OpOp2.POW
 				&& hi2.getInput().get(1) instanceof LiteralOp 
-				&& HopRewriteUtils.getIntValue((LiteralOp)hi2.getInput().get(1))==2
+				&& HopRewriteUtils.getDoubleValue((LiteralOp)hi2.getInput().get(1))==2
 				&& hi2.getParent().size() == 1 ) //no other consumer than sum
 			{
 				Hop input = hi2.getInput().get(0);

--- a/src/main/java/com/ibm/bi/dml/hops/rewrite/RewriteAlgebraicSimplificationStatic.java
+++ b/src/main/java/com/ibm/bi/dml/hops/rewrite/RewriteAlgebraicSimplificationStatic.java
@@ -1347,7 +1347,7 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 				&& HopRewriteUtils.isEqualSize(bop.getInput().get(0), bop.getInput().get(1)) //prevent mv
 				&& ((BinaryOp)bop.getInput().get(1)).getOp()==OpOp2.POW 
 				&& bop.getInput().get(1).getInput().get(1) instanceof LiteralOp
-				&& HopRewriteUtils.getIntValue((LiteralOp)bop.getInput().get(1).getInput().get(1))==2)
+				&& HopRewriteUtils.getDoubleValue((LiteralOp)bop.getInput().get(1).getInput().get(1))==2)
 			{
 				Hop W = bop.getInput().get(0);
 				Hop tmp = bop.getInput().get(1).getInput().get(0); //(X - U %*% t(V))
@@ -1403,7 +1403,7 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 			//alternative pattern: sum ((W * (U %*% t(V)) - X) ^ 2)
 			if( !appliedPattern
 				&& bop.getOp()==OpOp2.POW && bop.getInput().get(1) instanceof LiteralOp
-				&& HopRewriteUtils.getIntValue((LiteralOp)bop.getInput().get(1))==2
+				&& HopRewriteUtils.getDoubleValue((LiteralOp)bop.getInput().get(1))==2
 				&& bop.getInput().get(0) instanceof BinaryOp	
 				&& bop.getInput().get(0).getDataType()==DataType.MATRIX	
 				&& ((BinaryOp)bop.getInput().get(0)).getOp()==OpOp2.MINUS
@@ -1458,7 +1458,7 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 			//alternative pattern: sum (((U %*% t(V)) - X) ^ 2)
 			if( !appliedPattern
 				&& bop.getOp()==OpOp2.POW && bop.getInput().get(1) instanceof LiteralOp
-				&& HopRewriteUtils.getIntValue((LiteralOp)bop.getInput().get(1))==2
+				&& HopRewriteUtils.getDoubleValue((LiteralOp)bop.getInput().get(1))==2
 				&& bop.getInput().get(0) instanceof BinaryOp	
 				&& bop.getInput().get(0).getDataType()==DataType.MATRIX	
 				&& ((BinaryOp)bop.getInput().get(0)).getOp()==OpOp2.MINUS


### PR DESCRIPTION
This addresses a few inconsistencies with our optimizer in which accidental truncation of double values to integer values could lead to rewrite rules being mistakenly applied.  As an example, a rewrite rule targeting the expression `sum(v^2)` could be mistakenly applied to the expression `sum(v^2.3)`.