### PR TITLE
Update sparkDML.sh to remove some hard-coded parameters and fix a pat…

### DIFF
--- a/scripts/sparkDML.sh
+++ b/scripts/sparkDML.sh
@@ -39,12 +39,13 @@ fi
 
 # Default Values
 
-master=yarn-client
-driver_memory=20G
-num_executors=5
-executor_memory=60G
-executor_cores=24
+master="--master yarn-client"
+driver_memory="--driver-memory 20G"
+num_executors="--num-executors 5"
+executor_memory="--executor-memory 60G"
+executor_cores="--executor-cores 24"
 conf="--conf spark.driver.maxResultSize=0 --conf spark.akka.frameSize=128"
+
 
 # error help print
 
@@ -83,17 +84,16 @@ EOF
   exit 1
 }
 
-
 # command line parameter processing
 
 while true ; do
   case "$1" in
     -h)                printUsageExit ; exit 1 ;;
-    --master)          master=$2 ; shift 2 ;;
-    --driver-memory)   driver_memory=$2 ; shift 2 ;;
-    --num-executors)   num_executors=$2 ; shift 2 ;;
-    --executor-memory) executor_memory=$2 ; shift 2 ;;
-    --executor-cores)  executor_cores=$2 ; shift 2 ;;
+    --master)          master="--master "$2 ; shift 2 ;;
+    --driver-memory)   driver_memory="--driver-memory "$2 ; shift 2 ;;
+    --num-executors)   num_executors="--num-executors "$2 ; shift 2 ;;
+    --executor-memory) executor_memory="--executor-memory "$2 ; shift 2 ;;
+    --executor-cores)  executor_cores="--executor-cores "$2 ; shift 2 ;;
     --conf)            conf=${conf}' --conf '$2 ; shift 2 ;;
      -f)               f=$2 ; shift 2 ;;
     --stats)           stats="-stats" ; shift 1 ;;
@@ -114,11 +114,11 @@ if [ ${SPARK_CONF_DIR} ]; then
 fi
 
 $SPARK_HOME/bin/spark-submit \
-     --master ${master} \
-     --driver-memory ${driver_memory} \
-     --num-executors ${num_executors} \
-     --executor-memory ${executor_memory} \
-     --executor-cores ${executor_cores} \
+     ${master} \
+     ${driver_memory} \
+     ${num_executors} \
+     ${executor_memory} \
+     ${executor_cores} \
      --properties-file ${spark_conf}/spark-defaults.conf \
      ${conf} \
      ${SYSTEMML_HOME}/SystemML.jar \

--- a/scripts/sparkDML.sh
+++ b/scripts/sparkDML.sh
@@ -107,19 +107,12 @@ done
 
 # SystemML Spark invocation
 
-spark_conf=${SPARK_HOME}/conf
-
-if [ ${SPARK_CONF_DIR} ]; then
-  spark_conf=${SPARK_CONF_DIR}
-fi
-
 $SPARK_HOME/bin/spark-submit \
      ${master} \
      ${driver_memory} \
      ${num_executors} \
      ${executor_memory} \
      ${executor_cores} \
-     --properties-file ${spark_conf}/spark-defaults.conf \
      ${conf} \
      ${SYSTEMML_HOME}/SystemML.jar \
          -f ${f} \

--- a/scripts/sparkDML.sh
+++ b/scripts/sparkDML.sh
@@ -25,7 +25,8 @@
 
 # Environment
 
-DEFAULT_SPARK_HOME=/home/biadmin/spark-1.4.0/spark-1.4.0-SNAPSHOT-bin-hadoop2.4
+# Following variables must be rewritten by your installation paths.
+DEFAULT_SPARK_HOME=/usr/local/spark-1.4.0/spark-1.4.0-SNAPSHOT-bin-hadoop2.4
 DEFAULT_SYSTEMML_HOME=.
 
 if [ -z ${SPARK_HOME} ]; then
@@ -33,8 +34,17 @@ if [ -z ${SPARK_HOME} ]; then
 fi
 
 if [ -z ${SYSTEMML_HOME} ]; then
-  SYSTEMML_HOME="."
+  SYSTEMML_HOME=${DEFAULT_SYSTEMML_HOME}
 fi
+
+# Default Values
+
+master=yarn-client
+driver_memory=20G
+num_executors=5
+executor_memory=60G
+executor_cores=24
+conf="--conf spark.driver.maxResultSize=0 --conf spark.akka.frameSize=128"
 
 # error help print
 
@@ -53,13 +63,13 @@ Usage: $0 [-h] [SPARK-SUBMIT OPTIONS] -f <dml-filename> [SYSTEMML OPTIONS]
 
    SPARK-SUBMIT OPTIONS:
    --conf <property>=<value>   Configuration settings:                  
-                                 spark.driver.maxResultSize
-                                 spark.akka.frameSize
-   --driver-memory <num>       Memory for driver (e.g. 512M)]
-   --master <string>           local | yarn-client | yarn-cluster]
-   --num-executors <num>       Number of executors to launch (e.g. 2)
-   --executor-memory <num>     Memory per executor (e.g. 1G)
-   --executor-cores <num>      Memory per executor (e.g. )
+                                 spark.driver.maxResultSize            Default: 0
+                                 spark.akka.frameSize                  Default: 128
+   --driver-memory <num>       Memory for driver (e.g. 512M)]          Default: 20G
+   --master <string>           local | yarn-client | yarn-cluster]     Default: yarn-client
+   --num-executors <num>       Number of executors to launch (e.g. 2)  Default: 5
+   --executor-memory <num>     Memory per executor (e.g. 1G)           Default: 60G
+   --executor-cores <num>      Memory per executor (e.g. )             Default: 24
 
    -f                          DML script file name, e.g. hdfs:/user/biadmin/test.dml
 
@@ -79,11 +89,11 @@ EOF
 while true ; do
   case "$1" in
     -h)                printUsageExit ; exit 1 ;;
-    --master)          master="--master "$2 ; shift 2 ;;
-    --driver-memory)   driver_memory="--driver-memory "$2 ; shift 2 ;;
-    --num-executors)   num_executors="--num-executors "$2 ; shift 2 ;;
-    --executor-memory) executor_memory="--executor-memory "$2 ; shift 2 ;;
-    --executor-cores)  executor_cores="--executor-cores "$2 ; shift 2 ;;
+    --master)          master=$2 ; shift 2 ;;
+    --driver-memory)   driver_memory=$2 ; shift 2 ;;
+    --num-executors)   num_executors=$2 ; shift 2 ;;
+    --executor-memory) executor_memory=$2 ; shift 2 ;;
+    --executor-cores)  executor_cores=$2 ; shift 2 ;;
     --conf)            conf=${conf}' --conf '$2 ; shift 2 ;;
      -f)               f=$2 ; shift 2 ;;
     --stats)           stats="-stats" ; shift 1 ;;
@@ -104,16 +114,16 @@ if [ ${SPARK_CONF_DIR} ]; then
 fi
 
 $SPARK_HOME/bin/spark-submit \
-     ${master} \
-     $driver_memory \
-     $num_executors \
-     $executor_memory \
-     $executor_cores \
+     --master ${master} \
+     --driver-memory ${driver_memory} \
+     --num-executors ${num_executors} \
+     --executor-memory ${executor_memory} \
+     --executor-cores ${executor_cores} \
      --properties-file ${spark_conf}/spark-defaults.conf \
      ${conf} \
      ${SYSTEMML_HOME}/SystemML.jar \
          -f ${f} \
-         -config=${SYSTEMML_HOME}/conf/SystemML-config.xml \
+         -config=${SYSTEMML_HOME}/SystemML-config.xml \
          -exec hybrid_spark \
          $explain \
          $stats \


### PR DESCRIPTION
Update scripts/sparkDML.sh to remove some hard-coded parameters and fix a path of SystemML configuration in spark-submit command-line options.

The sparkDML.sh overwrite $SPARK_HOME and $SYSTEMML_HOME by hard-coded parameters. If these environment variables is already defineded, using it without overwritting is helpful for users. And, some default parameters (eg. driver_memory, num_executors, ...) for spark-submit are hard-coded too. I think that these parameters setting in ($SPARK_HOME | $SPARK_CONF_DIR)/conf/spark-defaults.conf is better than hard-coded in the shell-script. This PR fixes these.

In addition, this PR change a path of SystemML-config.xml in spark-submit comand-line options. Because, SystemML-config.xml is placed under conf/ now.