### PR TITLE
Refactor unit tests in descriptivestats and parfor packages.

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/BivariateCategoricalCategoricallTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/BivariateCategoricalCategoricallTest.java
@@ -29,9 +29,9 @@ import org.apache.sysml.test.utils.TestUtils;
 
 public class BivariateCategoricalCategoricallTest extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_DIR = "applications/descriptivestats/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + BivariateCategoricalCategoricallTest.class.getSimpleName() + "/";
 	private final static String TEST_NOMINAL_NOMINAL = "CategoricalCategorical";
 	private final static String TEST_NOMINAL_NOMINAL_WEIGHTS = "CategoricalCategoricalWithWeightsTest";
 	private final static String TEST_ODDS_RATIO = "OddsRatio";
@@ -44,41 +44,41 @@ public class BivariateCategoricalCategoricallTest extends AutomatedTestBase
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NOMINAL_NOMINAL, new TestConfiguration(TEST_DIR, TEST_NOMINAL_NOMINAL, 
+		addTestConfiguration(TEST_NOMINAL_NOMINAL, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NOMINAL_NOMINAL, 
 				new String[] { "PValue"+".scalar", "CramersV"+".scalar" }));
-		addTestConfiguration(TEST_NOMINAL_NOMINAL_WEIGHTS, new TestConfiguration(TEST_DIR, TEST_NOMINAL_NOMINAL_WEIGHTS, new String[] { "PValue"+".scalar", "CramersV"+".scalar" }));
-		addTestConfiguration(TEST_ODDS_RATIO, new TestConfiguration(TEST_DIR, TEST_ODDS_RATIO, new String[] { 	"oddsRatio"+".scalar", 
-																												"sigma"+".scalar", 
-																												"leftConf"+".scalar", 
-																												"rightConf"+".scalar", 
-																												"sigmasAway"+".scalar" 
-																												//"chiSquared"+".scalar", 
-																												//"degFreedom"+".scalar", 
-																												//"pValue"+".scalar", 
-																												//"cramersV"+".scalar"
-																												}));
+		addTestConfiguration(TEST_NOMINAL_NOMINAL_WEIGHTS, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NOMINAL_NOMINAL_WEIGHTS, 
+				new String[] { "PValue"+".scalar", "CramersV"+".scalar" }));
+		addTestConfiguration(TEST_ODDS_RATIO, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_ODDS_RATIO, 
+				new String[] { 	
+					"oddsRatio"+".scalar", 
+					"sigma"+".scalar", 
+					"leftConf"+".scalar", 
+					"rightConf"+".scalar", 
+					"sigmasAway"+".scalar" 
+					//"chiSquared"+".scalar", 
+					//"degFreedom"+".scalar", 
+					//"pValue"+".scalar", 
+					//"cramersV"+".scalar"
+					}));
 	}
 
 	@Test
 	public void testCategoricalCategorical() {
-		
 		TestConfiguration config = getTestConfiguration(TEST_NOMINAL_NOMINAL);
-		
 		config.addVariable("rows", rows);
+		loadTestConfiguration(config);
 
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String CC_HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = CC_HOME + TEST_NOMINAL_NOMINAL + ".dml";
-		programArgs = new String[]{"-args",  CC_HOME + INPUT_DIR + "A" , 
-				                        Integer.toString(rows),
-				                        CC_HOME + INPUT_DIR + "B" , 
-				                        CC_HOME + OUTPUT_DIR + "PValue" , 
-				                        CC_HOME + OUTPUT_DIR + "CramersV" };
-		fullRScriptName = CC_HOME + TEST_NOMINAL_NOMINAL + ".R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       CC_HOME + INPUT_DIR + " " + CC_HOME + EXPECTED_DIR;
+		programArgs = new String[]{"-args", input("A"), Integer.toString(rows), input("B"), 
+			output("PValue"), output("CramersV")};
 		
-		loadTestConfiguration(config);
+		fullRScriptName = CC_HOME + TEST_NOMINAL_NOMINAL + ".R";
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
         double[][] A = getRandomMatrix(rows, 1, 1, ncatA, 1, 3);
         double[][] B = getRandomMatrix(rows, 1, 1, ncatB, 1, 7);
@@ -126,25 +126,18 @@ public class BivariateCategoricalCategoricallTest extends AutomatedTestBase
 
 	@Test
 	public void testCategoricalCategoricalWithWeights() {
-
 		TestConfiguration config = getTestConfiguration(TEST_NOMINAL_NOMINAL_WEIGHTS);
-		
 		config.addVariable("rows", rows);
+		loadTestConfiguration(config);
 
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String CC_HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = CC_HOME + TEST_NOMINAL_NOMINAL_WEIGHTS + ".dml";
-		programArgs = new String[]{"-args",  CC_HOME + INPUT_DIR + "A" , 
-				                        Integer.toString(rows),
-				                        CC_HOME + INPUT_DIR + "B" , 
-				                        CC_HOME + INPUT_DIR + "WM" , 
-				                        CC_HOME + OUTPUT_DIR + "PValue" , 
-				                        CC_HOME + OUTPUT_DIR + "CramersV" };
-		fullRScriptName = CC_HOME + TEST_NOMINAL_NOMINAL_WEIGHTS + ".R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       CC_HOME + INPUT_DIR + " " + CC_HOME + EXPECTED_DIR;
+		programArgs = new String[]{"-args", input("A"), Integer.toString(rows),
+			input("B"), input("WM"), output("PValue"), output("CramersV") };
 		
-		loadTestConfiguration(config);
+		fullRScriptName = CC_HOME + TEST_NOMINAL_NOMINAL_WEIGHTS + ".R";
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
         double[][] A = getRandomMatrix(rows, 1, 1, ncatA, 1, System.currentTimeMillis());
         double[][] B = getRandomMatrix(rows, 1, 1, ncatB, 1, System.currentTimeMillis()+1);
@@ -191,32 +184,27 @@ public class BivariateCategoricalCategoricallTest extends AutomatedTestBase
 	
 	@Test
 	public void testOddsRatio() {
-		
 		TestConfiguration config = getTestConfiguration(TEST_ODDS_RATIO);
-		
 		config.addVariable("rows", rows);
+		loadTestConfiguration(config);
 
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String CC_HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = CC_HOME + TEST_ODDS_RATIO + ".dml";
-		programArgs = new String[]{"-args",  CC_HOME + INPUT_DIR + "A" , 
-				                        Integer.toString(rows),
-				                        CC_HOME + INPUT_DIR + "B" , 
-				                        CC_HOME + OUTPUT_DIR + "oddsRatio" , 
-				                        CC_HOME + OUTPUT_DIR + "sigma", 
-				                        CC_HOME + OUTPUT_DIR + "leftConf" , 
-				                        CC_HOME + OUTPUT_DIR + "rightConf", 
-				                        CC_HOME + OUTPUT_DIR + "sigmasAway" 
-				                        //CC_HOME + OUTPUT_DIR + "chiSquared", 
-				                        //CC_HOME + OUTPUT_DIR + "degFreedom" , 
-				                        //CC_HOME + OUTPUT_DIR + "pValue", 
-				                        //CC_HOME + OUTPUT_DIR + "cramersV"
-				                        };
-		fullRScriptName = CC_HOME + TEST_ODDS_RATIO + ".R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       CC_HOME + INPUT_DIR + " " + CC_HOME + EXPECTED_DIR;
+		programArgs = new String[]{"-args",  input("A"), Integer.toString(rows), input("B"), 
+			output("oddsRatio"), 
+			output("sigma"), 
+			output("leftConf"), 
+			output("rightConf"), 
+			output("sigmasAway")
+			//output("chiSquared"), 
+			//output(degFreedom"), 
+			//output("pValue"), 
+			//output("cramersV")
+			};
 		
-		loadTestConfiguration(config);
+		fullRScriptName = CC_HOME + TEST_ODDS_RATIO + ".R";
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
 		// current test works only for 2x2 contingency tables => #categories must be 2
 		int numCat = 2;
@@ -251,6 +239,4 @@ public class BivariateCategoricalCategoricallTest extends AutomatedTestBase
 		
 	}
 	
-
-
 }

--- a/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/BivariateOrdinalOrdinalTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/BivariateOrdinalOrdinalTest.java
@@ -29,11 +29,11 @@ import org.apache.sysml.test.utils.TestUtils;
 
 public class BivariateOrdinalOrdinalTest extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_DIR = "applications/descriptivestats/";
 	private final static String TEST_ORDINAL_ORDINAL = "OrdinalOrdinal";
 	private final static String TEST_ORDINAL_ORDINAL_WEIGHTS = "OrdinalOrdinalWithWeightsTest";
+	private final static String TEST_CLASS_DIR = TEST_DIR + BivariateOrdinalOrdinalTest.class.getSimpleName() + "/";
 
 	private final static double eps = 1e-9;
 	private final static int rows = 10000;
@@ -44,31 +44,27 @@ public class BivariateOrdinalOrdinalTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		addTestConfiguration(TEST_ORDINAL_ORDINAL, 
-				new TestConfiguration(TEST_DIR, TEST_ORDINAL_ORDINAL, 
+				new TestConfiguration(TEST_CLASS_DIR, TEST_ORDINAL_ORDINAL, 
 					new String[] { "Spearman"+".scalar" }));
 		addTestConfiguration(TEST_ORDINAL_ORDINAL_WEIGHTS, 
-				new TestConfiguration(TEST_DIR, TEST_ORDINAL_ORDINAL_WEIGHTS, 
+				new TestConfiguration(TEST_CLASS_DIR, TEST_ORDINAL_ORDINAL_WEIGHTS, 
 					new String[] { "Spearman"+".scalar" }));
 	}
 	
 	@Test
 	public void testOrdinalOrdinal() {
 		TestConfiguration config = getTestConfiguration(TEST_ORDINAL_ORDINAL);
-		
 		config.addVariable("rows", rows);
+		loadTestConfiguration(config);
 		
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String OO_HOME = SCRIPT_DIR + TEST_DIR;	
 		fullDMLScriptName = OO_HOME + TEST_ORDINAL_ORDINAL + ".dml";
-		programArgs = new String[]{"-args", OO_HOME + INPUT_DIR + "A", 
-	                        Integer.toString(rows),
-	                        OO_HOME + INPUT_DIR + "B", 
-	                        OO_HOME + OUTPUT_DIR + "Spearman"};
+		programArgs = new String[]{"-args", input("A"),
+			Integer.toString(rows), input("B"), output("Spearman")};
+		
 		fullRScriptName = OO_HOME + TEST_ORDINAL_ORDINAL + ".R";
-		rCmd = "Rscript" + " " + OO_HOME + TEST_ORDINAL_ORDINAL + ".R" + " " + 
-		       OO_HOME + INPUT_DIR + " " + OO_HOME + EXPECTED_DIR;
-
-		loadTestConfiguration(config);
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
         double[][] A = getRandomMatrix(rows, 1, 1, ncatA, 1, System.currentTimeMillis());
         double[][] B = getRandomMatrix(rows, 1, 1, ncatB, 1, System.currentTimeMillis()+1);
@@ -107,23 +103,17 @@ public class BivariateOrdinalOrdinalTest extends AutomatedTestBase
 	@Test
 	public void testOrdinalOrdinalWithWeights() {
 		TestConfiguration config = getTestConfiguration(TEST_ORDINAL_ORDINAL_WEIGHTS);
-		
 		config.addVariable("rows", rows);
+		loadTestConfiguration(config);
 
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String OO_HOME = SCRIPT_DIR + TEST_DIR;	
 		fullDMLScriptName = OO_HOME + TEST_ORDINAL_ORDINAL_WEIGHTS + ".dml";
-		programArgs = new String[]{"-args", OO_HOME + INPUT_DIR + "A", 
-	                        Integer.toString(rows),
-	                        OO_HOME + INPUT_DIR + "B", 
-	                        OO_HOME + INPUT_DIR + "WM", 
-	                        OO_HOME + OUTPUT_DIR + "Spearman"};
+		programArgs = new String[]{"-args", input("A"),
+			Integer.toString(rows), input("B"), input("WM"), output("Spearman")};
 
 		fullRScriptName = OO_HOME + TEST_ORDINAL_ORDINAL_WEIGHTS + ".R";
-		rCmd = "Rscript" + " " + OO_HOME + TEST_ORDINAL_ORDINAL_WEIGHTS + ".R" + " " + 
-		       OO_HOME + INPUT_DIR + " " + OO_HOME + EXPECTED_DIR;
-
-		loadTestConfiguration(config);
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
         double[][] A = getRandomMatrix(rows, 1, 1, ncatA, 1, System.currentTimeMillis());
         double[][] B = getRandomMatrix(rows, 1, 1, ncatB, 1, System.currentTimeMillis());
@@ -157,5 +147,4 @@ public class BivariateOrdinalOrdinalTest extends AutomatedTestBase
 		}
 	}
 	
-
 }

--- a/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/BivariateScaleCategoricalTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/BivariateScaleCategoricalTest.java
@@ -31,11 +31,11 @@ import org.apache.sysml.test.utils.TestUtils;
 public class BivariateScaleCategoricalTest extends AutomatedTestBase 
 {
 
-	
 	private final static String TEST_DIR = "applications/descriptivestats/";
 	private final static String TEST_SCALE_NOMINAL = "ScaleCategorical";
 	private final static String TEST_SCALE_NOMINAL_WEIGHTS = "ScaleCategoricalWithWeightsTest";
-
+	private final static String TEST_CLASS_DIR = TEST_DIR + BivariateScaleCategoricalTest.class.getSimpleName() + "/";
+	
 	private final static double eps = 1e-9;
 	private final static int rows = 10000;
 	private final static int ncatA = 100; // # of categories in A
@@ -46,37 +46,30 @@ public class BivariateScaleCategoricalTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		addTestConfiguration(TEST_SCALE_NOMINAL, 
-				new TestConfiguration(TEST_DIR, TEST_SCALE_NOMINAL, 
-					new String[] { "Eta"+".scalar", "AnovaF"+".scalar", "VarY"+".scalar", "MeanY"+".scalar", "CFreqs", "CMeans", "CVars" }));
-		//addTestConfiguration(TEST_SCALE_NOMINAL_WEIGHTS, new TestConfiguration(TEST_DIR, "ScaleCategoricalWithWeightsTest", new String[] { "outEta", "outAnovaF", "outVarY", "outMeanY", "outCatFreqs", "outCatMeans", "outCatVars" }));
-		addTestConfiguration(TEST_SCALE_NOMINAL_WEIGHTS, new TestConfiguration(TEST_DIR, "ScaleCategoricalWithWeightsTest", new String[] { "Eta"+".scalar", "AnovaF"+".scalar", "VarY"+".scalar", "MeanY"+".scalar", "CFreqs", "CMeans", "CVars" }));
+			new TestConfiguration(TEST_CLASS_DIR, TEST_SCALE_NOMINAL, 
+				new String[] { "Eta"+".scalar", "AnovaF"+".scalar", "VarY"+".scalar", "MeanY"+".scalar", "CFreqs", "CMeans", "CVars" }));
+		//addTestConfiguration(TEST_SCALE_NOMINAL_WEIGHTS, new TestConfiguration(TEST_CLASS_DIR, "ScaleCategoricalWithWeightsTest", new String[] { "outEta", "outAnovaF", "outVarY", "outMeanY", "outCatFreqs", "outCatMeans", "outCatVars" }));
+		addTestConfiguration(TEST_SCALE_NOMINAL_WEIGHTS, 
+			new TestConfiguration(TEST_CLASS_DIR, "ScaleCategoricalWithWeightsTest", 
+				new String[] { "Eta"+".scalar", "AnovaF"+".scalar", "VarY"+".scalar", "MeanY"+".scalar", "CFreqs", "CMeans", "CVars" }));
 	}
 	
 	@Test
 	public void testScaleCategorical() {
 		
 		TestConfiguration config = getTestConfiguration(TEST_SCALE_NOMINAL);
-		
 		config.addVariable("rows", rows);
+		loadTestConfiguration(config);
 		
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String SC_HOME = SCRIPT_DIR + TEST_DIR;	
 		fullDMLScriptName = SC_HOME + TEST_SCALE_NOMINAL + ".dml";
-		programArgs = new String[]{"-args",  SC_HOME + INPUT_DIR + "A" , 
-	                        Integer.toString(rows),
-	                         SC_HOME + INPUT_DIR + "Y" , 
-	                         SC_HOME + OUTPUT_DIR + "VarY" ,
-	                         SC_HOME + OUTPUT_DIR + "MeanY" ,
-	                         SC_HOME + OUTPUT_DIR + "CFreqs" ,
-	                         SC_HOME + OUTPUT_DIR + "CMeans" ,
-	                         SC_HOME + OUTPUT_DIR + "CVars" ,
-	                         SC_HOME + OUTPUT_DIR + "Eta" ,
-	                         SC_HOME + OUTPUT_DIR + "AnovaF" };
+		programArgs = new String[]{"-args",  input("A"), Integer.toString(rows), input("Y"),
+			output("VarY"), output("MeanY"), output("CFreqs"), output("CMeans"), output("CVars"),
+			output("Eta"), output("AnovaF") };
+		
 		fullRScriptName = SC_HOME + TEST_SCALE_NOMINAL + ".R";
-		rCmd = "Rscript" + " " + SC_HOME + TEST_SCALE_NOMINAL + ".R" + " " + 
-		       SC_HOME + INPUT_DIR + " " + SC_HOME + EXPECTED_DIR;
-
-		loadTestConfiguration(config);
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
         double[][] A = getRandomMatrix(rows, 1, 1, ncatA, 1, System.currentTimeMillis()) ; 
         round(A);
@@ -85,7 +78,6 @@ public class BivariateScaleCategoricalTest extends AutomatedTestBase
 		writeInputMatrix("A", A, true);
 		writeInputMatrix("Y", Y, true);
 
- 
 		boolean exceptionExpected = false;
 		/*
 		 * Expected number of jobs:
@@ -121,28 +113,19 @@ public class BivariateScaleCategoricalTest extends AutomatedTestBase
 	@Test
 	public void testScaleCategoricalWithWeights() {
 		TestConfiguration config = getTestConfiguration(TEST_SCALE_NOMINAL_WEIGHTS);
-		
 		config.addVariable("rows", rows);
+		loadTestConfiguration(config);
 
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String SC_HOME = SCRIPT_DIR + TEST_DIR;	
 		fullDMLScriptName = SC_HOME + TEST_SCALE_NOMINAL_WEIGHTS + ".dml";
-		programArgs = new String[]{"-args",  SC_HOME + INPUT_DIR + "A" , 
-	                        Integer.toString(rows),
-	                         SC_HOME + INPUT_DIR + "Y" , 
-	                         SC_HOME + INPUT_DIR + "WM" , 
-	                         SC_HOME + OUTPUT_DIR + "VarY" ,
-	                         SC_HOME + OUTPUT_DIR + "MeanY" ,
-	                         SC_HOME + OUTPUT_DIR + "CFreqs" ,
-	                         SC_HOME + OUTPUT_DIR + "CMeans" ,
-	                         SC_HOME + OUTPUT_DIR + "CVars" ,
-	                         SC_HOME + OUTPUT_DIR + "Eta" ,
-	                         SC_HOME + OUTPUT_DIR + "AnovaF" };
-		fullRScriptName = SC_HOME + TEST_SCALE_NOMINAL_WEIGHTS + ".R";
-		rCmd = "Rscript" + " " + SC_HOME + TEST_SCALE_NOMINAL_WEIGHTS + ".R" + " " + 
-		       SC_HOME + INPUT_DIR + " " + SC_HOME + EXPECTED_DIR;
+		programArgs = new String[]{"-args", 
+			input("A"), Integer.toString(rows), input("Y"), input("WM"),
+			output("VarY"), output("MeanY"), output("CFreqs"), output("CMeans"), output("CVars"),
+			output("Eta"), output("AnovaF") };
 		
-		loadTestConfiguration(config);
+		fullRScriptName = SC_HOME + TEST_SCALE_NOMINAL_WEIGHTS + ".R";
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
         double[][] A = getRandomMatrix(rows, 1, 1, ncatA, 1, System.currentTimeMillis());
         double[][] Y = getRandomMatrix(rows, 1, minVal, maxVal, 0.1, System.currentTimeMillis());
@@ -177,5 +160,4 @@ public class BivariateScaleCategoricalTest extends AutomatedTestBase
 
 	}
 	
-
 }

--- a/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/BivariateScaleScaleTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/BivariateScaleScaleTest.java
@@ -30,11 +30,11 @@ import org.apache.sysml.test.utils.TestUtils;
 public class BivariateScaleScaleTest extends AutomatedTestBase 
 {
 
-	
 	private final static String TEST_DIR = "applications/descriptivestats/";
 	private final static String TEST_SCALE_SCALE = "ScaleScale";
 	private final static String TEST_SCALE_SCALE_WEIGHTS = "ScaleScalePearsonRWithWeightsTest";
-
+	private final static String TEST_CLASS_DIR = TEST_DIR + BivariateScaleScaleTest.class.getSimpleName() + "/";
+	
 	private final static double eps = 1e-10;
 	
 	private final static int rows = 100000;      // # of rows in each vector
@@ -44,10 +44,10 @@ public class BivariateScaleScaleTest extends AutomatedTestBase
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_SCALE_SCALE, new TestConfiguration(TEST_DIR,
+		addTestConfiguration(TEST_SCALE_SCALE, new TestConfiguration(TEST_CLASS_DIR,
 				TEST_SCALE_SCALE, new String[] { "PearsonR" + ".scalar" }));
 		addTestConfiguration(TEST_SCALE_SCALE_WEIGHTS, new TestConfiguration(
-				TEST_DIR, "ScaleScalePearsonRWithWeightsTest",
+				TEST_CLASS_DIR, "ScaleScalePearsonRWithWeightsTest",
 				new String[] { "PearsonR" + ".scalar" }));
 	}
 	
@@ -55,21 +55,17 @@ public class BivariateScaleScaleTest extends AutomatedTestBase
 	public void testPearsonR() {
 
 		TestConfiguration config = getTestConfiguration(TEST_SCALE_SCALE);
-		
 		config.addVariable("rows", rows);
+		loadTestConfiguration(config);
 		
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String SS_HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = SS_HOME + TEST_SCALE_SCALE + ".dml";
-		programArgs = new String[]{"-args",  SS_HOME + INPUT_DIR + "X" , 
-				                        Integer.toString(rows),
-				                         SS_HOME + INPUT_DIR + "Y" , 
-				                         SS_HOME + OUTPUT_DIR + "PearsonR" };
-		fullRScriptName = SS_HOME + TEST_SCALE_SCALE + ".R";
-		rCmd = "Rscript" + " " + SS_HOME + TEST_SCALE_SCALE + ".R" + " " + 
-		       SS_HOME + INPUT_DIR + " " + SS_HOME + EXPECTED_DIR;
+		programArgs = new String[]{"-args",  input("X"), 
+			Integer.toString(rows), input("Y"), output("PearsonR") };
 		
-		loadTestConfiguration(config);
+		fullRScriptName = SS_HOME + TEST_SCALE_SCALE + ".R";
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
 		long seed = System.currentTimeMillis();
 		//System.out.println("Seed = " + seed);
@@ -114,22 +110,17 @@ public class BivariateScaleScaleTest extends AutomatedTestBase
 	public void testPearsonRWithWeights() {
 
 		TestConfiguration config = getTestConfiguration(TEST_SCALE_SCALE_WEIGHTS);
-		
 		config.addVariable("rows", rows);
+		loadTestConfiguration(config);
 
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String SS_HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = SS_HOME + TEST_SCALE_SCALE_WEIGHTS + ".dml";
-		programArgs = new String[]{"-args",  SS_HOME + INPUT_DIR + "X" , 
-				                        Integer.toString(rows),
-				                         SS_HOME + INPUT_DIR + "Y" , 
-				                         SS_HOME + INPUT_DIR + "WM" , 
-				                         SS_HOME + OUTPUT_DIR + "PearsonR" };
+		programArgs = new String[]{"-args",  input("X"),
+			Integer.toString(rows), input("Y"), input("WM"), output("PearsonR") };
+		
 		fullRScriptName = SS_HOME + TEST_SCALE_SCALE_WEIGHTS + ".R";
-		rCmd = "Rscript" + " " + SS_HOME + TEST_SCALE_SCALE_WEIGHTS + ".R" + " " + 
-		       SS_HOME + INPUT_DIR + " " + SS_HOME + EXPECTED_DIR;
-
-		loadTestConfiguration(config);
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
 		//long seed = System.currentTimeMillis();
 		//System.out.println("Seed = " + seed);
@@ -173,5 +164,4 @@ public class BivariateScaleScaleTest extends AutomatedTestBase
 
 	}
 	
-
 }

--- a/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/OrderStatisticsTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/OrderStatisticsTest.java
@@ -28,17 +28,16 @@ public class OrderStatisticsTest extends AutomatedTestBase
 {
 	
 	private static final String TEST_DIR = "applications/descriptivestats/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + OrderStatisticsTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		addTestConfiguration("SimpleQuantileTest",
-				new TestConfiguration(TEST_DIR, "SimpleQuantileTest", new String[] { "median", "weighted_median" }));
+			new TestConfiguration(TEST_CLASS_DIR, "SimpleQuantileTest", new String[] { "median", "weighted_median" }));
 		addTestConfiguration("QuantileTest",
-				new TestConfiguration(TEST_DIR, "QuantileTest", new String[] { "quantile", "weighted_quantile" }));
+			new TestConfiguration(TEST_CLASS_DIR, "QuantileTest", new String[] { "quantile", "weighted_quantile" }));
 		addTestConfiguration("IQMTest",
-				new TestConfiguration(TEST_DIR, "IQMTest", new String[] { "iqm", "weighted_iqm" }));
-		
-		
+			new TestConfiguration(TEST_CLASS_DIR, "IQMTest", new String[] { "iqm", "weighted_iqm" }));
 	}
 	
 	public static double quantile(double[] vector, double p)

--- a/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/UnivariateCategoricalTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/UnivariateCategoricalTest.java
@@ -30,27 +30,26 @@ import org.apache.sysml.test.utils.TestUtils;
 public class UnivariateCategoricalTest extends UnivariateStatsBase
 {
 	
+	public UnivariateCategoricalTest() {
+		super();
+		TEST_CLASS_DIR = TEST_DIR + UnivariateCategoricalTest.class.getSimpleName() + "/";
+	}
+
 	@Test
 	public void testCategoricalWithR() {
 	
         TestConfiguration config = getTestConfiguration("Categorical");
         config.addVariable("rows1", rows1);
+		loadTestConfiguration(config);
         
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String C_HOME = SCRIPT_DIR + TEST_DIR;	
 		fullDMLScriptName = C_HOME + "Categorical" + ".dml";
-		programArgs = new String[]{"-args",  C_HOME + INPUT_DIR + "vector" , 
-	                        Integer.toString(rows1),
-	                         C_HOME + OUTPUT_DIR + "Nc" , 
-	                         C_HOME + OUTPUT_DIR + "R" , 
-	                         C_HOME + OUTPUT_DIR + "Pc" ,
-	                         C_HOME + OUTPUT_DIR + "C" ,
-	                         C_HOME + OUTPUT_DIR + "Mode" };
+		programArgs = new String[]{"-args",  input("vector"), Integer.toString(rows1),
+			output("Nc"), output("R"), output("Pc"), output("C"), output("Mode") };
+		
 		fullRScriptName = C_HOME + "Categorical" + ".R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       C_HOME + INPUT_DIR + " " + C_HOME + EXPECTED_DIR;
-
-		loadTestConfiguration(config);
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
         double[][] vector = getRandomMatrix(rows1, 1, 1, 10, 1, System.currentTimeMillis());
         OrderStatisticsTest.round(vector);
@@ -93,23 +92,17 @@ public class UnivariateCategoricalTest extends UnivariateStatsBase
 	
         TestConfiguration config = getTestConfiguration("WeightedCategoricalTest");
         config.addVariable("rows1", rows1);
+		loadTestConfiguration(config);
 
 		// This is for running the junit test the new way, i.e., construct the arguments directly
 		String C_HOME = SCRIPT_DIR + TEST_DIR;	
 		fullDMLScriptName = C_HOME + "WeightedCategoricalTest" + ".dml";
-		programArgs = new String[]{"-args",  C_HOME + INPUT_DIR + "vector" , 
-	                        Integer.toString(rows1),
-	                         C_HOME + INPUT_DIR + "weight" , 
-	                         C_HOME + OUTPUT_DIR + "Nc" , 
-	                         C_HOME + OUTPUT_DIR + "R" , 
-	                         C_HOME + OUTPUT_DIR + "Pc" ,
-	                         C_HOME + OUTPUT_DIR + "C" ,
-	                         C_HOME + OUTPUT_DIR + "Mode" };
-		fullRScriptName = C_HOME + "WeightedCategoricalTest" + ".R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       C_HOME + INPUT_DIR + " " + C_HOME + EXPECTED_DIR;
+		programArgs = new String[]{"-args",  
+			input("vector"), Integer.toString(rows1), input("weight"),
+			output("Nc"), output("R"), output("Pc"), output("C"), output("Mode") };
 		
-		loadTestConfiguration(config);
+		fullRScriptName = C_HOME + "WeightedCategoricalTest" + ".R";
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
 		createHelperMatrix();
         double[][] vector = getRandomMatrix(rows1, 1, 1, 10, 1, System.currentTimeMillis());

--- a/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/UnivariateStatsBase.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/UnivariateStatsBase.java
@@ -19,7 +19,8 @@ public abstract class UnivariateStatsBase extends AutomatedTestBase {
 	 * generated and static
 	 */
 	protected final static String TEST_DIR = "applications/descriptivestats/";
-
+	protected String TEST_CLASS_DIR = TEST_DIR + UnivariateStatsBase.class.getSimpleName() + "/";
+	
 	/** Fudge factor for comparisons against R's output */
 	protected final static double epsilon = 0.000000001;
 
@@ -77,7 +78,7 @@ public abstract class UnivariateStatsBase extends AutomatedTestBase {
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
 		
-		addTestConfiguration("Scale", new TestConfiguration(TEST_DIR, "Scale",
+		addTestConfiguration("Scale", new TestConfiguration(TEST_CLASS_DIR, "Scale",
 				new String[] { "mean" + ".scalar", "std" + ".scalar",
 						"se" + ".scalar", "var" + ".scalar", "cv" + ".scalar",
 						/* "har", "geom", */
@@ -87,7 +88,7 @@ public abstract class UnivariateStatsBase extends AutomatedTestBase {
 						"se_g2" + ".scalar", "out_minus", "out_plus",
 						"median" + ".scalar", "quantile", "iqm" + ".scalar" }));
 		addTestConfiguration("WeightedScaleTest", new TestConfiguration(
-				TEST_DIR, "WeightedScaleTest", new String[] {
+				TEST_CLASS_DIR, "WeightedScaleTest", new String[] {
 						"mean" + ".scalar", "std" + ".scalar",
 						"se" + ".scalar", "var" + ".scalar", "cv" + ".scalar",
 						/* "har", "geom", */
@@ -96,11 +97,11 @@ public abstract class UnivariateStatsBase extends AutomatedTestBase {
 						"se_g1" + ".scalar", "g2" + ".scalar",
 						"se_g2" + ".scalar", "out_minus", "out_plus",
 						"median" + ".scalar", "quantile", "iqm" + ".scalar" }));
-		addTestConfiguration("Categorical", new TestConfiguration(TEST_DIR,
+		addTestConfiguration("Categorical", new TestConfiguration(TEST_CLASS_DIR,
 				"Categorical", new String[] { "Nc", "R" + ".scalar", "Pc", "C",
 						"Mode" })); // Indicate some file is scalar
 		addTestConfiguration("WeightedCategoricalTest", new TestConfiguration(
-				TEST_DIR, "WeightedCategoricalTest", new String[] { "Nc",
+				TEST_CLASS_DIR, "WeightedCategoricalTest", new String[] { "Nc",
 						"R" + ".scalar", "Pc", "C", "Mode" }));
 	}
 
@@ -117,9 +118,7 @@ public abstract class UnivariateStatsBase extends AutomatedTestBase {
 	 * @param rt
 	 *            backend platform to test
 	 */
-	protected void testScaleWithR(SIZE sz, RANGE rng, SPARSITY sp,
-			RUNTIME_PLATFORM rt) {
-
+	protected void testScaleWithR(SIZE sz, RANGE rng, SPARSITY sp, RUNTIME_PLATFORM rt) {
 		RUNTIME_PLATFORM oldrt = rtplatform;
 		rtplatform = rt;
 
@@ -127,30 +126,29 @@ public abstract class UnivariateStatsBase extends AutomatedTestBase {
 			TestConfiguration config = getTestConfiguration("Scale");
 			config.addVariable("rows1", sz.size);
 			config.addVariable("rows2", rows2);
+			loadTestConfiguration(config);
 
 			// This is for running the junit test the new way, i.e., construct
 			// the arguments directly
 			String S_HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = S_HOME + "Scale" + ".dml";
 			programArgs = new String[] { "-args",
-					S_HOME + INPUT_DIR + "vector", Integer.toString(sz.size),
-					S_HOME + INPUT_DIR + "prob", Integer.toString(rows2),
-					S_HOME + OUTPUT_DIR + "mean", S_HOME + OUTPUT_DIR + "std",
-					S_HOME + OUTPUT_DIR + "se", S_HOME + OUTPUT_DIR + "var",
-					S_HOME + OUTPUT_DIR + "cv", S_HOME + OUTPUT_DIR + "min",
-					S_HOME + OUTPUT_DIR + "max", S_HOME + OUTPUT_DIR + "rng",
-					S_HOME + OUTPUT_DIR + "g1", S_HOME + OUTPUT_DIR + "se_g1",
-					S_HOME + OUTPUT_DIR + "g2", S_HOME + OUTPUT_DIR + "se_g2",
-					S_HOME + OUTPUT_DIR + "median",
-					S_HOME + OUTPUT_DIR + "iqm",
-					S_HOME + OUTPUT_DIR + "out_minus",
-					S_HOME + OUTPUT_DIR + "out_plus",
-					S_HOME + OUTPUT_DIR + "quantile" };
+					input("vector"), Integer.toString(sz.size),
+					input("prob"), Integer.toString(rows2),
+					output("mean"), output("std"),
+					output("se"), output("var"),
+					output("cv"), output("min"),
+					output("max"), output("rng"),
+					output("g1"), output("se_g1"),
+					output("g2"), output("se_g2"),
+					output("median"),
+					output("iqm"),
+					output("out_minus"),
+					output("out_plus"),
+					output("quantile") };
+			
 			fullRScriptName = S_HOME + "Scale" + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + S_HOME + INPUT_DIR
-					+ " " + S_HOME + EXPECTED_DIR;
-
-			loadTestConfiguration(config);
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
 			long seed1 = System.currentTimeMillis();
 			long seed2 = System.currentTimeMillis();
@@ -219,31 +217,30 @@ public abstract class UnivariateStatsBase extends AutomatedTestBase {
 			TestConfiguration config = getTestConfiguration("WeightedScaleTest");
 			config.addVariable("rows1", sz.size);
 			config.addVariable("rows2", rows2);
+			loadTestConfiguration(config);
 
 			// This is for running the junit test the new way, i.e., construct
 			// the arguments directly
 			String S_HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = S_HOME + "WeightedScaleTest" + ".dml";
 			programArgs = new String[] { "-args",
-					S_HOME + INPUT_DIR + "vector", Integer.toString(sz.size),
-					S_HOME + INPUT_DIR + "weight", S_HOME + INPUT_DIR + "prob",
-					Integer.toString(rows2), S_HOME + OUTPUT_DIR + "mean",
-					S_HOME + OUTPUT_DIR + "std", S_HOME + OUTPUT_DIR + "se",
-					S_HOME + OUTPUT_DIR + "var", S_HOME + OUTPUT_DIR + "cv",
-					S_HOME + OUTPUT_DIR + "min", S_HOME + OUTPUT_DIR + "max",
-					S_HOME + OUTPUT_DIR + "rng", S_HOME + OUTPUT_DIR + "g1",
-					S_HOME + OUTPUT_DIR + "se_g1", S_HOME + OUTPUT_DIR + "g2",
-					S_HOME + OUTPUT_DIR + "se_g2",
-					S_HOME + OUTPUT_DIR + "median",
-					S_HOME + OUTPUT_DIR + "iqm",
-					S_HOME + OUTPUT_DIR + "out_minus",
-					S_HOME + OUTPUT_DIR + "out_plus",
-					S_HOME + OUTPUT_DIR + "quantile" };
+					input("vector"), Integer.toString(sz.size),
+					input("weight"), input("prob"),
+					Integer.toString(rows2), output("mean"),
+					output("std"), output("se"),
+					output("var"), output("cv"),
+					output("min"), output("max"),
+					output("rng"), output("g1"),
+					output("se_g1"), output("g2"),
+					output("se_g2"),
+					output("median"),
+					output("iqm"),
+					output("out_minus"),
+					output("out_plus"),
+					output("quantile") };
+			
 			fullRScriptName = S_HOME + "WeightedScaleTest" + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + S_HOME + INPUT_DIR
-					+ " " + S_HOME + EXPECTED_DIR;
-
-			loadTestConfiguration(config);
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
 			createHelperMatrix();
 			double[][] vector = getRandomMatrix(sz.size, 1, rng.min, rng.max,

--- a/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/UnivariateUnweightedScaleDenseTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/UnivariateUnweightedScaleDenseTest.java
@@ -29,7 +29,10 @@ import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 public class UnivariateUnweightedScaleDenseTest extends UnivariateStatsBase
 {
 	
-	
+	public UnivariateUnweightedScaleDenseTest() {
+		super();
+		TEST_CLASS_DIR = TEST_DIR + UnivariateUnweightedScaleDenseTest.class.getSimpleName() + "/";
+	}
 
 	// -------------------------------------------------------------------------------------
 	// Tests 1-12 moved to UnivariateUnweightedScaleSparseTest.java
@@ -159,6 +162,5 @@ public class UnivariateUnweightedScaleDenseTest extends UnivariateStatsBase
 		testScaleWithR(SIZE.DIV4P3, RANGE.POS, SPARSITY.DENSE, RUNTIME_PLATFORM.HADOOP);
 	}
 	// -------------------------------------------------------------------------------------
-		
 	
 }

--- a/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/UnivariateUnweightedScaleSparseTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/UnivariateUnweightedScaleSparseTest.java
@@ -30,6 +30,11 @@ import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 public class UnivariateUnweightedScaleSparseTest extends UnivariateStatsBase
 {
 	
+	public UnivariateUnweightedScaleSparseTest() {
+		super();
+		TEST_CLASS_DIR = TEST_DIR + UnivariateUnweightedScaleSparseTest.class.getSimpleName() + "/";
+	}
+
 	// -------------------------------------------------------------------------------------
 	@Test
 	public void testScale1() {
@@ -155,10 +160,5 @@ public class UnivariateUnweightedScaleSparseTest extends UnivariateStatsBase
 		testScaleWithR(SIZE.DIV4P3, RANGE.POS, SPARSITY.SPARSE, RUNTIME_PLATFORM.HADOOP);
 	}
 	
-	
-	
-	// -------------------------------------------------------------------------------------------------------
-	
-	
-	
+	// -------------------------------------------------------------------------------------
 }

--- a/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/UnivariateWeightedScaleDenseTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/UnivariateWeightedScaleDenseTest.java
@@ -28,8 +28,13 @@ import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
  */
 public class UnivariateWeightedScaleDenseTest extends UnivariateStatsBase
 {
+
+	public UnivariateWeightedScaleDenseTest() {
+		super();
+		TEST_CLASS_DIR = TEST_DIR + UnivariateWeightedScaleDenseTest.class.getSimpleName() + "/";
+	}
 	
-	// -------------------------------------------------------------------------------------------------------
+	// -------------------------------------------------------------------------------------
 	// Tests 1-12 moved to UnivariateWeightedScaleSparseTest.java
 	// -------------------------------------------------------------------------------------
 

--- a/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/UnivariateWeightedScaleSparseTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/descriptivestats/UnivariateWeightedScaleSparseTest.java
@@ -29,8 +29,13 @@ import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 public class UnivariateWeightedScaleSparseTest extends UnivariateStatsBase
 {
 	
-	// -------------------------------------------------------------------------------------------------------
-	
+	public UnivariateWeightedScaleSparseTest() {
+		super();
+		TEST_CLASS_DIR = TEST_DIR + UnivariateWeightedScaleSparseTest.class.getSimpleName() + "/";
+	}
+
+	// -------------------------------------------------------------------------------------
+
 	@Test
 	public void testWeightedScale1() {
 		testWeightedScaleWithR(SIZE.DIV4, RANGE.NEG, SPARSITY.SPARSE, RUNTIME_PLATFORM.HYBRID);
@@ -158,6 +163,5 @@ public class UnivariateWeightedScaleSparseTest extends UnivariateStatsBase
 	// -------------------------------------------------------------------------------------
 	// Tests 37-48 moved to UnivariateWeightedScaleDenseTest.java
 	// -------------------------------------------------------------------------------------
-	
 	
 }

--- a/src/test/java/org/apache/sysml/test/integration/applications/parfor/ParForBivariateStatsTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/parfor/ParForBivariateStatsTest.java
@@ -34,6 +34,7 @@ public class ParForBivariateStatsTest extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "parfor_bivariate";
 	private final static String TEST_DIR = "applications/parfor/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ParForBivariateStatsTest.class.getSimpleName() + "/";
 	private final static double eps = 1e-10;
 	
 	private final static int rows1 = 1000;  // # of rows in each vector (for CP instructions) 
@@ -47,10 +48,8 @@ public class ParForBivariateStatsTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   );
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) );
 	}
 
 	
@@ -59,7 +58,6 @@ public class ParForBivariateStatsTest extends AutomatedTestBase
 	{
 		runParForBivariateStatsTest(false, PExecMode.LOCAL, PExecMode.LOCAL, ExecType.MR);
 	}
-
 	
 	@Test 
 	public void testParForBivariateStatsLocalLocalMR() 
@@ -67,7 +65,6 @@ public class ParForBivariateStatsTest extends AutomatedTestBase
 		runParForBivariateStatsTest(true, PExecMode.LOCAL, PExecMode.LOCAL, ExecType.MR);
 	}
 	
-
 	@Test
 	public void testParForBivariateStatsLocalRemoteCP() 
 	{
@@ -118,27 +115,19 @@ public class ParForBivariateStatsTest extends AutomatedTestBase
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		//config.addVariable("rows", rows);
 		//config.addVariable("cols", cols);
+		loadTestConfiguration(config);
 		
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME +scriptNum + ".dml";
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "D" ,
-				                        HOME + INPUT_DIR + "S1" ,
-				                        HOME + INPUT_DIR + "S2" ,
-				                        HOME + INPUT_DIR + "K1" ,
-				                        HOME + INPUT_DIR + "K2" ,
-				                        HOME + OUTPUT_DIR + "bivarstats",
-				                        Integer.toString(rows),
-				                        Integer.toString(cols),
-				                        Integer.toString(cols2),
-				                        Integer.toString(cols2*cols2),
-				                        Integer.toString((int)maxVal)
-				                         };
+		programArgs = new String[]{"-args", input("D"),
+			input("S1"), input("S2"), input("K1"), input("K2"), output("bivarstats"),
+			Integer.toString(rows), Integer.toString(cols), Integer.toString(cols2),
+			Integer.toString(cols2*cols2), Integer.toString((int)maxVal) };
+		
 		fullRScriptName = HOME + TEST_NAME + ".R";
 		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       HOME + INPUT_DIR + " " + Integer.toString((int)maxVal) + " " + HOME + EXPECTED_DIR;
-		
-		loadTestConfiguration(config);
+			inputDir() + " " + Integer.toString((int)maxVal) + " " + expectedDir();
 
 		//generate actual dataset
 		double[][] D = getRandomMatrix(rows, cols, minVal, maxVal, 1, 7777); 
@@ -169,7 +158,6 @@ public class ParForBivariateStatsTest extends AutomatedTestBase
         }
         writeInputMatrix("K1", K1, true);
 		writeInputMatrix("K2", K2, true);			
-
 		
 		boolean exceptionExpected = false;
 		runTest(true, exceptionExpected, null, 92); 

--- a/src/test/java/org/apache/sysml/test/integration/applications/parfor/ParForCVMulticlassSVMTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/parfor/ParForCVMulticlassSVMTest.java
@@ -29,10 +29,10 @@ import org.apache.sysml.test.utils.TestUtils;
 
 public class ParForCVMulticlassSVMTest extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_NAME = "parfor_cv_multiclasssvm";
 	private final static String TEST_DIR = "applications/parfor/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ParForCVMulticlassSVMTest.class.getSimpleName() + "/";
 	
 	private final static double eps = 1e-10; 
 		
@@ -70,10 +70,8 @@ public class ParForCVMulticlassSVMTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "stats" })   );  
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "stats" }) );
 	}
 	
 	@Test
@@ -122,29 +120,22 @@ public class ParForCVMulticlassSVMTest extends AutomatedTestBase
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
+		loadTestConfiguration(config);
 		
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME +scriptNum + ".dml";
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "X" ,
-				                        HOME + INPUT_DIR + "y",
-				                        Integer.toString(rows),
-				                        Integer.toString(cols),
-				                        Integer.toString(k),
-				                        Integer.toString(intercept),
-				                        Integer.toString(numclasses),
-				                        Double.toString(epsilon),
-				                        Double.toString(lambda),
-				                        Integer.toString(maxiter),
-				                        HOME + OUTPUT_DIR + "stats",
-				                        HOME + INPUT_DIR + "P"};
-		fullRScriptName = HOME + TEST_NAME + ".R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       HOME + INPUT_DIR + " " + Integer.toString(k) + " " + Integer.toString(intercept) 
-		       + " " + Integer.toString(numclasses) + " " + Double.toString(epsilon) + " " + Double.toString(lambda)  
-		       + " " + Integer.toString(maxiter)+ " " + HOME + EXPECTED_DIR;
+		programArgs = new String[]{"-args", input("X"), input("y"),
+			Integer.toString(rows), Integer.toString(cols),
+			Integer.toString(k), Integer.toString(intercept), Integer.toString(numclasses),
+			Double.toString(epsilon), Double.toString(lambda), Integer.toString(maxiter),
+			output("stats"), input("P")};
 		
-		loadTestConfiguration(config);
+		fullRScriptName = HOME + TEST_NAME + ".R";
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + 
+			Integer.toString(k) + " " + Integer.toString(intercept) + " " + Integer.toString(numclasses) + " " + 
+			Double.toString(epsilon) + " " + Double.toString(lambda) + " " + Integer.toString(maxiter) + " " + 
+			expectedDir();
 
 		double sparsity = (sparse)? sparsity2 : sparsity1;
 		

--- a/src/test/java/org/apache/sysml/test/integration/applications/parfor/ParForCorrelationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/parfor/ParForCorrelationTest.java
@@ -35,6 +35,7 @@ public class ParForCorrelationTest extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "parfor_corr";
 	private final static String TEST_DIR = "applications/parfor/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ParForCorrelationTest.class.getSimpleName() + "/";
 	private final static double eps = 1e-10;
 	
 	private final static int rows = 3578;  
@@ -48,10 +49,8 @@ public class ParForCorrelationTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   );
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) );
 	}
 
 	@Test
@@ -158,6 +157,7 @@ public class ParForCorrelationTest extends AutomatedTestBase
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
+		loadTestConfiguration(config);
 		
 		boolean oldStatistics = DMLScript.STATISTICS;
 		
@@ -165,24 +165,16 @@ public class ParForCorrelationTest extends AutomatedTestBase
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME + scriptNum + ".dml";
 		if( statistics ){
-			programArgs = new String[]{ "-stats", "-args", 
-					                    HOME + INPUT_DIR + "V" , 
-					                    Integer.toString(rows),
-					                    Integer.toString(cols),
-					                    HOME + OUTPUT_DIR + "PearsonR" };
+			programArgs = new String[]{ "-stats", "-args",
+				input("V"), Integer.toString(rows), Integer.toString(cols), output("PearsonR") };
 		}
 		else {
-			programArgs = new String[]{ "-args", 
-					                    HOME + INPUT_DIR + "V" , 
-					                    Integer.toString(rows),
-					                    Integer.toString(cols),
-					                    HOME + OUTPUT_DIR + "PearsonR" };
+			programArgs = new String[]{ "-args",
+				input("V"), Integer.toString(rows), Integer.toString(cols), output("PearsonR") };
 		}
-		fullRScriptName = HOME + TEST_NAME + ".R";
-		rCmd = "Rscript" + " " + HOME + TEST_NAME + ".R" + " " + 
-		       HOME + INPUT_DIR + " " + HOME + EXPECTED_DIR;
 		
-		loadTestConfiguration(config);
+		fullRScriptName = HOME + TEST_NAME + ".R";
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
 		long seed = System.nanoTime();
         double[][] V = getRandomMatrix(rows, cols, minVal, maxVal, 1.0, seed);

--- a/src/test/java/org/apache/sysml/test/integration/applications/parfor/ParForCorrelationTestLarge.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/parfor/ParForCorrelationTestLarge.java
@@ -37,10 +37,10 @@ import org.apache.sysml.test.utils.TestUtils;
  */
 public class ParForCorrelationTestLarge extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_NAME = "parfor_corr_large";
 	private final static String TEST_DIR = "applications/parfor/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ParForCorrelationTestLarge.class.getSimpleName() + "/";
 	private final static double eps = 1e-10;
 	
 	private final static int rows = (int)Hop.CPThreshold+1;  // # of rows in each vector (for MR instructions)
@@ -53,10 +53,8 @@ public class ParForCorrelationTestLarge extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   ); //TODO this specification is not intuitive
+		addTestConfiguration(TEST_NAME,
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) );
 	}
 
 	
@@ -104,20 +102,16 @@ public class ParForCorrelationTestLarge extends AutomatedTestBase
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
+		loadTestConfiguration(config);
 		
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME +scriptNum + ".dml";
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "V" , 
-				                        Integer.toString(rows),
-				                        Integer.toString(cols),
-				                        HOME + OUTPUT_DIR + "PearsonR" };
+		programArgs = new String[]{"-args", input("V"),
+			Integer.toString(rows), Integer.toString(cols), output("PearsonR") };
 		
 		fullRScriptName = HOME + TEST_NAME + ".R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       HOME + INPUT_DIR + " " + HOME + EXPECTED_DIR;
-		
-		loadTestConfiguration(config);
+		rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
 		long seed = System.nanoTime();
         double[][] V = getRandomMatrix(rows, cols, minVal, maxVal, 1.0, seed);

--- a/src/test/java/org/apache/sysml/test/integration/applications/parfor/ParForNaiveBayesTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/parfor/ParForNaiveBayesTest.java
@@ -40,6 +40,7 @@ public class ParForNaiveBayesTest extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "parfor_naive-bayes";
 	private final static String TEST_DIR = "applications/parfor/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ParForNaiveBayesTest.class.getSimpleName() + "/";
 	private final static double eps = 1e-10; 
 	
 	private final static int rows = 50000;
@@ -57,10 +58,9 @@ public class ParForNaiveBayesTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "class_prior", "class_conditionals" })   );  
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, 
+				new String[] { "class_prior", "class_conditionals" }) );
 	}
 	
 	@Test
@@ -163,20 +163,16 @@ public class ParForNaiveBayesTest extends AutomatedTestBase
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
+		loadTestConfiguration(config);
 		
 		String HOME = SCRIPT_DIR + TEST_DIR;
-		fullDMLScriptName = HOME + TEST_NAME +scriptNum + ".dml";
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "D" ,
-				                            HOME + INPUT_DIR + "C",
-				                            Integer.toString((int)maxVal),
-				                            HOME + OUTPUT_DIR + "class_prior",
-				                            HOME + OUTPUT_DIR + "class_conditionals"};
+		fullDMLScriptName = HOME + TEST_NAME + scriptNum + ".dml";
+		programArgs = new String[]{"-args", input("D"), input("C"), Integer.toString((int)maxVal),
+			output("class_prior"), output("class_conditionals")};
 		
 		fullRScriptName = HOME + TEST_NAME + ".R";
 		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       HOME + INPUT_DIR + " " + Integer.toString((int)maxVal) + " " + HOME + EXPECTED_DIR;
-		
-		loadTestConfiguration(config);
+			inputDir() + " " + Integer.toString((int)maxVal) + " " + expectedDir();
 
 		//input data
 		double[][] D = getRandomMatrix(rows, cols, -1, 1, sparse?sparsity2:sparsity1, 7); 

--- a/src/test/java/org/apache/sysml/test/integration/applications/parfor/ParForUnivariateStatsTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/parfor/ParForUnivariateStatsTest.java
@@ -32,10 +32,10 @@ import org.apache.sysml.test.utils.TestUtils;
 
 public class ParForUnivariateStatsTest extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_NAME = "parfor_univariate";
 	private final static String TEST_DIR = "applications/parfor/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ParForUnivariateStatsTest.class.getSimpleName() + "/";
 	private final static double eps = 1e-10; 
 	
 	//for test of sort_mr set optimizerutils mem to 0.00001 and decomment the following
@@ -67,10 +67,8 @@ public class ParForUnivariateStatsTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   );  
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) );
 	}
 	
 	@Test
@@ -124,19 +122,17 @@ public class ParForUnivariateStatsTest extends AutomatedTestBase
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
+		loadTestConfiguration(config);
 		
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String HOME = SCRIPT_DIR + TEST_DIR;
-		fullDMLScriptName = HOME + TEST_NAME +scriptNum + ".dml";
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "D" ,
-				                        HOME + INPUT_DIR + "K",
-				                        Integer.toString((int)maxVal),
-				                        HOME + OUTPUT_DIR + "univarstats" };
+		fullDMLScriptName = HOME + TEST_NAME + scriptNum + ".dml";
+		programArgs = new String[]{"-args", input("D"),
+			input("K"), Integer.toString((int)maxVal), output("univarstats") };
+		
 		fullRScriptName = HOME + TEST_NAME + ".R";
 		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       HOME + INPUT_DIR + " " + Integer.toString((int)maxVal) + " " + HOME + EXPECTED_DIR;
-		
-		loadTestConfiguration(config);
+			inputDir() + " " + Integer.toString((int)maxVal) + " " + expectedDir();
 
 		//generate actual dataset
 		double[][] D = getRandomMatrix(rows, cols, minVal, maxVal, 1, 7777); 


### PR DESCRIPTION
Refactored unit tests in applications.descriptivestats and applications.parfor so expected/in/out test data no longer generated in src/test/scripts folder.  This refactoring also allows these tests to be run in parallel and follows similar pattern applied to other unit tests in functions packages.

Tests completed successfully [here](https://sparktc.ibmcloud.com/jenkins/job/SystemML-OnDemand/25/).
