### PR TITLE
Refactor unit tests in dml and pydml packages.

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysml/test/integration/AutomatedTestBase.java
@@ -1581,11 +1581,11 @@ public abstract class AutomatedTestBase
 	}
 	
 	protected String getScript() {
-		return baseDirectory + selectedTest + "." + scriptType.lowerCase();
+		return sourceDirectory + selectedTest + "." + scriptType.lowerCase();
 	}
 	
 	protected String getRScript() {
-		return baseDirectory + selectedTest + ".R";
+		return sourceDirectory + selectedTest + ".R";
 	}
 	
 	protected String getRCmd(String ... args) {

--- a/src/test/java/org/apache/sysml/test/integration/applications/ApplyTransformTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/ApplyTransformTest.java
@@ -34,6 +34,7 @@ public abstract class ApplyTransformTest extends AutomatedTestBase{
 	
 	protected final static String TEST_DIR = "applications/apply-transform/";
 	protected final static String TEST_NAME = "apply-transform";
+	protected String TEST_CLASS_DIR = TEST_DIR + ApplyTransformTest.class.getSimpleName() + "/";
 	
 	protected String X, missing_value_maps, binning_maps, dummy_coding_maps, normalization_maps;
     
@@ -65,7 +66,7 @@ public abstract class ApplyTransformTest extends AutomatedTestBase{
 
 	 @Override
 		public void setUp() {
-	    	addTestConfiguration(TEST_DIR, TEST_NAME);
+	    	addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
 		}
 
 	    protected void testApplyTransform(ScriptType scriptType) {
@@ -81,11 +82,11 @@ public abstract class ApplyTransformTest extends AutomatedTestBase{
 		 }
 		 proArgs.add("-stats");
 		 proArgs.add("-nvargs");
-		 proArgs.add("X=" + baseDirectory + X);
-		 proArgs.add("missing_value_maps=" + (missing_value_maps.equals(" ") ? " " : baseDirectory + missing_value_maps));
-		 proArgs.add("bin_defns=" + (binning_maps.equals(" ") ? " " : baseDirectory + binning_maps));
-		 proArgs.add("dummy_code_maps=" + (dummy_coding_maps.equals(" ") ? " " : baseDirectory + dummy_coding_maps));
-		 proArgs.add("normalization_maps=" + (normalization_maps.equals(" ") ? " " : baseDirectory + normalization_maps));
+		 proArgs.add("X=" + sourceDirectory + X);
+		 proArgs.add("missing_value_maps=" + (missing_value_maps.equals(" ") ? " " : sourceDirectory + missing_value_maps));
+		 proArgs.add("bin_defns=" + (binning_maps.equals(" ") ? " " : sourceDirectory + binning_maps));
+		 proArgs.add("dummy_code_maps=" + (dummy_coding_maps.equals(" ") ? " " : sourceDirectory + dummy_coding_maps));
+		 proArgs.add("normalization_maps=" + (normalization_maps.equals(" ") ? " " : sourceDirectory + normalization_maps));
 		 proArgs.add("transformed_X=" + output("transformed_X.mtx"));
 		 proArgs.add("Log=" + output("log.csv"));
 		 programArgs = proArgs.toArray(new String[proArgs.size()]);

--- a/src/test/java/org/apache/sysml/test/integration/applications/ArimaTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/ArimaTest.java
@@ -34,6 +34,7 @@ public abstract class ArimaTest extends AutomatedTestBase {
 	
 	protected final static String TEST_DIR = "applications/arima_box-jenkins/";
 	protected final static String TEST_NAME = "arima";
+	protected String TEST_CLASS_DIR = TEST_DIR + ArimaTest.class.getSimpleName() + "/";
 	
 	protected int max_func_invoc, p, d, q, P, D, Q, s, include_mean, useJacobi;
 	
@@ -58,7 +59,7 @@ public abstract class ArimaTest extends AutomatedTestBase {
 	
 	@Override
 	public void setUp() {
-    	addTestConfiguration(TEST_DIR, TEST_NAME);
+    	addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
 	}
 	
 	protected void testArima(ScriptType scriptType) {

--- a/src/test/java/org/apache/sysml/test/integration/applications/CsplineCGTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/CsplineCGTest.java
@@ -30,6 +30,7 @@ import org.apache.sysml.test.utils.TestUtils;
 public abstract class CsplineCGTest extends AutomatedTestBase {
     protected final static String TEST_DIR = "applications/cspline/";
     protected final static String TEST_NAME = "CsplineCG";
+    protected String TEST_CLASS_DIR = TEST_DIR + CsplineCGTest.class.getSimpleName() + "/";
     protected int numRecords, numDim;
     public CsplineCGTest(int rows, int cols) {
         numRecords = rows;
@@ -46,7 +47,7 @@ public abstract class CsplineCGTest extends AutomatedTestBase {
     }
     @Override
     public void setUp() {
-        addTestConfiguration(TEST_DIR, TEST_NAME);
+        addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
     }
     protected void testCsplineCG(ScriptType scriptType)
     {

--- a/src/test/java/org/apache/sysml/test/integration/applications/CsplineDSTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/CsplineDSTest.java
@@ -33,6 +33,7 @@ public abstract class CsplineDSTest  extends AutomatedTestBase {
 
     protected final static String TEST_DIR = "applications/cspline/";
     protected final static String TEST_NAME = "CsplineDS";
+    protected String TEST_CLASS_DIR = TEST_DIR + CsplineDSTest.class.getSimpleName() + "/";
 
     protected int numRecords, numDim;
 
@@ -53,7 +54,7 @@ public abstract class CsplineDSTest  extends AutomatedTestBase {
 
     @Override
     public void setUp() {
-        addTestConfiguration(TEST_DIR, TEST_NAME);
+        addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
     }
 
     protected void testCsplineDS(ScriptType scriptType)
@@ -107,4 +108,3 @@ public abstract class CsplineDSTest  extends AutomatedTestBase {
         TestUtils.compareMatrices(priorR, priorSYSTEMML, Math.pow(10, -12), "k_R", "k_SYSTEMML");
     }
 }
-

--- a/src/test/java/org/apache/sysml/test/integration/applications/GLMTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/GLMTest.java
@@ -37,6 +37,7 @@ public abstract class GLMTest extends AutomatedTestBase
 	
     protected final static String TEST_DIR = "applications/glm/";
     protected final static String TEST_NAME = "GLM";
+    protected String TEST_CLASS_DIR = TEST_DIR + GLMTest.class.getSimpleName() + "/";
 
     protected int numRecords, numFeatures, distFamilyType, linkType;
     protected double distParam, linkPower, intercept, logFeatureVarianceDisbalance, avgLinearForm, stdevLinearForm, dispersion;
@@ -190,7 +191,7 @@ public abstract class GLMTest extends AutomatedTestBase
     @Override
     public void setUp()
     {
-    	addTestConfiguration(TEST_DIR, TEST_NAME);
+    	addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
     }
     
     protected void testGLM(ScriptType scriptType)

--- a/src/test/java/org/apache/sysml/test/integration/applications/GNMFTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/GNMFTest.java
@@ -34,6 +34,7 @@ public abstract class GNMFTest extends AutomatedTestBase
 
 	protected final static String TEST_DIR = "applications/gnmf/";
 	protected final static String TEST_NAME = "GNMF";
+	protected String TEST_CLASS_DIR = TEST_DIR + GNMFTest.class.getSimpleName() + "/";
 	
 	protected int m, n, k;
 	
@@ -51,7 +52,7 @@ public abstract class GNMFTest extends AutomatedTestBase
 	 
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_DIR, TEST_NAME);
+		addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
 	}
 	
 	protected void testGNMF(ScriptType scriptType) {

--- a/src/test/java/org/apache/sysml/test/integration/applications/HITSTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/HITSTest.java
@@ -30,10 +30,11 @@ public abstract class HITSTest extends AutomatedTestBase
 {
 	protected final static String TEST_DIR = "applications/hits/";
 	protected final static String TEST_NAME = "HITS";
+	protected String TEST_CLASS_DIR = TEST_DIR + HITSTest.class.getSimpleName() + "/";
 
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_DIR, TEST_NAME);
+		addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
 	}
 	
 	protected void testHits(ScriptType scriptType) {

--- a/src/test/java/org/apache/sysml/test/integration/applications/ID3Test.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/ID3Test.java
@@ -37,6 +37,7 @@ public abstract class ID3Test extends AutomatedTestBase
 	
     protected final static String TEST_DIR = "applications/id3/";
     protected final static String TEST_NAME = "id3";
+    protected String TEST_CLASS_DIR = TEST_DIR + ID3Test.class.getSimpleName() + "/";
 
     protected int numRecords, numFeatures;
     
@@ -55,7 +56,7 @@ public abstract class ID3Test extends AutomatedTestBase
     @Override
     public void setUp()
     {
-    	addTestConfiguration(TEST_DIR, TEST_NAME);
+    	addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
     }
     
     protected void testID3(ScriptType scriptType) 

--- a/src/test/java/org/apache/sysml/test/integration/applications/L2SVMTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/L2SVMTest.java
@@ -34,6 +34,7 @@ public abstract class L2SVMTest extends AutomatedTestBase
 	
 	protected final static String TEST_DIR = "applications/l2svm/";
 	protected final static String TEST_NAME = "L2SVM";
+	protected String TEST_CLASS_DIR = TEST_DIR + L2SVMTest.class.getSimpleName() + "/";
 
 	protected int numRecords, numFeatures;
 	protected double sparsity;
@@ -58,7 +59,7 @@ public abstract class L2SVMTest extends AutomatedTestBase
 	
 	@Override
 	public void setUp() {
-    	addTestConfiguration(TEST_DIR, TEST_NAME);
+    	addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
 	}
 	
 	protected void testL2SVM(ScriptType scriptType)

--- a/src/test/java/org/apache/sysml/test/integration/applications/LinearLogRegTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/LinearLogRegTest.java
@@ -34,6 +34,7 @@ public abstract class LinearLogRegTest extends AutomatedTestBase
 	
     protected final static String TEST_DIR = "applications/linearLogReg/";
     protected final static String TEST_NAME = "LinearLogReg";
+    protected String TEST_CLASS_DIR = TEST_DIR + LinearLogRegTest.class.getSimpleName() + "/";
 
     protected int numRecords, numFeatures, numTestRecords;
     protected double sparsity;
@@ -58,7 +59,7 @@ public abstract class LinearLogRegTest extends AutomatedTestBase
     @Override
     public void setUp()
     {
-    	addTestConfiguration(TEST_DIR, TEST_NAME);
+    	addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
     }
     
     protected void testLinearLogReg(ScriptType scriptType) {

--- a/src/test/java/org/apache/sysml/test/integration/applications/LinearRegressionTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/LinearRegressionTest.java
@@ -33,6 +33,7 @@ public abstract class LinearRegressionTest extends AutomatedTestBase {
 	
 	protected final static String TEST_DIR = "applications/linear_regression/";
 	protected final static String TEST_NAME = "LinearRegression";
+	protected String TEST_CLASS_DIR = TEST_DIR + LinearRegressionTest.class.getSimpleName() + "/";
 
 	protected int numRecords, numFeatures;
 	protected double sparsity;
@@ -56,7 +57,7 @@ public abstract class LinearRegressionTest extends AutomatedTestBase {
     @Override
     public void setUp()
     {
-        addTestConfiguration(TEST_DIR, TEST_NAME);
+        addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
     }
     
     protected void testLinearRegression(ScriptType scriptType) {

--- a/src/test/java/org/apache/sysml/test/integration/applications/MDABivariateStatsTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/MDABivariateStatsTest.java
@@ -35,6 +35,7 @@ public abstract class MDABivariateStatsTest extends AutomatedTestBase
 
 	protected final static String TEST_DIR = "applications/mdabivar/";
 	protected final static String TEST_NAME = "MDABivariateStats";
+	protected String TEST_CLASS_DIR = TEST_DIR + MDABivariateStatsTest.class.getSimpleName() + "/";
 	
 	protected int n, m, label_index, label_measurement_level;
 	
@@ -55,7 +56,7 @@ public abstract class MDABivariateStatsTest extends AutomatedTestBase
 	 
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_DIR, TEST_NAME);
+		addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
 	}
 	
 	protected void testMDABivariateStats(ScriptType scriptType) {

--- a/src/test/java/org/apache/sysml/test/integration/applications/MultiClassSVMTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/MultiClassSVMTest.java
@@ -33,6 +33,7 @@ public abstract class MultiClassSVMTest  extends AutomatedTestBase
 {	
 	protected final static String TEST_DIR = "applications/m-svm/";
 	protected final static String TEST_NAME = "m-svm";
+	protected String TEST_CLASS_DIR = TEST_DIR + MultiClassSVMTest.class.getSimpleName() + "/";
 
 	protected int _numRecords;
 	protected int _numFeatures;
@@ -68,7 +69,7 @@ public abstract class MultiClassSVMTest  extends AutomatedTestBase
 	 
 	 @Override
 	 public void setUp() {
-		 addTestConfiguration(TEST_DIR, TEST_NAME);
+		 addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
 	 }
 	 
 	 protected void testMultiClassSVM( ScriptType scriptType ) 

--- a/src/test/java/org/apache/sysml/test/integration/applications/NaiveBayesTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/NaiveBayesTest.java
@@ -33,6 +33,7 @@ public abstract class NaiveBayesTest  extends AutomatedTestBase{
 	
 	protected final static String TEST_DIR = "applications/naive-bayes/";
 	protected final static String TEST_NAME = "naive-bayes";
+	protected String TEST_CLASS_DIR = TEST_DIR + NaiveBayesTest.class.getSimpleName() + "/";
 
 	protected int numRecords, numFeatures, numClasses;
     protected double sparsity;
@@ -62,7 +63,7 @@ public abstract class NaiveBayesTest  extends AutomatedTestBase{
 	 
 	 @Override
 	 public void setUp() {
-		 addTestConfiguration(TEST_DIR, TEST_NAME);
+		 addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
 	 }
 	 
 	 protected void testNaiveBayes(ScriptType scriptType)

--- a/src/test/java/org/apache/sysml/test/integration/applications/PageRankTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/PageRankTest.java
@@ -32,6 +32,7 @@ public abstract class PageRankTest extends AutomatedTestBase {
 
 	protected final static String TEST_DIR = "applications/page_rank/";
 	protected final static String TEST_NAME = "PageRank";
+	protected String TEST_CLASS_DIR = TEST_DIR + PageRankTest.class.getSimpleName() + "/";
 
 	protected int numRows, numCols;
 
@@ -48,7 +49,7 @@ public abstract class PageRankTest extends AutomatedTestBase {
 
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_DIR, TEST_NAME, new String[] { "p" }));
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "p" }));
 	}
 
 	protected void testPageRank(ScriptType scriptType) {

--- a/src/test/java/org/apache/sysml/test/integration/applications/WelchTTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/WelchTTest.java
@@ -37,6 +37,7 @@ public abstract class WelchTTest extends AutomatedTestBase {
 	
 	protected final static String TEST_DIR = "applications/welchTTest/";
 	protected final static String TEST_NAME = "welchTTest";
+	protected String TEST_CLASS_DIR = TEST_DIR + WelchTTest.class.getSimpleName() + "/";
 
 	protected int numAttr, numPosSamples, numNegSamples;
 	
@@ -54,7 +55,7 @@ public abstract class WelchTTest extends AutomatedTestBase {
 	 
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_DIR, TEST_NAME);
+		addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
 	}
 	
 	protected void testWelchTTest(ScriptType scriptType) {

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/ApplyTransformDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/ApplyTransformDMLTest.java
@@ -29,6 +29,7 @@ public class ApplyTransformDMLTest extends ApplyTransformTest {
 	public ApplyTransformDMLTest(String X, String missing_value_maps, String binning_maps, String dummy_coding_maps,
 			String normalization_maps) {
 		super(X, missing_value_maps, binning_maps, dummy_coding_maps, normalization_maps);
+		TEST_CLASS_DIR = TEST_DIR + ApplyTransformDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/ArimaDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/ArimaDMLTest.java
@@ -28,6 +28,7 @@ public class ArimaDMLTest extends ArimaTest {
 
 	public ArimaDMLTest(int m, int p, int d, int q, int P, int D, int Q, int s, int include_mean, int useJacobi) {
 		super(m, p, d, q, P, D, Q, s, include_mean, useJacobi);
+		TEST_CLASS_DIR = TEST_DIR + ArimaDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/CsplineCGDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/CsplineCGDMLTest.java
@@ -28,6 +28,7 @@ public class CsplineCGDMLTest extends CsplineCGTest {
 
 	public CsplineCGDMLTest(int rows, int cols) {
 		super(rows, cols);
+		TEST_CLASS_DIR = TEST_DIR + CsplineCGDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/CsplineDSDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/CsplineDSDMLTest.java
@@ -28,6 +28,7 @@ public class CsplineDSDMLTest extends CsplineDSTest {
 
 	public CsplineDSDMLTest(int rows, int cols) {
 		super(rows, cols);
+		TEST_CLASS_DIR = TEST_DIR + CsplineDSDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/GLMDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/GLMDMLTest.java
@@ -31,6 +31,7 @@ public class GLMDMLTest extends GLMTest {
 			double stdevLinearForm_, double dispersion_) {
 		super(numRecords_, numFeatures_, distFamilyType_, distParam_, linkType_, linkPower_, intercept_,
 				logFeatureVarianceDisbalance_, avgLinearForm_, stdevLinearForm_, dispersion_);
+		TEST_CLASS_DIR = TEST_DIR + GLMDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/GNMFDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/GNMFDMLTest.java
@@ -28,6 +28,7 @@ public class GNMFDMLTest extends GNMFTest {
 
 	public GNMFDMLTest(int m, int n, int k) {
 		super(m, n, k);
+		TEST_CLASS_DIR = TEST_DIR + GNMFDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/HITSDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/HITSDMLTest.java
@@ -23,6 +23,11 @@ import org.apache.sysml.test.integration.applications.HITSTest;
 
 public class HITSDMLTest extends HITSTest {
 
+	public HITSDMLTest() {
+		super();
+		TEST_CLASS_DIR = TEST_DIR + HITSDMLTest.class.getSimpleName() + "/";
+	}
+
 	@Test
 	public void testHitsDml() {
 		testHits(ScriptType.DML);

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/ID3DMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/ID3DMLTest.java
@@ -28,6 +28,7 @@ public class ID3DMLTest extends ID3Test {
 
 	public ID3DMLTest(int numRecords, int numFeatures) {
 		super(numRecords, numFeatures);
+		TEST_CLASS_DIR = TEST_DIR + ID3DMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/L2SVMDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/L2SVMDMLTest.java
@@ -28,6 +28,7 @@ public class L2SVMDMLTest extends L2SVMTest {
 
 	public L2SVMDMLTest(int rows, int cols, double sp, boolean intercept) {
 		super(rows, cols, sp, intercept);
+		TEST_CLASS_DIR = TEST_DIR + L2SVMDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/LinearLogRegDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/LinearLogRegDMLTest.java
@@ -28,6 +28,7 @@ public class LinearLogRegDMLTest extends LinearLogRegTest {
 
 	public LinearLogRegDMLTest(int numRecords, int numFeatures, int numTestRecords, double sparsity) {
 		super(numRecords, numFeatures, numTestRecords, sparsity);
+		TEST_CLASS_DIR = TEST_DIR + LinearLogRegDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/LinearRegressionDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/LinearRegressionDMLTest.java
@@ -28,6 +28,7 @@ public class LinearRegressionDMLTest extends LinearRegressionTest {
 
 	public LinearRegressionDMLTest(int rows, int cols, double sp) {
 		super(rows, cols, sp);
+		TEST_CLASS_DIR = TEST_DIR + LinearRegressionDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/MDABivariateStatsDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/MDABivariateStatsDMLTest.java
@@ -28,6 +28,7 @@ public class MDABivariateStatsDMLTest extends MDABivariateStatsTest {
 
 	public MDABivariateStatsDMLTest(int n, int m, int li, int lml) {
 		super(n, m, li, lml);
+		TEST_CLASS_DIR = TEST_DIR + MDABivariateStatsDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/MultiClassSVMDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/MultiClassSVMDMLTest.java
@@ -28,6 +28,7 @@ public class MultiClassSVMDMLTest extends MultiClassSVMTest {
 
 	public MultiClassSVMDMLTest(int rows, int cols, int nc, boolean intercept, double sp) {
 		super(rows, cols, nc, intercept, sp);
+		TEST_CLASS_DIR = TEST_DIR + MultiClassSVMDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/NaiveBayesDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/NaiveBayesDMLTest.java
@@ -28,6 +28,7 @@ public class NaiveBayesDMLTest extends NaiveBayesTest {
 
 	public NaiveBayesDMLTest(int rows, int cols, int nc, double sp) {
 		super(rows, cols, nc, sp);
+		TEST_CLASS_DIR = TEST_DIR + NaiveBayesDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/PageRankDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/PageRankDMLTest.java
@@ -28,6 +28,7 @@ public class PageRankDMLTest extends PageRankTest {
 
 	public PageRankDMLTest(int rows, int cols) {
 		super(rows, cols);
+		TEST_CLASS_DIR = TEST_DIR + PageRankDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/dml/WelchTDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/dml/WelchTDMLTest.java
@@ -28,6 +28,7 @@ public class WelchTDMLTest extends WelchTTest {
 
 	public WelchTDMLTest(int numAttr, int numPosSamples, int numNegSamples) {
 		super(numAttr, numPosSamples, numNegSamples);
+		TEST_CLASS_DIR = TEST_DIR + WelchTDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/ApplyTransformPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/ApplyTransformPyDMLTest.java
@@ -29,6 +29,7 @@ public class ApplyTransformPyDMLTest extends ApplyTransformTest {
 	public ApplyTransformPyDMLTest(String X, String missing_value_maps, String binning_maps, String dummy_coding_maps,
 			String normalization_maps) {
 		super(X, missing_value_maps, binning_maps, dummy_coding_maps, normalization_maps);
+		TEST_CLASS_DIR = TEST_DIR + ApplyTransformPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/ArimaPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/ArimaPyDMLTest.java
@@ -28,6 +28,7 @@ public class ArimaPyDMLTest extends ArimaTest {
 
 	public ArimaPyDMLTest(int m, int p, int d, int q, int P, int D, int Q, int s, int include_mean, int useJacobi) {
 		super(m, p, d, q, P, D, Q, s, include_mean, useJacobi);
+		TEST_CLASS_DIR = TEST_DIR + ArimaPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/CsplineCGPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/CsplineCGPyDMLTest.java
@@ -28,6 +28,7 @@ public class CsplineCGPyDMLTest extends CsplineCGTest {
 
 	public CsplineCGPyDMLTest(int rows, int cols) {
 		super(rows, cols);
+		TEST_CLASS_DIR = TEST_DIR + CsplineCGPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/CsplineDSPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/CsplineDSPyDMLTest.java
@@ -28,6 +28,7 @@ public class CsplineDSPyDMLTest extends CsplineDSTest {
 
 	public CsplineDSPyDMLTest(int rows, int cols) {
 		super(rows, cols);
+		TEST_CLASS_DIR = TEST_DIR + CsplineDSPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/GLMPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/GLMPyDMLTest.java
@@ -31,6 +31,7 @@ public class GLMPyDMLTest extends GLMTest {
 			double stdevLinearForm_, double dispersion_) {
 		super(numRecords_, numFeatures_, distFamilyType_, distParam_, linkType_, linkPower_, intercept_,
 				logFeatureVarianceDisbalance_, avgLinearForm_, stdevLinearForm_, dispersion_);
+		TEST_CLASS_DIR = TEST_DIR + GLMPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/GNMFPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/GNMFPyDMLTest.java
@@ -28,6 +28,7 @@ public class GNMFPyDMLTest extends GNMFTest {
 
 	public GNMFPyDMLTest(int m, int n, int k) {
 		super(m, n, k);
+		TEST_CLASS_DIR = TEST_DIR + GNMFPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/HITSPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/HITSPyDMLTest.java
@@ -23,6 +23,11 @@ import org.apache.sysml.test.integration.applications.HITSTest;
 
 public class HITSPyDMLTest extends HITSTest {
 
+	public HITSPyDMLTest() {
+		super();
+		TEST_CLASS_DIR = TEST_DIR + HITSPyDMLTest.class.getSimpleName() + "/";
+	}
+
 	@Test
 	public void testHitsPyDml() {
 		testHits(ScriptType.PYDML);

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/ID3PyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/ID3PyDMLTest.java
@@ -28,6 +28,7 @@ public class ID3PyDMLTest extends ID3Test {
 
 	public ID3PyDMLTest(int numRecords, int numFeatures) {
 		super(numRecords, numFeatures);
+		TEST_CLASS_DIR = TEST_DIR + ID3PyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/L2SVMPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/L2SVMPyDMLTest.java
@@ -28,6 +28,7 @@ public class L2SVMPyDMLTest extends L2SVMTest {
 
 	public L2SVMPyDMLTest(int rows, int cols, double sp, boolean intercept) {
 		super(rows, cols, sp, intercept);
+		TEST_CLASS_DIR = TEST_DIR + L2SVMPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/LinearLogRegPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/LinearLogRegPyDMLTest.java
@@ -28,6 +28,7 @@ public class LinearLogRegPyDMLTest extends LinearLogRegTest {
 
 	public LinearLogRegPyDMLTest(int numRecords, int numFeatures, int numTestRecords, double sparsity) {
 		super(numRecords, numFeatures, numTestRecords, sparsity);
+		TEST_CLASS_DIR = TEST_DIR + LinearLogRegPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/LinearRegressionPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/LinearRegressionPyDMLTest.java
@@ -28,6 +28,7 @@ public class LinearRegressionPyDMLTest extends LinearRegressionTest {
 
 	public LinearRegressionPyDMLTest(int rows, int cols, double sp) {
 		super(rows, cols, sp);
+		TEST_CLASS_DIR = TEST_DIR + LinearRegressionPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/MDABivariateStatsPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/MDABivariateStatsPyDMLTest.java
@@ -28,6 +28,7 @@ public class MDABivariateStatsPyDMLTest extends MDABivariateStatsTest {
 
 	public MDABivariateStatsPyDMLTest(int n, int m, int li, int lml) {
 		super(n, m, li, lml);
+		TEST_CLASS_DIR = TEST_DIR + MDABivariateStatsPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/MultiClassSVMPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/MultiClassSVMPyDMLTest.java
@@ -28,6 +28,7 @@ public class MultiClassSVMPyDMLTest extends MultiClassSVMTest {
 
 	public MultiClassSVMPyDMLTest(int rows, int cols, int nc, boolean intercept, double sp) {
 		super(rows, cols, nc, intercept, sp);
+		TEST_CLASS_DIR = TEST_DIR + MultiClassSVMPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/NaiveBayesPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/NaiveBayesPyDMLTest.java
@@ -28,6 +28,7 @@ public class NaiveBayesPyDMLTest extends NaiveBayesTest {
 
 	public NaiveBayesPyDMLTest(int rows, int cols, int nc, double sp) {
 		super(rows, cols, nc, sp);
+		TEST_CLASS_DIR = TEST_DIR + NaiveBayesPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/PageRankPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/PageRankPyDMLTest.java
@@ -28,6 +28,7 @@ public class PageRankPyDMLTest extends PageRankTest {
 
 	public PageRankPyDMLTest(int rows, int cols) {
 		super(rows, cols);
+		TEST_CLASS_DIR = TEST_DIR + PageRankPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/applications/pydml/WelchTPyDMLTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/applications/pydml/WelchTPyDMLTest.java
@@ -28,6 +28,7 @@ public class WelchTPyDMLTest extends WelchTTest {
 
 	public WelchTPyDMLTest(int numAttr, int numPosSamples, int numNegSamples) {
 		super(numAttr, numPosSamples, numNegSamples);
+		TEST_CLASS_DIR = TEST_DIR + WelchTPyDMLTest.class.getSimpleName() + "/";
 	}
 
 	@Test


### PR DESCRIPTION
Small refactoring of unit tests in applications.dml and applications.pydml so expected/in/out test data no longer generated in src/test/scripts folder. This refactoring also allows these tests to be run in parallel.

Tests completed successfully [here](https://sparktc.ibmcloud.com/jenkins/job/SystemML-OnDemand/26/).
