### PR TITLE
Add caching to selected matrix unit tests.

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix/DiagMatrixMultiplicationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix/DiagMatrixMultiplicationTest.java
@@ -21,6 +21,8 @@ package org.apache.sysml.test.integration.functions.binary.matrix;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -57,8 +59,25 @@ public class DiagMatrixMultiplicationTest extends AutomatedTestBase
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "C" }) ); 
 		addTestConfiguration(TEST_NAME2, 
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "C" }) ); 
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
 	}
 
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
+	}
 	
 	@Test
 	public void testDiagMMDenseDenseCP() 
@@ -286,9 +305,20 @@ public class DiagMatrixMultiplicationTest extends AutomatedTestBase
 		
 		try
 		{
-			getAndLoadTestConfiguration(TEST_NAME);
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
 			
 			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = simplify;
+			
+			double sparsityM1 = sparseM1?sparsity2:sparsity1;
+			double sparsityM2 = sparseM2?sparsity2:sparsity1;
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = sparsityM1 + "_" + sparsityM2 + "_" + rightTranspose + "_" + rightVector + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;
@@ -301,9 +331,9 @@ public class DiagMatrixMultiplicationTest extends AutomatedTestBase
 			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 			
 			//generate actual dataset
-			double[][] A = getRandomMatrix(rowsA, colsA, 0, 1, sparseM1?sparsity2:sparsity1, 7); 
+			double[][] A = getRandomMatrix(rowsA, colsA, 0, 1, sparsityM1, 7); 
 			writeInputMatrix("A", A, true);
-			double[][] B = getRandomMatrix(rowsB, rightVector?1:colsB, 0, 1, sparseM2?sparsity2:sparsity1, 3); 
+			double[][] B = getRandomMatrix(rowsB, rightVector?1:colsB, 0, 1, sparsityM2, 3); 
 			writeInputMatrix("B", B, true);
 	
 			boolean exceptionExpected = false;

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix/MapMultChainTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix/MapMultChainTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.binary.matrix;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -59,6 +61,24 @@ public class MapMultChainTest extends AutomatedTestBase
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "R" })); 
 		addTestConfiguration(TEST_NAME2, 
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "R" })); 
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	@Test
@@ -232,7 +252,15 @@ public class MapMultChainTest extends AutomatedTestBase
 		try
 		{
 			String TEST_NAME = testname;
-			getAndLoadTestConfiguration(TEST_NAME);
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = TEST_NAME + "_" + sparse + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix/TransposeMatrixMultiplicationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix/TransposeMatrixMultiplicationTest.java
@@ -21,6 +21,8 @@ package org.apache.sysml.test.integration.functions.binary.matrix;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -68,8 +70,25 @@ public class TransposeMatrixMultiplicationTest extends AutomatedTestBase
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "C" }) );
 		addTestConfiguration( TEST_NAME2, 
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "C" }) );
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
 	}
 
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
+	}
 	
 	@Test
 	public void testTransposeMMDenseDenseCP() 
@@ -299,7 +318,18 @@ public class TransposeMatrixMultiplicationTest extends AutomatedTestBase
 		
 		try
 		{
-			getAndLoadTestConfiguration(TEST_NAME);
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			
+			double sparsityM1 = sparseM1?sparsity2:sparsity1;
+			double sparsityM2 = sparseM2?sparsity2:sparsity1;
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = sparsityM1 + "_" + sparsityM2 + "_" + vectorM2 + "_" + minusM1 + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;
@@ -312,9 +342,9 @@ public class TransposeMatrixMultiplicationTest extends AutomatedTestBase
 			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 			
 			//generate actual dataset
-			double[][] A = getRandomMatrix(rowsA, colsA, 0, 1, sparseM1?sparsity2:sparsity1, 7); 
+			double[][] A = getRandomMatrix(rowsA, colsA, 0, 1, sparsityM1, 7); 
 			writeInputMatrix("A", A, true);
-			double[][] B = getRandomMatrix(rowsB, colsB, 0, 1, sparseM2?sparsity2:sparsity1, 3); 
+			double[][] B = getRandomMatrix(rowsB, colsB, 0, 1, sparsityM2, 3); 
 			writeInputMatrix("B", B, true);
 	
 			boolean exceptionExpected = false;

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix_full_cellwise/FullMatrixMatrixCellwiseOperationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix_full_cellwise/FullMatrixMatrixCellwiseOperationTest.java
@@ -21,6 +21,8 @@ package org.apache.sysml.test.integration.functions.binary.matrix_full_cellwise;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -68,6 +70,24 @@ public class FullMatrixMatrixCellwiseOperationTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME2,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2,new String[]{"C"})); 
 		addTestConfiguration(TEST_NAME3,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3,new String[]{"C"})); 
 		addTestConfiguration(TEST_NAME4,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4,new String[]{"C"})); 
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	// ----------------
@@ -754,18 +774,6 @@ public class FullMatrixMatrixCellwiseOperationTest extends AutomatedTestBase
 			}
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			loadTestConfiguration(config);
-			
-			/* This is for running the junit test the new way, i.e., construct the arguments directly */
-			String HOME = SCRIPT_DIR + TEST_DIR;
-			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-explain", "-args",
-				input("A"), Integer.toString(rows), Integer.toString(cols),
-				input("B"), Integer.toString(rows), Integer.toString(cols),
-				output("C") };
-			
-			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 	
 			//get sparsity
 			double lsparsity1 = 1.0, lsparsity2 = 1.0;
@@ -779,6 +787,25 @@ public class FullMatrixMatrixCellwiseOperationTest extends AutomatedTestBase
 				case SPARSE: lsparsity2 = sparsity2; break;
 				case EMPTY: lsparsity2 = 0.0; break;
 			}
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED && (type != OpType.DIVISION))
+			{
+				TEST_CACHE_DIR = type.ordinal() + "_" + lsparsity1 + "_" + lsparsity2 + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
+			
+			/* This is for running the junit test the new way, i.e., construct the arguments directly */
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[]{"-explain", "-args",
+				input("A"), Integer.toString(rows), Integer.toString(cols),
+				input("B"), Integer.toString(rows), Integer.toString(cols),
+				output("C") };
+			
+			fullRScriptName = HOME + TEST_NAME + ".R";
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 			
 			//generate actual dataset
 			double[][] A = getRandomMatrix(rows, cols, 0, (lsparsity1==0)?0:1, lsparsity1, 7); 

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix_full_cellwise/FullMatrixVectorColCellwiseOperationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix_full_cellwise/FullMatrixVectorColCellwiseOperationTest.java
@@ -21,6 +21,8 @@ package org.apache.sysml.test.integration.functions.binary.matrix_full_cellwise;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -64,10 +66,28 @@ public class FullMatrixVectorColCellwiseOperationTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(TEST_NAME1,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1,new String[]{"C"})); 
-		addTestConfiguration(TEST_NAME2,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2,new String[]{"C"})); 
-		addTestConfiguration(TEST_NAME3,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3,new String[]{"C"})); 
-		addTestConfiguration(TEST_NAME4,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4,new String[]{"C"})); 
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[]{"C"}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[]{"C"}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[]{"C"}));
+		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[]{"C"}));
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	// ----------------------------
@@ -127,55 +147,55 @@ public class FullMatrixVectorColCellwiseOperationTest extends AutomatedTestBase
 	}
 	
 	@Test
-	public void testSubstractionDenseDenseSP() 
+	public void testSubtractionDenseDenseSP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.DENSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionDenseSparseSP() 
+	public void testSubtractionDenseSparseSP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.SPARSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionDenseEmptySP() 
+	public void testSubtractionDenseEmptySP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.EMPTY, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionSparseDenseSP() 
+	public void testSubtractionSparseDenseSP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.DENSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionSparseSparseSP() 
+	public void testSubtractionSparseSparseSP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.SPARSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionSparseEmptySP() 
+	public void testSubtractionSparseEmptySP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.EMPTY, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionEmptyDenseSP() 
+	public void testSubtractionEmptyDenseSP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.DENSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionEmptySparseSP() 
+	public void testSubtractionEmptySparseSP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.SPARSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionEmptyEmptySP() 
+	public void testSubtractionEmptyEmptySP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.EMPTY, ExecType.SPARK);
 	}
@@ -399,109 +419,109 @@ public class FullMatrixVectorColCellwiseOperationTest extends AutomatedTestBase
 	}	
 	
 	@Test
-	public void testSubstractionDenseDenseCP() 
+	public void testSubtractionDenseDenseCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.DENSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionDenseSparseCP() 
+	public void testSubtractionDenseSparseCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.SPARSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionDenseEmptyCP() 
+	public void testSubtractionDenseEmptyCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.EMPTY, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionSparseDenseCP() 
+	public void testSubtractionSparseDenseCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.DENSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionSparseSparseCP() 
+	public void testSubtractionSparseSparseCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.SPARSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionSparseEmptyCP() 
+	public void testSubtractionSparseEmptyCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.EMPTY, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionEmptyDenseCP() 
+	public void testSubtractionEmptyDenseCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.DENSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionEmptySparseCP() 
+	public void testSubtractionEmptySparseCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.SPARSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionEmptyEmptyCP() 
+	public void testSubtractionEmptyEmptyCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.EMPTY, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionDenseDenseMR() 
+	public void testSubtractionDenseDenseMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.DENSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionDenseSparseMR() 
+	public void testSubtractionDenseSparseMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.SPARSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionDenseEmptyMR() 
+	public void testSubtractionDenseEmptyMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.EMPTY, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionSparseDenseMR() 
+	public void testSubtractionSparseDenseMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.DENSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionSparseSparseMR() 
+	public void testSubtractionSparseSparseMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.SPARSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionSparseEmptyMR() 
+	public void testSubtractionSparseEmptyMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.EMPTY, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionEmptyDenseMR() 
+	public void testSubtractionEmptyDenseMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.DENSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionEmptySparseMR() 
+	public void testSubtractionEmptySparseMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.SPARSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionEmptyEmptyMR() 
+	public void testSubtractionEmptyEmptyMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.EMPTY, ExecType.MR);
 	}
@@ -754,16 +774,6 @@ public class FullMatrixVectorColCellwiseOperationTest extends AutomatedTestBase
 			}
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			loadTestConfiguration(config);
-			
-			/* This is for running the junit test the new way, i.e., construct the arguments directly */
-			String HOME = SCRIPT_DIR + TEST_DIR;
-			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-explain","recompile_runtime","-args",
-				input("A"), input("B"), output("C") };
-			
-			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 			
 			//get sparsity
 			double lsparsity1 = 1.0, lsparsity2 = 1.0;
@@ -777,6 +787,23 @@ public class FullMatrixVectorColCellwiseOperationTest extends AutomatedTestBase
 				case SPARSE: lsparsity2 = sparsity2; break;
 				case EMPTY: lsparsity2 = 0.0; break;
 			}
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED && (type != OpType.DIVISION))
+			{
+				TEST_CACHE_DIR = type.ordinal() + "_" + lsparsity1 + "_" + lsparsity2 + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
+			
+			/* This is for running the junit test the new way, i.e., construct the arguments directly */
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[]{"-explain","recompile_runtime","-args",
+				input("A"), input("B"), output("C") };
+			
+			fullRScriptName = HOME + TEST_NAME + ".R";
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 			
 			//generate actual dataset
 			double[][] A = getRandomMatrix(rows, cols, 0, (lsparsity1==0)?0:1, lsparsity1, 7); 

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix_full_cellwise/FullMatrixVectorRowCellwiseOperationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix_full_cellwise/FullMatrixVectorRowCellwiseOperationTest.java
@@ -21,6 +21,8 @@ package org.apache.sysml.test.integration.functions.binary.matrix_full_cellwise;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -64,10 +66,28 @@ public class FullMatrixVectorRowCellwiseOperationTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(TEST_NAME1,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1,new String[]{"C"})); 
-		addTestConfiguration(TEST_NAME2,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2,new String[]{"C"})); 
-		addTestConfiguration(TEST_NAME3,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3,new String[]{"C"})); 
-		addTestConfiguration(TEST_NAME4,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4,new String[]{"C"})); 
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[]{"C"}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[]{"C"}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[]{"C"}));
+		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[]{"C"}));
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	// ------------------------------------
@@ -127,55 +147,55 @@ public class FullMatrixVectorRowCellwiseOperationTest extends AutomatedTestBase
 	}
 	
 	@Test
-	public void testSubstractionDenseDenseSP() 
+	public void testSubtractionDenseDenseSP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.DENSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionDenseSparseSP() 
+	public void testSubtractionDenseSparseSP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.SPARSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionDenseEmptySP() 
+	public void testSubtractionDenseEmptySP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.EMPTY, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionSparseDenseSP() 
+	public void testSubtractionSparseDenseSP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.DENSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionSparseSparseSP() 
+	public void testSubtractionSparseSparseSP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.SPARSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionSparseEmptySP() 
+	public void testSubtractionSparseEmptySP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.EMPTY, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionEmptyDenseSP() 
+	public void testSubtractionEmptyDenseSP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.DENSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionEmptySparseSP() 
+	public void testSubtractionEmptySparseSP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.SPARSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionEmptyEmptySP() 
+	public void testSubtractionEmptyEmptySP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.EMPTY, ExecType.SPARK);
 	}
@@ -399,109 +419,109 @@ public class FullMatrixVectorRowCellwiseOperationTest extends AutomatedTestBase
 	}	
 	
 	@Test
-	public void testSubstractionDenseDenseCP() 
+	public void testSubtractionDenseDenseCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.DENSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionDenseSparseCP() 
+	public void testSubtractionDenseSparseCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.SPARSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionDenseEmptyCP() 
+	public void testSubtractionDenseEmptyCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.EMPTY, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionSparseDenseCP() 
+	public void testSubtractionSparseDenseCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.DENSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionSparseSparseCP() 
+	public void testSubtractionSparseSparseCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.SPARSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionSparseEmptyCP() 
+	public void testSubtractionSparseEmptyCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.EMPTY, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionEmptyDenseCP() 
+	public void testSubtractionEmptyDenseCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.DENSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionEmptySparseCP() 
+	public void testSubtractionEmptySparseCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.SPARSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionEmptyEmptyCP() 
+	public void testSubtractionEmptyEmptyCP() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.EMPTY, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionDenseDenseMR() 
+	public void testSubtractionDenseDenseMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.DENSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionDenseSparseMR() 
+	public void testSubtractionDenseSparseMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.SPARSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionDenseEmptyMR() 
+	public void testSubtractionDenseEmptyMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.EMPTY, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionSparseDenseMR() 
+	public void testSubtractionSparseDenseMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.DENSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionSparseSparseMR() 
+	public void testSubtractionSparseSparseMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.SPARSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionSparseEmptyMR() 
+	public void testSubtractionSparseEmptyMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.EMPTY, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionEmptyDenseMR() 
+	public void testSubtractionEmptyDenseMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.DENSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionEmptySparseMR() 
+	public void testSubtractionEmptySparseMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.SPARSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionEmptyEmptyMR() 
+	public void testSubtractionEmptyEmptyMR() 
 	{
 		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.EMPTY, ExecType.MR);
 	}
@@ -754,16 +774,6 @@ public class FullMatrixVectorRowCellwiseOperationTest extends AutomatedTestBase
 			}
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			loadTestConfiguration(config);
-			
-			/* This is for running the junit test the new way, i.e., construct the arguments directly */
-			String HOME = SCRIPT_DIR + TEST_DIR;
-			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-explain","recompile_runtime","-args",
-				input("A"), input("B"), output("C") };
-			
-			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 	
 			//get sparsity
 			double lsparsity1 = 1.0, lsparsity2 = 1.0;
@@ -777,6 +787,23 @@ public class FullMatrixVectorRowCellwiseOperationTest extends AutomatedTestBase
 				case SPARSE: lsparsity2 = sparsity2; break;
 				case EMPTY: lsparsity2 = 0.0; break;
 			}
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED && (type != OpType.DIVISION))
+			{
+				TEST_CACHE_DIR = type.ordinal() + "_" + lsparsity1 + "_" + lsparsity2 + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
+			
+			/* This is for running the junit test the new way, i.e., construct the arguments directly */
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[]{"-explain","recompile_runtime","-args",
+				input("A"), input("B"), output("C") };
+			
+			fullRScriptName = HOME + TEST_NAME + ".R";
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 			
 			//generate actual dataset
 			double[][] A = getRandomMatrix(rows, cols, 0, (lsparsity1==0)?0:1, lsparsity1, 7); 

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix_full_cellwise/FullVectorVectorCellwiseOperationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix_full_cellwise/FullVectorVectorCellwiseOperationTest.java
@@ -21,6 +21,8 @@ package org.apache.sysml.test.integration.functions.binary.matrix_full_cellwise;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -51,7 +53,7 @@ public class FullVectorVectorCellwiseOperationTest extends AutomatedTestBase
 	
 	private enum OpType{
 		ADDITION,
-		SUBSTRACTION,
+		SUBTRACTION,
 		MULTIPLICATION,
 		LESS_THAN,
 	}
@@ -66,6 +68,24 @@ public class FullVectorVectorCellwiseOperationTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[]{"C"}));
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 	
 	@Test
@@ -123,57 +143,57 @@ public class FullVectorVectorCellwiseOperationTest extends AutomatedTestBase
 	}
 	
 	@Test
-	public void testSubstractionDenseDenseSP() 
+	public void testSubtractionDenseDenseSP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.DENSE, SparsityType.DENSE, ExecType.SPARK);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.DENSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionDenseSparseSP() 
+	public void testSubtractionDenseSparseSP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.DENSE, SparsityType.SPARSE, ExecType.SPARK);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.SPARSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionDenseEmptySP() 
+	public void testSubtractionDenseEmptySP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.DENSE, SparsityType.EMPTY, ExecType.SPARK);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.EMPTY, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionSparseDenseSP() 
+	public void testSubtractionSparseDenseSP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.SPARSE, SparsityType.DENSE, ExecType.SPARK);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.DENSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionSparseSparseSP() 
+	public void testSubtractionSparseSparseSP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.SPARSE, SparsityType.SPARSE, ExecType.SPARK);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.SPARSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionSparseEmptySP() 
+	public void testSubtractionSparseEmptySP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.SPARSE, SparsityType.EMPTY, ExecType.SPARK);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.EMPTY, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionEmptyDenseSP() 
+	public void testSubtractionEmptyDenseSP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.EMPTY, SparsityType.DENSE, ExecType.SPARK);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.DENSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionEmptySparseSP() 
+	public void testSubtractionEmptySparseSP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.EMPTY, SparsityType.SPARSE, ExecType.SPARK);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.SPARSE, ExecType.SPARK);
 	}
 	
 	@Test
-	public void testSubstractionEmptyEmptySP() 
+	public void testSubtractionEmptyEmptySP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.EMPTY, SparsityType.EMPTY, ExecType.SPARK);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.EMPTY, ExecType.SPARK);
 	}
 	
 	@Test
@@ -394,111 +414,111 @@ public class FullVectorVectorCellwiseOperationTest extends AutomatedTestBase
 	}	
 	
 	@Test
-	public void testSubstractionDenseDenseCP() 
+	public void testSubtractionDenseDenseCP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.DENSE, SparsityType.DENSE, ExecType.CP);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.DENSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionDenseSparseCP() 
+	public void testSubtractionDenseSparseCP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.DENSE, SparsityType.SPARSE, ExecType.CP);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.SPARSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionDenseEmptyCP() 
+	public void testSubtractionDenseEmptyCP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.DENSE, SparsityType.EMPTY, ExecType.CP);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.EMPTY, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionSparseDenseCP() 
+	public void testSubtractionSparseDenseCP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.SPARSE, SparsityType.DENSE, ExecType.CP);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.DENSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionSparseSparseCP() 
+	public void testSubtractionSparseSparseCP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.SPARSE, SparsityType.SPARSE, ExecType.CP);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.SPARSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionSparseEmptyCP() 
+	public void testSubtractionSparseEmptyCP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.SPARSE, SparsityType.EMPTY, ExecType.CP);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.EMPTY, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionEmptyDenseCP() 
+	public void testSubtractionEmptyDenseCP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.EMPTY, SparsityType.DENSE, ExecType.CP);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.DENSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionEmptySparseCP() 
+	public void testSubtractionEmptySparseCP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.EMPTY, SparsityType.SPARSE, ExecType.CP);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.SPARSE, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionEmptyEmptyCP() 
+	public void testSubtractionEmptyEmptyCP() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.EMPTY, SparsityType.EMPTY, ExecType.CP);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.EMPTY, ExecType.CP);
 	}
 	
 	@Test
-	public void testSubstractionDenseDenseMR() 
+	public void testSubtractionDenseDenseMR() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.DENSE, SparsityType.DENSE, ExecType.MR);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.DENSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionDenseSparseMR() 
+	public void testSubtractionDenseSparseMR() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.DENSE, SparsityType.SPARSE, ExecType.MR);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.SPARSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionDenseEmptyMR() 
+	public void testSubtractionDenseEmptyMR() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.DENSE, SparsityType.EMPTY, ExecType.MR);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.DENSE, SparsityType.EMPTY, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionSparseDenseMR() 
+	public void testSubtractionSparseDenseMR() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.SPARSE, SparsityType.DENSE, ExecType.MR);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.DENSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionSparseSparseMR() 
+	public void testSubtractionSparseSparseMR() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.SPARSE, SparsityType.SPARSE, ExecType.MR);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.SPARSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionSparseEmptyMR() 
+	public void testSubtractionSparseEmptyMR() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.SPARSE, SparsityType.EMPTY, ExecType.MR);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.SPARSE, SparsityType.EMPTY, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionEmptyDenseMR() 
+	public void testSubtractionEmptyDenseMR() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.EMPTY, SparsityType.DENSE, ExecType.MR);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.DENSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionEmptySparseMR() 
+	public void testSubtractionEmptySparseMR() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.EMPTY, SparsityType.SPARSE, ExecType.MR);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.SPARSE, ExecType.MR);
 	}
 	
 	@Test
-	public void testSubstractionEmptyEmptyMR() 
+	public void testSubtractionEmptyEmptyMR() 
 	{
-		runMatrixVectorCellwiseOperationTest(OpType.SUBSTRACTION, SparsityType.EMPTY, SparsityType.EMPTY, ExecType.MR);
+		runMatrixVectorCellwiseOperationTest(OpType.SUBTRACTION, SparsityType.EMPTY, SparsityType.EMPTY, ExecType.MR);
 	}
 	
 	@Test
@@ -745,22 +765,12 @@ public class FullVectorVectorCellwiseOperationTest extends AutomatedTestBase
 			switch( type )
 			{
 				case ADDITION: opcode = "+"; opcoder="+";  break;
-				case SUBSTRACTION: opcode = "-";  opcoder="-"; break;
+				case SUBTRACTION: opcode = "-";  opcoder="-"; break;
 				case MULTIPLICATION: opcode="*";  opcoder="mult"; break;
 				case LESS_THAN: opcode="<"; opcoder="lt"; break;
 			}
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			loadTestConfiguration(config);
-			
-			String HOME = SCRIPT_DIR + TEST_DIR;
-			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-explain","recompile_runtime","-args",
-				input("A"), input("B"), opcode, output("C") };
-			
-			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + 
-				inputDir() + " " + opcoder + " " + expectedDir();
 			
 			//get sparsity
 			double lsparsity1 = 1.0, lsparsity2 = 1.0;
@@ -774,6 +784,23 @@ public class FullVectorVectorCellwiseOperationTest extends AutomatedTestBase
 				case SPARSE: lsparsity2 = sparsity2; break;
 				case EMPTY: lsparsity2 = 0.0; break;
 			}
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = type.ordinal() + "_" + lsparsity1 + "_" + lsparsity2 + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
+			
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[]{"-explain", "recompile_runtime", "-args",
+				input("A"), input("B"), opcode, output("C") };
+			
+			fullRScriptName = HOME + TEST_NAME + ".R";
+			rCmd = "Rscript" + " " + fullRScriptName + " " + 
+				inputDir() + " " + opcoder + " " + expectedDir();
 			
 			//generate actual dataset
 			double[][] A = getRandomMatrix(rows1, 1, 0, (lsparsity1==0)?0:1, lsparsity1, 7); 

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix_full_other/FullMatrixMultiplicationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix_full_other/FullMatrixMultiplicationTest.java
@@ -272,24 +272,17 @@ public class FullMatrixMultiplicationTest extends AutomatedTestBase
 				TEST_CACHE_DIR = "mm" + String.valueOf(sparsityA) + "_" + String.valueOf(sparsityB) + "/";
 			}
 			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
+			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;
-			String TARGET_IN = TEST_DATA_DIR + TEST_CLASS_DIR + INPUT_DIR;
-			String TARGET_OUT = TEST_DATA_DIR + TEST_CLASS_DIR + OUTPUT_DIR;
-			String TARGET_EXPECTED = TEST_DATA_DIR + TEST_CLASS_DIR + EXPECTED_DIR + TEST_CACHE_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-args", TARGET_IN + "A",
-                                            Integer.toString(rowsA),
-                                            Integer.toString(colsA),
-                                            TARGET_IN + "B",
-                                            Integer.toString(rowsB),
-                                            Integer.toString(colsB),
-                                            TARGET_OUT + "C"    };
-			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + 
-			       TARGET_IN + " " + TARGET_EXPECTED;
+			programArgs = new String[]{"-args",
+				input("A"), Integer.toString(rowsA), Integer.toString(colsA),
+				input("B"), Integer.toString(rowsB), Integer.toString(colsB), output("C") };
 			
-			loadTestConfiguration(config, TEST_CACHE_DIR);
+			fullRScriptName = HOME + TEST_NAME + ".R";
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 	
 			//generate actual dataset
 			double[][] A = getRandomMatrix(rowsA, colsA, 0, 1, sparsityA, 7); 
@@ -337,24 +330,17 @@ public class FullMatrixMultiplicationTest extends AutomatedTestBase
 				TEST_CACHE_DIR = "mv" + String.valueOf(sparsityA) + "/";
 			}
 			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
+			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;
-			String TARGET_IN = TEST_DATA_DIR + TEST_CLASS_DIR + INPUT_DIR;
-			String TARGET_OUT = TEST_DATA_DIR + TEST_CLASS_DIR + OUTPUT_DIR;
-			String TARGET_EXPECTED = TEST_DATA_DIR + TEST_CLASS_DIR + EXPECTED_DIR + TEST_CACHE_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-args", TARGET_IN + "A",
-					                        Integer.toString(rowsA),
-					                        Integer.toString(colsA),
-					                        TARGET_IN + "B",
-					                        Integer.toString(rowsB),
-					                        Integer.toString(1),
-					                        TARGET_OUT + "C"    };
-			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + 
-			       TARGET_IN + " " + TARGET_EXPECTED;
+			programArgs = new String[]{"-args",
+				input("A"), Integer.toString(rowsA), Integer.toString(colsA),
+				input("B"), Integer.toString(rowsB), Integer.toString(1), output("C") };
 			
-			loadTestConfiguration(config, TEST_CACHE_DIR);
+			fullRScriptName = HOME + TEST_NAME + ".R";
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 	
 			//generate actual dataset
 			double[][] A = getRandomMatrix(rowsA, colsA, 0, 1, sparsityA, 7); 

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/FullCummaxTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/FullCummaxTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.unary.matrix;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -61,6 +63,24 @@ public class FullCummaxTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"B"})); 
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	@Test
@@ -243,7 +263,14 @@ public class FullCummaxTest extends AutomatedTestBase
 			int rows = (type==InputType.ROW_VECTOR) ? 1 : rowsMatrix;
 			double sparsity = (sparse) ? spSparse : spDense;
 			
-			getAndLoadTestConfiguration(TEST_NAME);
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = type.ordinal() + "_" + sparsity + "/";
+			}
+			
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/FullCumminTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/FullCumminTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.unary.matrix;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -61,6 +63,24 @@ public class FullCumminTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"B"})); 
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	@Test
@@ -243,7 +263,14 @@ public class FullCumminTest extends AutomatedTestBase
 			int rows = (type==InputType.ROW_VECTOR) ? 1 : rowsMatrix;
 			double sparsity = (sparse) ? spSparse : spDense;
 			
-			getAndLoadTestConfiguration(TEST_NAME);
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = type.ordinal() + "_" + sparsity + "/";
+			}
+			
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/FullCumprodTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/FullCumprodTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.unary.matrix;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -61,8 +63,25 @@ public class FullCumprodTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"B"})); 
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
 	}
 
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
+	}
 		
 	@Test
 	public void testCumprodColVectorDenseCP() 
@@ -244,7 +263,14 @@ public class FullCumprodTest extends AutomatedTestBase
 			int rows = (type==InputType.ROW_VECTOR) ? 1 : rowsMatrix;
 			double sparsity = (sparse) ? spSparse : spDense;
 			
-			getAndLoadTestConfiguration(TEST_NAME);
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = type.ordinal() + "_" + sparsity + "/";
+			}
+			
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/FullCumsumTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/FullCumsumTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.unary.matrix;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -61,6 +63,24 @@ public class FullCumsumTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"B"})); 
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	@Test
@@ -242,7 +262,14 @@ public class FullCumsumTest extends AutomatedTestBase
 			int rows = (type==InputType.ROW_VECTOR) ? 1 : rowsMatrix;
 			double sparsity = (sparse) ? spSparse : spDense;
 			
-			getAndLoadTestConfiguration(TEST_NAME);
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = type.ordinal() + "_" + sparsity + "/";
+			}
+			
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/FullSelectPosTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/FullSelectPosTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.unary.matrix;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -57,6 +59,24 @@ public class FullSelectPosTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"B"})); 
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	@Test
@@ -147,7 +167,14 @@ public class FullSelectPosTest extends AutomatedTestBase
 		{
 			double sparsity = (sparse) ? spSparse : spDense;
 			
-			getAndLoadTestConfiguration(TEST_NAME);
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = sparsity + "/";
+			}
+			
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/MLUnaryBuiltinTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/MLUnaryBuiltinTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.unary.matrix;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -64,8 +66,25 @@ public class MLUnaryBuiltinTest extends AutomatedTestBase
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[]{"B"}));
 		addTestConfiguration(TEST_NAME2,
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[]{"B"}));
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
 	}
 
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
+	}
 	
 	@Test
 	public void testSampleProportionVectorDenseCP() 
@@ -241,7 +260,14 @@ public class MLUnaryBuiltinTest extends AutomatedTestBase
 			double sparsity = (sparse) ? spSparse : spDense;
 			String TEST_NAME = testname;
 			
-			getAndLoadTestConfiguration(TEST_NAME);
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = testname + type.ordinal() + "_" + sparsity + "/";
+			}
+			
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/MinusTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/matrix/MinusTest.java
@@ -21,6 +21,8 @@ package org.apache.sysml.test.integration.functions.unary.matrix;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
@@ -49,6 +51,24 @@ public class MinusTest extends AutomatedTestBase
 		
 		addTestConfiguration(TEST_NAME1, 
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "Y" }) ); 
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 	
 	@Test
@@ -108,7 +128,13 @@ public class MinusTest extends AutomatedTestBase
 			config.addVariable("rows", rows);
 			config.addVariable("cols", cols);
 			
-			loadTestConfiguration(config);
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = sparse + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;


### PR DESCRIPTION
These changes follow same pattern as done for matrix_full_other tests to reuse expected R results and skip redundant R script invocations to help reduce test harness time.  Note no changes to matrix characteristics of input test data.

Replaced left-over usage of TARGET_IN/OUT/EXPECTED variables in FullMatrixMultiplicationTest.  Also corrected typos in matrix_full_cellwise tests ('subtract' without 's') in VectorColCellwise, VectorRowCellwise and VectorVectorCellwise tests.

Tests completed successfully [here](https://sparktc.ibmcloud.com/jenkins/job/SystemML-OnDemand/31/).