### PR TITLE
Update doc links to incubator on GitHub and to website

### DIFF
--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -28,13 +28,13 @@
                     <div class="brand" style="padding: 15px 0px; font-size: 20px; font-style: italic; font-weight: bold;"><a href="index.html">SystemML {{site.SYSTEMML_VERSION}}</a>
                     </div>
                     <ul class="nav">
-                        <li><a href="index.html">Home</a></li>
+                        <li><a href="index.html">Overview</a></li>
 
                         <li class="dropdown">
                             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Documentation<b class="caret"></b></a>
                             <ul class="dropdown-menu">
                             
-                                <li><a href="http://www.github.com/SparkTC/systemml">SystemML GitHub README</a></li>
+                                <li><a href="https://github.com/apache/incubator-systemml">SystemML GitHub README</a></li>
                                 <li><a href="quick-start-guide.html">Quick Start Guide</a></li>
                                 <li><a href="dml-and-pydml-programming-guide.html">DML and PyDML Programming Guide</a></li>
                                 <li><a href="mlcontext-programming-guide.html">MLContext Programming Guide</a></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,16 +5,19 @@ title: SystemML Overview
 description: SystemML documentation homepage
 ---
 
-SystemML is a flexible, scalable machine learning (ML) language written in Java.
+SystemML is a flexible, scalable machine learning (ML) system.
 SystemML's distinguishing characteristics are: (1) algorithm customizability,
 (2) multiple execution modes, including Standalone, Hadoop Batch, and Spark Batch,
 and (3) automatic optimization.
+
+SystemML is now an **Apache Incubator** project! Please see the [**Apache SystemML (incubating)**](http://systemml.apache.org/)
+website for more information.
 
 ## SystemML Documentation
 
 For more information about SystemML, please consult the following references:
 
-* [SystemML GitHub README](http://www.github.com/SparkTC/systemml)
+* [SystemML GitHub README](https://github.com/apache/incubator-systemml)
 * [Quick Start Guide](quick-start-guide.html)
 * [DML and PyDML Programming Guide](dml-and-pydml-programming-guide.html)
 * [MLContext Programming Guide](mlcontext-programming-guide.html)

--- a/docs/mlcontext-programming-guide.md
+++ b/docs/mlcontext-programming-guide.md
@@ -23,7 +23,7 @@ binary-block data format, allowing for SystemML's optimizations to be performed.
 ## Start Spark Shell with SystemML
 
 To use SystemML with the Spark Shell, the SystemML jar can be referenced using the Spark Shell's `--jars` option. 
-Instructions to build the SystemML jar can be found in the [SystemML GitHub README](http://www.github.com/SparkTC/systemml).
+Instructions to build the SystemML jar can be found in the [SystemML GitHub README](https://github.com/apache/incubator-systemml).
 
 {% highlight bash %}
 ./bin/spark-shell --executor-memory 4G --driver-memory 4G --jars SystemML.jar

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -40,10 +40,11 @@ algorithms can be found in the [Algorithms Reference](algorithms-reference.html)
 
 # Download SystemML
 
-Binary releases of SystemML are available for download at
+The pre-incubator binary release of SystemML 0.8.0 is available for download at
 [https://github.com/SparkTC/systemml/releases](https://github.com/SparkTC/systemml/releases).
+Apache incubator binary releases of SystemML will be available from the [Apache SystemML (incubating)](http://systemml.apache.org/) website.
 
-The SystemML project is available on GitHub at [https://github.com/SparkTC/systemml](https://github.com/SparkTC/systemml).
+The SystemML project is available on GitHub at [https://github.com/apache/incubator-systemml](https://github.com/apache/incubator-systemml).
 SystemML can be downloaded from GitHub and built with Maven. Instructions to build and
 test SystemML can be found in the GitHub README file.
 
@@ -80,7 +81,7 @@ To follow along with this guide, first build a standalone package of SystemML
 or build it from source {% endcomment %} using [Apache Maven](http://maven.apache.org)
 and unpack it to your working directory, i.e. ```~/systemml-tutorial```.
 
-    $ git clone https://github.com/SparkTC/systemml.git
+    $ git clone https://github.com/apache/incubator-systemml.git
     $ mvn clean package
     $ tar -xzf `find . -name 'system-ml*standalone.tar.gz'` -C ~/systemml-tutorial
 


### PR DESCRIPTION
Minor updates to URLs in documentation to point to new SystemML GitHub site and to Apache SystemML Incubator website.

Does not require test suite to be run since only *.md and *.html updated.
