### PR TITLE
Add caching to aggregate and quaternary unit tests

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/functions/aggregate/ColSumsSqTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/aggregate/ColSumsSqTest.java
@@ -41,6 +41,7 @@ public class ColSumsSqTest extends AutomatedTestBase {
 
     private static final String TEST_NAME = "ColSumsSq";
     private static final String TEST_DIR = "functions/aggregate/";
+    private static final String TEST_CLASS_DIR = TEST_DIR + ColSumsSqTest.class.getSimpleName() + "/";
     private static final String INPUT_NAME = "X";
     private static final String OUTPUT_NAME = "colSumsSq";
 
@@ -54,7 +55,7 @@ public class ColSumsSqTest extends AutomatedTestBase {
     @Override
     public void setUp() {
         TestUtils.clearAssertionInformation();
-        TestConfiguration config = new TestConfiguration(TEST_DIR, TEST_NAME);
+        TestConfiguration config = new TestConfiguration(TEST_CLASS_DIR, TEST_NAME);
         addTestConfiguration(TEST_NAME, config);
     }
 
@@ -222,16 +223,13 @@ public class ColSumsSqTest extends AutomatedTestBase {
 
         try {
             // Create and load test configuration
-            TestConfiguration config = getTestConfiguration(testName);
+            getAndLoadTestConfiguration(testName);
             String HOME = SCRIPT_DIR + TEST_DIR;
             fullDMLScriptName = HOME + testName + ".dml";
             programArgs = new String[]{"-explain", "-stats", "-args",
-                    HOME + INPUT_DIR + INPUT_NAME,
-                    HOME + OUTPUT_DIR + OUTPUT_NAME};
+                    input(INPUT_NAME), output(OUTPUT_NAME)};
             fullRScriptName = HOME + testName + ".R";
-            rCmd = "Rscript" + " " + fullRScriptName + " " +
-                    HOME + INPUT_DIR + " " + HOME + EXPECTED_DIR;
-            loadTestConfiguration(config);
+            rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
             // Generate data
             double sparsity = sparse ? sparsity2 : sparsity1;

--- a/src/test/java/org/apache/sysml/test/integration/functions/aggregate/FullAggregateTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/aggregate/FullAggregateTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.aggregate;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -74,6 +76,24 @@ public class FullAggregateTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[]{"B"}));
 		addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5, new String[]{"B"}));
 		addTestConfiguration(TEST_NAME6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6, new String[]{"B"}));
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 	
 	@Test
@@ -545,7 +565,14 @@ public class FullAggregateTest extends AutomatedTestBase
 			int rows = (type==OpType.TRACE) ? cols : rows1;
 			double sparsity = (sparse) ? sparsity1 : sparsity2;
 			
-			getAndLoadTestConfiguration(TEST_NAME);
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = type.ordinal() + "_" + rows + "_" + cols + "_" + sparsity + "/";
+			}
+			
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/aggregate/FullColAggregateTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/aggregate/FullColAggregateTest.java
@@ -21,6 +21,8 @@ package org.apache.sysml.test.integration.functions.aggregate;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -71,8 +73,25 @@ public class FullColAggregateTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[]{"B"})); 
 		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[]{"B"})); 
 		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[]{"B"})); 
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
 	}
 
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
+	}
 	
 	@Test
 	public void testColSumsDenseMatrixCP() 
@@ -603,7 +622,14 @@ public class FullColAggregateTest extends AutomatedTestBase
 			int cols = (vector) ? cols1 : cols2;
 			double sparsity = (sparse) ? sparsity1 : sparsity2;
 			
-			getAndLoadTestConfiguration(TEST_NAME);
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = type.ordinal() + "_" + cols + "_" + sparsity + "/";
+			}
+			
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/aggregate/FullGroupedAggregateTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/aggregate/FullGroupedAggregateTest.java
@@ -22,6 +22,8 @@ package org.apache.sysml.test.integration.functions.aggregate;
 import java.io.IOException;
 import java.util.HashMap;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -72,6 +74,24 @@ public class FullGroupedAggregateTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[]{"C"})); 
 		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[]{"D"})); 
 		TestUtils.clearAssertionInformation();
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	@Test
@@ -564,7 +584,14 @@ public class FullGroupedAggregateTest extends AutomatedTestBase
 			
 			double sparsity = (sparse) ? sparsity1 : sparsity2;
 			
-			getAndLoadTestConfiguration(TEST_NAME);
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = TEST_NAME + type.ordinal() + "_" + sparsity + "_" + transpose + "/";
+			}
+			
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/aggregate/RowSumsSqTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/aggregate/RowSumsSqTest.java
@@ -41,6 +41,7 @@ public class RowSumsSqTest extends AutomatedTestBase {
 
     private static final String TEST_NAME = "RowSumsSq";
     private static final String TEST_DIR = "functions/aggregate/";
+    private static final String TEST_CLASS_DIR = TEST_DIR + RowSumsSqTest.class.getSimpleName() + "/";
     private static final String INPUT_NAME = "X";
     private static final String OUTPUT_NAME = "rowSumsSq";
 
@@ -54,7 +55,7 @@ public class RowSumsSqTest extends AutomatedTestBase {
     @Override
     public void setUp() {
         TestUtils.clearAssertionInformation();
-        TestConfiguration config = new TestConfiguration(TEST_DIR, TEST_NAME);
+        TestConfiguration config = new TestConfiguration(TEST_CLASS_DIR, TEST_NAME);
         addTestConfiguration(TEST_NAME, config);
     }
 
@@ -222,16 +223,13 @@ public class RowSumsSqTest extends AutomatedTestBase {
 
         try {
             // Create and load test configuration
-            TestConfiguration config = getTestConfiguration(testName);
+            getAndLoadTestConfiguration(testName);
             String HOME = SCRIPT_DIR + TEST_DIR;
             fullDMLScriptName = HOME + testName + ".dml";
             programArgs = new String[]{"-explain", "-stats", "-args",
-                    HOME + INPUT_DIR + INPUT_NAME,
-                    HOME + OUTPUT_DIR + OUTPUT_NAME};
+                    input(INPUT_NAME), output(OUTPUT_NAME)};
             fullRScriptName = HOME + testName + ".R";
-            rCmd = "Rscript" + " " + fullRScriptName + " " +
-                    HOME + INPUT_DIR + " " + HOME + EXPECTED_DIR;
-            loadTestConfiguration(config);
+            rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
             // Generate data
             double sparsity = sparse ? sparsity2 : sparsity1;

--- a/src/test/java/org/apache/sysml/test/integration/functions/aggregate/SumSqTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/aggregate/SumSqTest.java
@@ -41,6 +41,7 @@ public class SumSqTest extends AutomatedTestBase {
 
     private static final String TEST_NAME = "SumSq";
     private static final String TEST_DIR = "functions/aggregate/";
+    private static final String TEST_CLASS_DIR = TEST_DIR + SumSqTest.class.getSimpleName() + "/";
     private static final String INPUT_NAME = "X";
     private static final String OUTPUT_NAME = "sumSq";
 
@@ -54,7 +55,7 @@ public class SumSqTest extends AutomatedTestBase {
     @Override
     public void setUp() {
         TestUtils.clearAssertionInformation();
-        TestConfiguration config = new TestConfiguration(TEST_DIR, TEST_NAME);
+        TestConfiguration config = new TestConfiguration(TEST_CLASS_DIR, TEST_NAME);
         addTestConfiguration(TEST_NAME, config);
     }
 
@@ -222,16 +223,13 @@ public class SumSqTest extends AutomatedTestBase {
 
         try {
             // Create and load test configuration
-            TestConfiguration config = getTestConfiguration(testName);
+            getAndLoadTestConfiguration(testName);
             String HOME = SCRIPT_DIR + TEST_DIR;
             fullDMLScriptName = HOME + testName + ".dml";
             programArgs = new String[]{"-explain", "-stats", "-args",
-                    HOME + INPUT_DIR + INPUT_NAME,
-                    HOME + OUTPUT_DIR + OUTPUT_NAME};
+                    input(INPUT_NAME), output(OUTPUT_NAME)};
             fullRScriptName = HOME + testName + ".R";
-            rCmd = "Rscript" + " " + fullRScriptName + " " +
-                    HOME + INPUT_DIR + " " + HOME + EXPECTED_DIR;
-            loadTestConfiguration(config);
+            rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 
             // Generate data
             double sparsity = sparse ? sparsity2 : sparsity1;

--- a/src/test/java/org/apache/sysml/test/integration/functions/indexing/Jdk7IssueRightIndexingTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/indexing/Jdk7IssueRightIndexingTest.java
@@ -21,6 +21,8 @@ package org.apache.sysml.test.integration.functions.indexing;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
@@ -49,6 +51,24 @@ public class Jdk7IssueRightIndexingTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"R"}));
+		
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+	
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 	
 	@Test
@@ -124,8 +144,16 @@ public class Jdk7IssueRightIndexingTest extends AutomatedTestBase
 			
 		    config.addVariable("rows", rows);
 	        config.addVariable("cols", cols);
+			
+			double sparsity = sparse ? sparsity2 : sparsity1;
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = sparsity + "/";
+			}
 	
-			loadTestConfiguration(config);
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 	        
 	        String RI_HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = RI_HOME + TEST_NAME + ".dml";
@@ -135,7 +163,6 @@ public class Jdk7IssueRightIndexingTest extends AutomatedTestBase
 			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 			
 			//generate input data
-			double sparsity = sparse ? sparsity2 : sparsity1;
 			double[][] M = getRandomMatrix(rows, cols, 0, 1, sparsity, 7);
 	        writeInputMatrixWithMTD("M", M, true);
 	        

--- a/src/test/java/org/apache/sysml/test/integration/functions/indexing/LeftIndexingSparseDenseTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/indexing/LeftIndexingSparseDenseTest.java
@@ -21,6 +21,8 @@ package org.apache.sysml.test.integration.functions.indexing;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -60,8 +62,25 @@ public class LeftIndexingSparseDenseTest extends AutomatedTestBase
 	public void setUp() {
 		addTestConfiguration(TEST_NAME, 
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"R"}));
+		
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
 	}
 	
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
+	}
 	
 	@Test
 	public void testSparseMapLeftIndexingLeftAlignedSP() {
@@ -177,7 +196,14 @@ public class LeftIndexingSparseDenseTest extends AutomatedTestBase
 				DMLScript.USE_LOCAL_SPARK_CONFIG = true;
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			loadTestConfiguration(config);
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = type.toString() + "/";
+			}
+
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";

--- a/src/test/java/org/apache/sysml/test/integration/functions/indexing/LeftIndexingSparseSparseTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/indexing/LeftIndexingSparseSparseTest.java
@@ -21,6 +21,8 @@ package org.apache.sysml.test.integration.functions.indexing;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -60,6 +62,24 @@ public class LeftIndexingSparseSparseTest extends AutomatedTestBase
 	public void setUp() {
 		addTestConfiguration(TEST_NAME, 
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"R"}));
+		
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+	
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 	
 	@Test
@@ -175,7 +195,14 @@ public class LeftIndexingSparseSparseTest extends AutomatedTestBase
 				DMLScript.USE_LOCAL_SPARK_CONFIG = true;
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			loadTestConfiguration(config);
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = type.toString() + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 		    
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";

--- a/src/test/java/org/apache/sysml/test/integration/functions/parfor/ParForRepeatedOptimizationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/parfor/ParForRepeatedOptimizationTest.java
@@ -21,8 +21,9 @@ package org.apache.sysml.test.integration.functions.parfor;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
-
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
@@ -57,6 +58,23 @@ public class ParForRepeatedOptimizationTest extends AutomatedTestBase
 		addTestConfiguration( TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[]{"R"}) ); 
 		addTestConfiguration( TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[]{"R"}) ); 
 		
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+	
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	@Test
@@ -122,7 +140,14 @@ public class ParForRepeatedOptimizationTest extends AutomatedTestBase
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
-		loadTestConfiguration(config);
+		
+		String TEST_CACHE_DIR = "";
+		if (TEST_CACHE_ENABLED)
+		{
+			TEST_CACHE_DIR = TEST_NAME +  "/";
+		}
+		
+		loadTestConfiguration(config, TEST_CACHE_DIR);
 		
 		try
 		{

--- a/src/test/java/org/apache/sysml/test/integration/functions/quaternary/RewritesWeightedSigmoidTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/quaternary/RewritesWeightedSigmoidTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.quaternary;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -61,6 +63,24 @@ public class RewritesWeightedSigmoidTest extends AutomatedTestBase
 	{
 		TestUtils.clearAssertionInformation();
 		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"C"}));
+		
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+	
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	@Test
@@ -121,7 +141,14 @@ public class RewritesWeightedSigmoidTest extends AutomatedTestBase
 			double sparsity = (sparse) ? spSparse : spDense;
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			loadTestConfiguration(config);
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = sparsity + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedCrossEntropyTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedCrossEntropyTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.quaternary;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -62,8 +64,25 @@ public class WeightedCrossEntropyTest extends AutomatedTestBase
 	{
 		TestUtils.clearAssertionInformation();
 		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"R"}));
+		
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
 	}
 
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
+	}
 	
 	@Test
 	public void testCrossEntropyDenseCP() {
@@ -139,7 +158,14 @@ public class WeightedCrossEntropyTest extends AutomatedTestBase
 			String TEST_NAME = testname;
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			loadTestConfiguration(config);
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = sparsity + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedDivMatrixMultTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedDivMatrixMultTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.quaternary;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -75,6 +77,23 @@ public class WeightedDivMatrixMultTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME6,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6,new String[]{"R"}));
 		addTestConfiguration(TEST_NAME7,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME7,new String[]{"R"}));
 	
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	//a) testcases for wdivmm w/ DIVIDE LEFT/RIGHT
@@ -450,7 +469,14 @@ public class WeightedDivMatrixMultTest extends AutomatedTestBase
 			String TEST_NAME = testname;
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			loadTestConfiguration(config);
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = TEST_NAME + "_" + sparsity + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedSigmoidTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedSigmoidTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.quaternary;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -68,8 +70,25 @@ public class WeightedSigmoidTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME2,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2,new String[]{"R"}));
 		addTestConfiguration(TEST_NAME3,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3,new String[]{"R"}));
 		addTestConfiguration(TEST_NAME4,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4,new String[]{"R"}));
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
 	}
 
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
+	}
 	
 	@Test
 	public void testSigmoidDenseBasicNoRewritesCP() 
@@ -458,7 +477,14 @@ public class WeightedSigmoidTest extends AutomatedTestBase
 			String TEST_NAME = testname;
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			loadTestConfiguration(config);
+
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = TEST_NAME + "_" + sparsity + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedSquaredLossTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedSquaredLossTest.java
@@ -21,7 +21,9 @@ package org.apache.sysml.test.integration.functions.quaternary;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.sysml.api.DMLScript;
@@ -74,8 +76,25 @@ public class WeightedSquaredLossTest extends AutomatedTestBase
         addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5, new String[]{"R"}));
         addTestConfiguration(TEST_NAME6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6, new String[]{"R"}));
         addTestConfiguration(TEST_NAME7, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME7, new String[]{"R"}));
+
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
 	}
 
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
+	}
 	
 	@Test
 	public void testSquaredLossDensePostWeightsNoRewritesCP() 
@@ -460,7 +479,14 @@ public class WeightedSquaredLossTest extends AutomatedTestBase
 			String TEST_NAME = testname;
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			loadTestConfiguration(config);
+
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = TEST_NAME + "_" + sparsity + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;

--- a/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedUnaryMatrixMultTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedUnaryMatrixMultTest.java
@@ -21,9 +21,10 @@ package org.apache.sysml.test.integration.functions.quaternary;
 
 import java.util.HashMap;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.hops.OptimizerUtils;
@@ -68,6 +69,24 @@ public class WeightedUnaryMatrixMultTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME2,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2,new String[]{"R"}));
 		addTestConfiguration(TEST_NAME3,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3,new String[]{"R"}));
 		addTestConfiguration(TEST_NAME4,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4,new String[]{"R"}));
+		
+		if (TEST_CACHE_ENABLED) {
+			setOutAndExpectedDeletionDisabled(true);
+		}
+	}
+	
+	@BeforeClass
+	public static void init()
+	{
+		TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+	}
+
+	@AfterClass
+	public static void cleanUp()
+	{
+		if (TEST_CACHE_ENABLED) {
+			TestUtils.clearDirectory(TEST_DATA_DIR + TEST_CLASS_DIR);
+		}
 	}
 
 	//cp testcases
@@ -238,7 +257,14 @@ public class WeightedUnaryMatrixMultTest extends AutomatedTestBase
 			String TEST_NAME = testname;
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			loadTestConfiguration(config);
+			
+			String TEST_CACHE_DIR = "";
+			if (TEST_CACHE_ENABLED)
+			{
+				TEST_CACHE_DIR = TEST_NAME + "_" + sparsity + "/";
+			}
+			
+			loadTestConfiguration(config, TEST_CACHE_DIR);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;


### PR DESCRIPTION
These changes to unit tests in packages aggregate and quaternary follow same pattern as done for matrix_full_other tests to reuse expected R results and skip redundant R script invocations.  Note no changes to matrix characteristics of input test data.
Switched some tests in aggregate package to use target directory instead of previous base script src directory for storing generated test data.  Also included caching of specific tests in indexing and parfor packages.

Tests completed successfully [here](https://sparktc.ibmcloud.com/jenkins/job/SystemML-OnDemand/33/).