### PR TITLE
Refactor unit tests in multiple packages.

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysml/test/integration/AutomatedTestBase.java
@@ -690,6 +690,9 @@ public abstract class AutomatedTestBase
 	}
 
 	protected void writeExpectedScalar(String name, double value) {
+		File path = new File(baseDirectory, EXPECTED_DIR + cacheDir);
+		path.mkdirs();
+
 		TestUtils.writeTestScalar(baseDirectory + EXPECTED_DIR + cacheDir + name, value);
 		expectedFiles.add(baseDirectory + EXPECTED_DIR + cacheDir + name);
 	}

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/AdditionTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/AdditionTest.java
@@ -46,21 +46,22 @@ public class AdditionTest extends AutomatedTestBase
 {
 
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + AdditionTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		// positive tests
-		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_DIR, "AdditionTest",
+		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_CLASS_DIR, "AdditionTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
-		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_DIR, "AdditionTest",
+		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_CLASS_DIR, "AdditionTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
-		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_DIR, "AdditionTest",
+		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_CLASS_DIR, "AdditionTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
-		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_DIR, "AdditionTest",
+		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_CLASS_DIR, "AdditionTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
 		
 		// negative tests
-		addTestConfiguration("BooleanTest", new TestConfiguration(TEST_DIR, "AdditionSingleTest",
+		addTestConfiguration("BooleanTest", new TestConfiguration(TEST_CLASS_DIR, "AdditionSingleTest",
 				new String[] { "out" }));
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/AndTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/AndTest.java
@@ -30,10 +30,11 @@ public class AndTest extends AutomatedTestBase
 {
 	
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + AndTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration("AndTest", new TestConfiguration(TEST_DIR, "AndTest",
+		addTestConfiguration("AndTest", new TestConfiguration(TEST_CLASS_DIR, "AndTest",
 				new String[] { "left_1", "left_2", "left_3", "left_4", "right_1", "right_2", "right_3", "right_4" }));
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/DivisionTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/DivisionTest.java
@@ -27,25 +27,25 @@ import org.apache.sysml.test.integration.TestConfiguration;
 
 public class DivisionTest extends AutomatedTestBase 
 {
-
 	
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + DivisionTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_DIR, "DivisionTest", new String[] {
+		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_CLASS_DIR, "DivisionTest", new String[] {
 				"int_int", "int_double", "double_double", "double_int" }));
-		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_DIR, "DivisionTest", new String[] { "int_int",
+		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_CLASS_DIR, "DivisionTest", new String[] { "int_int",
 				"int_double", "double_double", "double_int" }));
-		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_DIR, "DivisionTest", new String[] { "int_int",
+		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_CLASS_DIR, "DivisionTest", new String[] { "int_int",
 				"int_double", "double_double", "double_int" }));
-		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_DIR, "DivisionTest", new String[] { "int_int",
+		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_CLASS_DIR, "DivisionTest", new String[] { "int_int",
 				"int_double", "double_double", "double_int" }));
-		addTestConfiguration("PositiveDivisionByZeroTest", new TestConfiguration(TEST_DIR, "DivisionSingleTest",
+		addTestConfiguration("PositiveDivisionByZeroTest", new TestConfiguration(TEST_CLASS_DIR, "DivisionSingleTest",
 				new String[] { "computed" }));
-		addTestConfiguration("NegativeDivisionByZeroTest", new TestConfiguration(TEST_DIR, "DivisionSingleTest",
+		addTestConfiguration("NegativeDivisionByZeroTest", new TestConfiguration(TEST_CLASS_DIR, "DivisionSingleTest",
 				new String[] { "computed" }));
-		addTestConfiguration("ZeroDivisionByZeroTest", new TestConfiguration(TEST_DIR, "DivisionSingleTest",
+		addTestConfiguration("ZeroDivisionByZeroTest", new TestConfiguration(TEST_CLASS_DIR, "DivisionSingleTest",
 				new String[] { "computed" }));
 	}
 

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/EqualTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/EqualTest.java
@@ -29,12 +29,12 @@ import org.apache.sysml.test.integration.TestConfiguration;
 public class EqualTest extends AutomatedTestBase 
 {
 
-		
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + EqualTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration("EqualTest", new TestConfiguration(TEST_DIR, "EqualTest",
+		addTestConfiguration("EqualTest", new TestConfiguration(TEST_CLASS_DIR, "EqualTest",
 				new String[] { "left_1", "left_2", "left_3", "right_1", "right_2", "right_3" }));
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/FullStringComparisonTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/FullStringComparisonTest.java
@@ -38,6 +38,7 @@ public class FullStringComparisonTest extends AutomatedTestBase
 	
 	private final static String TEST_NAME1 = "FullStringComparisonTest";
 	private final static String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + FullStringComparisonTest.class.getSimpleName() + "/";
 	
 	public enum Type{
 		GREATER,
@@ -52,7 +53,7 @@ public class FullStringComparisonTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration( TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "B" })   ); 
+		addTestConfiguration( TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "B" })   ); 
 	}
 
 	@Test
@@ -128,7 +129,6 @@ public class FullStringComparisonTest extends AutomatedTestBase
 	}
 	
 	
-	
 	/**
 	 * 
 	 * @param type
@@ -150,24 +150,19 @@ public class FullStringComparisonTest extends AutomatedTestBase
 			case GREATER_EQUALS: string2 = trueCondition ? "aabbccdd" : "abce"; break;
 		}
 		
-		TestConfiguration config = getTestConfiguration(TEST_NAME);
+		getAndLoadTestConfiguration(TEST_NAME);
 			
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[]{"-args", 
-				                        string1,
-				                        string2,
-				                        Integer.toString(type.ordinal()),
-				                        HOME + OUTPUT_DIR + "B"    };
-		
-		loadTestConfiguration(config);
+		programArgs = new String[]{"-args",
+			string1, string2, Integer.toString(type.ordinal()), output("B") };
 
 		//run tests
 		runTest(true, false, null, -1); 
 		
 		//compare result
 		try {
-			boolean retCondition = MapReduceTool.readBooleanFromHDFSFile(HOME + OUTPUT_DIR + "B");
+			boolean retCondition = MapReduceTool.readBooleanFromHDFSFile(output("B"));
 			Assert.assertEquals(trueCondition, retCondition);
 		} 
 		catch (IOException e) {

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/GreaterThanOrEqualTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/GreaterThanOrEqualTest.java
@@ -29,12 +29,12 @@ import org.apache.sysml.test.integration.TestConfiguration;
 public class GreaterThanOrEqualTest extends AutomatedTestBase 
 {
 
-		
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + GreaterThanOrEqualTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration("GreaterThanOrEqualTest", new TestConfiguration(TEST_DIR, "GreaterThanOrEqualTest",
+		addTestConfiguration("GreaterThanOrEqualTest", new TestConfiguration(TEST_CLASS_DIR, "GreaterThanOrEqualTest",
 				new String[] { "left_1", "left_2", "left_3", "right_1", "right_2", "right_3" }));
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/GreaterThanTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/GreaterThanTest.java
@@ -31,11 +31,12 @@ public class GreaterThanTest extends AutomatedTestBase
 {
 	
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + GreaterThanTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration("GreaterThanTest", new TestConfiguration(TEST_DIR,"GreaterThanTest",
+		addTestConfiguration("GreaterThanTest", new TestConfiguration(TEST_CLASS_DIR,"GreaterThanTest",
 				new String[] { "left_1", "left_2", "left_3", "right_1", "right_2", "right_3" }));
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/LessThanOrEqualTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/LessThanOrEqualTest.java
@@ -29,12 +29,12 @@ import org.apache.sysml.test.integration.TestConfiguration;
 public class LessThanOrEqualTest extends AutomatedTestBase 
 {
 
-		
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + LessThanOrEqualTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration("LessThanOrEqualTest", new TestConfiguration(TEST_DIR, "LessThanOrEqualTest",
+		addTestConfiguration("LessThanOrEqualTest", new TestConfiguration(TEST_CLASS_DIR, "LessThanOrEqualTest",
 				new String[] { "left_1", "left_2", "left_3", "right_1", "right_2", "right_3" }));
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/LessThanTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/LessThanTest.java
@@ -31,12 +31,13 @@ public class LessThanTest extends AutomatedTestBase
 {
 	
 	private	final static String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + LessThanTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration("LessThanTest", new TestConfiguration(TEST_DIR, "LessThanTest",
+		addTestConfiguration("LessThanTest", new TestConfiguration(TEST_CLASS_DIR, "LessThanTest",
 				new String[] { "left_1", "left_2", "left_3", "right_1", "right_2", "right_3" }));
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/LogarithmTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/LogarithmTest.java
@@ -25,22 +25,22 @@ import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
 
 
-
 public class LogarithmTest extends AutomatedTestBase 
 {
 		
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + LogarithmTest.class.getSimpleName() + "/";
 	private static final double EPS = 1e-14;
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_DIR, "LogarithmTest",
+		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_CLASS_DIR, "LogarithmTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
-		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_DIR, "LogarithmTest",
+		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_CLASS_DIR, "LogarithmTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
-		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_DIR, "LogarithmTest",
+		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_CLASS_DIR, "LogarithmTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
-		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_DIR, "LogarithmTest",
+		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_CLASS_DIR, "LogarithmTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/ModulusTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/ModulusTest.java
@@ -29,6 +29,7 @@ public class ModulusTest extends AutomatedTestBase
 {
 	
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ModulusTest.class.getSimpleName() + "/";
 	
 	private double intIntValue1 = 9;
 	private double intIntValue2 = 4;
@@ -47,19 +48,19 @@ public class ModulusTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_DIR, "ModulusTest", new String[] {
+		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_CLASS_DIR, "ModulusTest", new String[] {
 				"int_int", "int_double", "double_double", "double_int" }));
-		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_DIR, "ModulusTest", new String[] { "int_int",
+		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_CLASS_DIR, "ModulusTest", new String[] { "int_int",
 				"int_double", "double_double", "double_int" }));
-		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_DIR, "ModulusTest", new String[] { "int_int",
+		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_CLASS_DIR, "ModulusTest", new String[] { "int_int",
 				"int_double", "double_double", "double_int" }));
-		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_DIR, "ModulusTest", new String[] { "int_int",
+		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_CLASS_DIR, "ModulusTest", new String[] { "int_int",
 				"int_double", "double_double", "double_int" }));
-		addTestConfiguration("PositiveDivisionByZeroTest", new TestConfiguration(TEST_DIR, "ModulusSingleTest",
+		addTestConfiguration("PositiveDivisionByZeroTest", new TestConfiguration(TEST_CLASS_DIR, "ModulusSingleTest",
 				new String[] { "computed" }));
-		addTestConfiguration("NegativeDivisionByZeroTest", new TestConfiguration(TEST_DIR, "ModulusSingleTest",
+		addTestConfiguration("NegativeDivisionByZeroTest", new TestConfiguration(TEST_CLASS_DIR, "ModulusSingleTest",
 				new String[] { "computed" }));
-		addTestConfiguration("ZeroDivisionByZeroTest", new TestConfiguration(TEST_DIR, "ModulusSingleTest",
+		addTestConfiguration("ZeroDivisionByZeroTest", new TestConfiguration(TEST_CLASS_DIR, "ModulusSingleTest",
 				new String[] { "computed" }));		
 	}
 

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/MultiplicationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/MultiplicationTest.java
@@ -25,22 +25,21 @@ import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
 
 
-
 public class MultiplicationTest extends AutomatedTestBase 
 {
-
 	
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + MultiplicationTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_DIR, "MultiplicationTest",
+		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_CLASS_DIR, "MultiplicationTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
-		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_DIR, "MultiplicationTest",
+		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_CLASS_DIR, "MultiplicationTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
-		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_DIR, "MultiplicationTest",
+		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_CLASS_DIR, "MultiplicationTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
-		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_DIR, "MultiplicationTest",
+		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_CLASS_DIR, "MultiplicationTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/OrTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/OrTest.java
@@ -25,16 +25,15 @@ import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
 
 
-
 public class OrTest extends AutomatedTestBase 
 {
 
-		
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + OrTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration("OrTest", new TestConfiguration(TEST_DIR, "OrTest",
+		addTestConfiguration("OrTest", new TestConfiguration(TEST_CLASS_DIR, "OrTest",
 				new String[] { "left_1", "left_2", "left_3", "left_4", "right_1", "right_2", "right_3", "right_4" }));
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/PowerTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/PowerTest.java
@@ -25,22 +25,21 @@ import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
 
 
-
 public class PowerTest extends AutomatedTestBase 
 {
-
 	
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + PowerTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_DIR, "PowerTest",
+		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_CLASS_DIR, "PowerTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
-		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_DIR, "PowerTest",
+		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_CLASS_DIR, "PowerTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
-		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_DIR, "PowerTest",
+		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_CLASS_DIR, "PowerTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
-		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_DIR, "PowerTest",
+		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_CLASS_DIR, "PowerTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double"}));
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/SubtractionTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/scalar/SubtractionTest.java
@@ -27,29 +27,29 @@ import org.apache.sysml.test.integration.TestConfiguration;
 
 public class SubtractionTest extends AutomatedTestBase
 {
-
 	
 	private static final String TEST_DIR = "functions/binary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + SubtractionTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_DIR, "SubtractionTest", new String[] {
+		addTestConfiguration("ConstConstTest", new TestConfiguration(TEST_CLASS_DIR, "SubtractionTest", new String[] {
 				"int_int", "int_double", "double_double", "double_double" }));
-		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_DIR, "SubtractionTest", new String[] {
+		addTestConfiguration("VarConstTest", new TestConfiguration(TEST_CLASS_DIR, "SubtractionTest", new String[] {
 				"int_int", "int_double", "double_double", "double_double" }));
-		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_DIR, "SubtractionTest", new String[] {
+		addTestConfiguration("ConstVarTest", new TestConfiguration(TEST_CLASS_DIR, "SubtractionTest", new String[] {
 				"int_int", "int_double", "double_double", "double_double" }));
-		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_DIR, "SubtractionTest", new String[] {
+		addTestConfiguration("VarVarTest", new TestConfiguration(TEST_CLASS_DIR, "SubtractionTest", new String[] {
 				"int_int", "int_double", "double_double", "double_double" }));
-		addTestConfiguration("NegativeConstConstTest", new TestConfiguration(TEST_DIR, "SubtractionTest",
+		addTestConfiguration("NegativeConstConstTest", new TestConfiguration(TEST_CLASS_DIR, "SubtractionTest",
 				new String[] { "int_int", "int_double", "double_double", "double_double" }));
-		addTestConfiguration("NegativeVarConstTest", new TestConfiguration(TEST_DIR, "SubtractionTest", new String[] {
+		addTestConfiguration("NegativeVarConstTest", new TestConfiguration(TEST_CLASS_DIR, "SubtractionTest", new String[] {
 				"int_int", "int_double", "double_double", "double_double" }));
-		addTestConfiguration("NegativeConstVarTest", new TestConfiguration(TEST_DIR, "SubtractionTest", new String[] {
+		addTestConfiguration("NegativeConstVarTest", new TestConfiguration(TEST_CLASS_DIR, "SubtractionTest", new String[] {
 				"int_int", "int_double", "double_double", "double_double" }));
-		addTestConfiguration("NegativeVarVarTest", new TestConfiguration(TEST_DIR, "SubtractionTest", new String[] {
+		addTestConfiguration("NegativeVarVarTest", new TestConfiguration(TEST_CLASS_DIR, "SubtractionTest", new String[] {
 				"int_int", "int_double", "double_double", "double_double" }));
-		addTestConfiguration("ConstConstConstTest", new TestConfiguration(TEST_DIR, "SubtractionMultipleOperantsTest",
+		addTestConfiguration("ConstConstConstTest", new TestConfiguration(TEST_CLASS_DIR, "SubtractionMultipleOperantsTest",
 				new String[] { "int_int_int", "double_double_double" }));
 	}
 
@@ -121,7 +121,6 @@ public class SubtractionTest extends AutomatedTestBase
 		config.addVariable("doubleintop1", doubleIntValue1);
 		config.addVariable("doubleintop2", doubleIntValue2);
 
-		// loadTestConfiguration("ConstConstTest");
 		loadTestConfiguration(config);
 
 		double computedIntIntValue = intIntValue1 - intIntValue2;

--- a/src/test/java/org/apache/sysml/test/integration/functions/blocks/VariableTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/blocks/VariableTest.java
@@ -26,7 +26,6 @@ import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.test.utils.TestUtils;
 
 
-
 /**
  * <p><b>Positive tests:</b></p>
  * <ul>
@@ -42,6 +41,7 @@ public class VariableTest extends AutomatedTestBase
 {
 	
     private final static String TEST_DIR = "functions/blocks/";
+    private final static String TEST_CLASS_DIR = TEST_DIR + VariableTest.class.getSimpleName() + "/";
     private final static String TEST_VARIABLE_PASSING_1 = "VariablePassing1";
     private final static String TEST_VARIABLE_PASSING_2 = "VariablePassing2";
     private final static String TEST_VARIABLE_ANALYSIS_1 = "VariableAnalysis1";
@@ -50,14 +50,12 @@ public class VariableTest extends AutomatedTestBase
     @Override
     public void setUp()
     {
-        baseDirectory = SCRIPT_DIR + "functions/blocks/";
-
         // positive tests
-        addTestConfiguration(TEST_VARIABLE_PASSING_1, new TestConfiguration(TEST_DIR, "VariablePassing1Test",
+        addTestConfiguration(TEST_VARIABLE_PASSING_1, new TestConfiguration(TEST_CLASS_DIR, "VariablePassing1Test",
                 new String[] { "c", "e", "f" }));
-        addTestConfiguration(TEST_VARIABLE_PASSING_2, new TestConfiguration(TEST_DIR, "VariablePassing2Test",
+        addTestConfiguration(TEST_VARIABLE_PASSING_2, new TestConfiguration(TEST_CLASS_DIR, "VariablePassing2Test",
                 new String[] { "d" }));
-        addTestConfiguration(TEST_VARIABLE_ANALYSIS_1, new TestConfiguration(TEST_DIR, "VariableAnalysis1Test",
+        addTestConfiguration(TEST_VARIABLE_ANALYSIS_1, new TestConfiguration(TEST_CLASS_DIR, "VariableAnalysis1Test",
                 new String[] { "b" }));
 
         // negative tests

--- a/src/test/java/org/apache/sysml/test/integration/functions/blocks/WhileTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/blocks/WhileTest.java
@@ -37,14 +37,15 @@ import org.junit.Test;
 public class WhileTest extends AutomatedTestBase 
 {
 
-	public static final String TEST_DIR = "functions/blocks/";
+	private static final String TEST_DIR = "functions/blocks/";
+	private static String TEST_CLASS_DIR = TEST_DIR + WhileTest.class.getSimpleName() + "/";
 
     @Override
     public void setUp() {
         // positive tests
-        addTestConfiguration("ComputationTest", new TestConfiguration(TEST_DIR, "WhileTest",
+        addTestConfiguration("ComputationTest", new TestConfiguration(TEST_CLASS_DIR, "WhileTest",
         		new String[] { "b" }));
-        addTestConfiguration("CleanUpTest", new TestConfiguration(TEST_DIR, "WhileTest",
+        addTestConfiguration("CleanUpTest", new TestConfiguration(TEST_CLASS_DIR, "WhileTest",
                 new String[] { "b" }));
 
         // negative tests

--- a/src/test/java/org/apache/sysml/test/integration/functions/caching/CachingPWriteExportTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/caching/CachingPWriteExportTest.java
@@ -32,10 +32,10 @@ import org.apache.sysml.test.integration.TestConfiguration;
 
 public class CachingPWriteExportTest extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_NAME = "export";
 	private final static String TEST_DIR = "functions/caching/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + CachingPWriteExportTest.class.getSimpleName() + "/";
 
 	private final static int rows = (int)Hop.CPThreshold-1;
 	private final static int cols = (int)Hop.CPThreshold-1;    
@@ -44,10 +44,8 @@ public class CachingPWriteExportTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "V" })   ); 
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "V" }) ); 
 	}
 	
 	@Test
@@ -61,7 +59,6 @@ public class CachingPWriteExportTest extends AutomatedTestBase
 	{
 		runTestExport( "text" );
 	}
-
 	
 	
 	/**
@@ -75,17 +72,13 @@ public class CachingPWriteExportTest extends AutomatedTestBase
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
+		loadTestConfiguration(config);
 		
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "V" , 
-				                        Integer.toString(rows),
-				                        Integer.toString(cols),
-				                        HOME + OUTPUT_DIR + "V",
-				                        outputFormat };
-		
-		loadTestConfiguration(config);
+		programArgs = new String[]{"-args", input("V"),
+			Integer.toString(rows), Integer.toString(cols), output("V"), outputFormat };
 
 		long seed = System.nanoTime();
         double[][] V = getRandomMatrix(rows, cols, 0, 1, sparsity, seed);
@@ -104,19 +97,19 @@ public class CachingPWriteExportTest extends AutomatedTestBase
 			else
 				ii = InputInfo.TextCellInputInfo;
 			
-			MatrixBlock mb = DataConverter.readMatrixFromHDFS(HOME + OUTPUT_DIR + "V", ii, rows, cols, DMLTranslator.DMLBlockSize, DMLTranslator.DMLBlockSize, sparsity);
+			MatrixBlock mb = DataConverter.readMatrixFromHDFS(output("V"), ii, rows, cols, DMLTranslator.DMLBlockSize, DMLTranslator.DMLBlockSize, sparsity);
 			Vp = DataConverter.convertToDoubleMatrix(mb);
 		}
 		catch(Exception ex)
 		{
 			ex.printStackTrace();
-			throw new RuntimeException(ex);		}
+			throw new RuntimeException(ex);
+		}
 		
 		//compare
 		for( int i=0; i<rows; i++ )
 			for( int j=0; j<cols; j++ )
 				if( V[i][j]!=Vp[i][j] )
-					//System.out.println("Wrong value i="+i+", j="+j+", value1="+V[i][j]+", value2="+Vp[i][j]);
 					Assert.fail("Wrong value i="+i+", j="+j+", value1="+V[i][j]+", value2="+Vp[i][j]);
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/external/DynProjectTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/external/DynProjectTest.java
@@ -30,10 +30,10 @@ import org.apache.sysml.test.utils.TestUtils;
 
 public class DynProjectTest extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_NAME = "DynProject";
 	private final static String TEST_DIR = "functions/external/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + DynProjectTest.class.getSimpleName() + "/";
 	private final static double eps = 1e-10;
 	
 	private final static int rows = 1154;
@@ -46,10 +46,8 @@ public class DynProjectTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   ); 
+		addTestConfiguration(TEST_NAME,
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) );
 	}
 
 	
@@ -90,21 +88,15 @@ public class DynProjectTest extends AutomatedTestBase
 		
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
+		loadTestConfiguration(config);
 		
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "X" ,
-				                        HOME + INPUT_DIR + "c",
-				                        Integer.toString(rows),
-				                        Integer.toString(cols),
-				                        Integer.toString(size),
-				                        HOME + OUTPUT_DIR + "Y" };
-		fullRScriptName = HOME + TEST_NAME + ".R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       HOME + INPUT_DIR + " " + HOME + EXPECTED_DIR;
+		programArgs = new String[]{"-args", input("X"), input("c"),
+			Integer.toString(rows), Integer.toString(cols), Integer.toString(size), output("Y") };
 		
-		loadTestConfiguration(config);
+		rCmd = getRCmd(inputDir(), expectedDir());
 		
 		long seed = System.nanoTime();
         double[][] X = getRandomMatrix(rows, cols, 0, 1, sparsity, seed);

--- a/src/test/java/org/apache/sysml/test/integration/functions/external/DynReadWriteTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/external/DynReadWriteTest.java
@@ -29,10 +29,11 @@ import org.apache.sysml.test.utils.TestUtils;
 
 public class DynReadWriteTest extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_NAME = "DynReadWrite";
 	private final static String TEST_DIR = "functions/external/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + DynReadWriteTest.class.getSimpleName() + "/";
+	
 	private final static double eps = 1e-10;
 	
 	private final static int rows = 1200;
@@ -43,10 +44,8 @@ public class DynReadWriteTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   ); 
+		addTestConfiguration(TEST_NAME,
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) );
 	}
 
 	
@@ -74,16 +73,13 @@ public class DynReadWriteTest extends AutomatedTestBase
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
+		loadTestConfiguration(config);
 		
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "X" , 
-				                        Integer.toString(rows),
-				                        Integer.toString(cols),
-				                        format,
-				                        HOME + OUTPUT_DIR + "Y" };
-		loadTestConfiguration(config);
+		programArgs = new String[]{"-args", input("X"),
+			Integer.toString(rows), Integer.toString(cols), format, output("Y") };
 
 		try 
 		{
@@ -93,7 +89,7 @@ public class DynReadWriteTest extends AutomatedTestBase
 
 			runTest(true, false, null, -1);
 
-			double[][] Y = MapReduceTool.readMatrixFromHDFS(HOME + OUTPUT_DIR + "Y", InputInfo.stringToInputInfo(format), rows, cols, 1000,1000);
+			double[][] Y = MapReduceTool.readMatrixFromHDFS(output("Y"), InputInfo.stringToInputInfo(format), rows, cols, 1000, 1000);
 		
 			TestUtils.compareMatrices(X, Y, rows, cols, eps);
 		} 

--- a/src/test/java/org/apache/sysml/test/integration/functions/external/FunctionExpressionsTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/external/FunctionExpressionsTest.java
@@ -30,11 +30,11 @@ import org.apache.sysml.utils.Statistics;
 
 public class FunctionExpressionsTest extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_NAME1 = "FunctionExpressions1";
 	private final static String TEST_NAME2 = "FunctionExpressions2";
 	private final static String TEST_DIR = "functions/external/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + FunctionExpressionsTest.class.getSimpleName() + "/";
 	private final static double eps = 1e-10;
 	
 	private final static int rows = 12;
@@ -45,14 +45,10 @@ public class FunctionExpressionsTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME1, 
-				new TestConfiguration(TEST_DIR, TEST_NAME1, 
-				new String[] { "Y" })   ); 
-		addTestConfiguration(
-				TEST_NAME2, 
-				new TestConfiguration(TEST_DIR, TEST_NAME2, 
-				new String[] { "Y" })   ); 
+		addTestConfiguration(TEST_NAME1,
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "Y" }) );
+		addTestConfiguration(TEST_NAME2,
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "Y" }) ); 
 	}
 
 	
@@ -73,15 +69,13 @@ public class FunctionExpressionsTest extends AutomatedTestBase
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
+		loadTestConfiguration(config);
 		
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "X", 
-							                Integer.toString(rows),
-							                Integer.toString(cols),
-				                            HOME + OUTPUT_DIR + "Y" };
-		loadTestConfiguration(config);
+		programArgs = new String[]{"-args", input("X"),
+			Integer.toString(rows), Integer.toString(cols), output("Y") };
 
 		try 
 		{
@@ -91,7 +85,7 @@ public class FunctionExpressionsTest extends AutomatedTestBase
 
 			runTest(true, false, null, -1);
 
-			double[][] Y = MapReduceTool.readMatrixFromHDFS(HOME + OUTPUT_DIR + "Y", InputInfo.TextCellInputInfo, rows, cols, 1000,1000);
+			double[][] Y = MapReduceTool.readMatrixFromHDFS(output("Y"), InputInfo.TextCellInputInfo, rows, cols, 1000, 1000);
 		
 			double sx = sum(X,rows,cols);
 			double sy = sum(Y,rows,cols);

--- a/src/test/java/org/apache/sysml/test/integration/functions/external/OrderTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/external/OrderTest.java
@@ -35,6 +35,7 @@ public class OrderTest extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "Order";
 	private final static String TEST_DIR = "functions/external/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + OrderTest.class.getSimpleName() + "/";
 	
 	private final static int rows = 1200;
 	private final static int cols = 1100; 
@@ -45,10 +46,8 @@ public class OrderTest extends AutomatedTestBase
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "B.mtx" })   ); 
+		addTestConfiguration(TEST_NAME,
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "B.mtx" }) );
 	}
 
 	@Test
@@ -68,22 +67,17 @@ public class OrderTest extends AutomatedTestBase
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
+		loadTestConfiguration(config);
 		
 		int sortcol = sc * (asc ? 1 : -1);
 		int namesuffix = (asc ? 1 : 2);
 		
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME + namesuffix + ".dml";
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "A" , 
-				                        Integer.toString(rows),
-				                        Integer.toString(cols),
-				                        Integer.toString(sc),
-				                        HOME + OUTPUT_DIR + "B" };
-		fullRScriptName = HOME + TEST_NAME + ".R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       HOME + INPUT_DIR + " " + sortcol + " " + HOME + EXPECTED_DIR;
+		programArgs = new String[]{"-args", input("A"),
+			Integer.toString(rows), Integer.toString(cols), Integer.toString(sc), output("B") };
 		
-		loadTestConfiguration(config);
+		rCmd = getRCmd(inputDir(), Integer.toString(sortcol), expectedDir());
 
 		try 
 		{
@@ -97,7 +91,6 @@ public class OrderTest extends AutomatedTestBase
 			//check number of compiled and executed scripts (assumes IPA and recompile)
 			Assert.assertEquals("Unexpected number of compiled MR jobs.", 1, Statistics.getNoOfCompiledMRJobs()); //reblock
 			Assert.assertEquals("Unexpected number of executed MR jobs.", 0, Statistics.getNoOfExecutedMRJobs());
-			
 			
 			//compare matrices
 			HashMap<CellIndex, Double> dmlfile = readDMLMatrixFromHDFS("B");

--- a/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOLinregCG.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOLinregCG.java
@@ -39,6 +39,7 @@ public class GDFOLinregCG extends AutomatedTestBase
 	
 	private final static String TEST_NAME1 = "LinregCG";
 	private final static String TEST_DIR = "functions/gdfo/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + GDFOLinregCG.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-globalopt.xml";
 	
 	private final static double eps = 1e-5;
@@ -57,7 +58,7 @@ public class GDFOLinregCG extends AutomatedTestBase
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "w" })); 
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "w" })); 
 	}
 
 	@Test
@@ -122,25 +123,18 @@ public class GDFOLinregCG extends AutomatedTestBase
 		{
 			String TEST_NAME = testname;
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config);
 			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{ "-explain",//"hops",
-					                    "-config="+HOME+TEST_CONF,
-					                    "-args", HOME + INPUT_DIR + "X",
-					                             HOME + INPUT_DIR + "y",
-					                             String.valueOf(intercept),
-					                             String.valueOf(epsilon),
-					                             String.valueOf(maxiter),
-					                            HOME + OUTPUT_DIR + "w"};
-			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + 
-			       HOME + INPUT_DIR + " " + 
-			       String.valueOf(intercept) + " " + String.valueOf(epsilon) + " " + 
-			       String.valueOf(maxiter) + " " + HOME + EXPECTED_DIR;
-			
-			loadTestConfiguration(config);
+			programArgs = new String[]{ "-explain", //"hops",
+				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("y"),
+				String.valueOf(intercept), String.valueOf(epsilon),
+				String.valueOf(maxiter), output("w")};
+
+			rCmd = getRCmd(inputDir(), String.valueOf(intercept),String.valueOf(epsilon),
+				String.valueOf(maxiter), expectedDir());
 	
 			//generate actual datasets
 			double[][] X = getRandomMatrix(rows, cols, 0, 1, sparse?sparsity2:sparsity1, 7);

--- a/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOLinregDS.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOLinregDS.java
@@ -39,6 +39,7 @@ public class GDFOLinregDS extends AutomatedTestBase
 	
 	private final static String TEST_NAME1 = "LinregDS";
 	private final static String TEST_DIR = "functions/gdfo/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + GDFOLinregDS.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-globalopt.xml";
 	
 	private final static double eps = 1e-8;
@@ -56,7 +57,7 @@ public class GDFOLinregDS extends AutomatedTestBase
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "B" })); 
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "B" })); 
 	}
 
 	@Test
@@ -119,24 +120,16 @@ public class GDFOLinregDS extends AutomatedTestBase
 		{
 			String TEST_NAME = testname;
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config);
 			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain","hops",
-					                    "-config="+HOME+TEST_CONF,
-					                    "-args", HOME + INPUT_DIR + "X",
-					                             HOME + INPUT_DIR + "y",
-					                             String.valueOf(intercept),
-					                             String.valueOf(lambda),
-					                            HOME + OUTPUT_DIR + "B"};
-			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + 
-			       HOME + INPUT_DIR + " " + 
-			       String.valueOf(intercept) + " " + String.valueOf(lambda) + " " +
-			       HOME + EXPECTED_DIR;
-			
-			loadTestConfiguration(config);
+				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("y"),
+				String.valueOf(intercept), String.valueOf(lambda), output("B")};
+
+			rCmd = getRCmd(inputDir(), String.valueOf(intercept), String.valueOf(lambda), expectedDir());
 	
 			//generate actual datasets
 			double[][] X = getRandomMatrix(rows, cols, 0, 1, sparse?sparsity2:sparsity1, 7);

--- a/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOLinregDSsimpl.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOLinregDSsimpl.java
@@ -39,6 +39,7 @@ public class GDFOLinregDSsimpl extends AutomatedTestBase
 	
 	private final static String TEST_NAME1 = "LinregDSsimpl";
 	private final static String TEST_DIR = "functions/gdfo/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + GDFOLinregDSsimpl.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-globalopt.xml";
 	
 	private final static double eps = 1e-8;
@@ -56,7 +57,7 @@ public class GDFOLinregDSsimpl extends AutomatedTestBase
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "B" })); 
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "B" })); 
 	}
 
 	@Test
@@ -70,7 +71,6 @@ public class GDFOLinregDSsimpl extends AutomatedTestBase
 	{
 		runGDFOTest(TEST_NAME1, true, ExecType.CP);
 	}
-
 
 	@Test
 	public void testGDFOLinregDSDenseMR() 
@@ -120,24 +120,16 @@ public class GDFOLinregDSsimpl extends AutomatedTestBase
 		{
 			String TEST_NAME = testname;
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config);
 			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain","hops",
-					                    "-config="+HOME+TEST_CONF,
-					                    "-args", HOME + INPUT_DIR + "X",
-					                             HOME + INPUT_DIR + "y",
-					                             String.valueOf(intercept),
-					                             String.valueOf(lambda),
-					                            HOME + OUTPUT_DIR + "B"};
-			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + 
-			       HOME + INPUT_DIR + " " + 
-			       String.valueOf(intercept) + " " + String.valueOf(lambda) + " " +
-			       HOME + EXPECTED_DIR;
-			
-			loadTestConfiguration(config);
+				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("y"),
+				String.valueOf(intercept), String.valueOf(lambda), output("B")};
+
+			rCmd = getRCmd(inputDir(), String.valueOf(intercept), String.valueOf(lambda), expectedDir());
 	
 			//generate actual datasets
 			double[][] X = getRandomMatrix(rows, cols, 0, 1, sparse?sparsity2:sparsity1, 7);

--- a/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOMMChainLoop.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOMMChainLoop.java
@@ -37,6 +37,7 @@ public class GDFOMMChainLoop extends AutomatedTestBase
 	
 	private final static String TEST_NAME1 = "MMChainLoop";
 	private final static String TEST_DIR = "functions/gdfo/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + GDFOMMChainLoop.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-globalopt.xml";
 	
 	private final static double eps = 1e-10;
@@ -53,7 +54,7 @@ public class GDFOMMChainLoop extends AutomatedTestBase
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "w" })); 
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "w" })); 
 	}
 
 	@Test
@@ -84,21 +85,16 @@ public class GDFOMMChainLoop extends AutomatedTestBase
 		{
 			String TEST_NAME = testname;
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config);
 			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{ "-explain",//"hops",
-					                    "-config="+HOME+TEST_CONF,
-					                    "-args", HOME + INPUT_DIR + "X",
-					                             HOME + INPUT_DIR + "v",
-					                             String.valueOf(maxiter),
-					                            HOME + OUTPUT_DIR + "w"};
-			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + 
-			       HOME + INPUT_DIR + " " + String.valueOf(maxiter) + " " + HOME + EXPECTED_DIR;
+			programArgs = new String[]{ "-explain", //"hops",
+				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("v"),
+				String.valueOf(maxiter), output("w")};
 			
-			loadTestConfiguration(config);
+			rCmd = getRCmd(inputDir(), String.valueOf(maxiter), expectedDir());
 	
 			//generate actual datasets
 			double[][] X = getRandomMatrix(rows, cols, 0, 1, sparse?sparsity2:sparsity1, 7);

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/ACosTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/ACosTest.java
@@ -26,7 +26,6 @@ import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.test.utils.TestUtils;
 
 
-
 /**
  * <p><b>Positive tests:</b></p>
  * <ul>
@@ -41,22 +40,21 @@ import org.apache.sysml.test.utils.TestUtils;
  */
 public class ACosTest extends AutomatedTestBase 
 {
-
 	
 	private static final String TEST_DIR = "functions/unary/scalar/";
-	
+	private static final String TEST_CLASS_DIR = TEST_DIR + ACosTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		
 		// positive tests
-		addTestConfiguration("PositiveTest", new TestConfiguration(TEST_DIR, "ACosTest",
+		addTestConfiguration("PositiveTest", new TestConfiguration(TEST_CLASS_DIR, "ACosTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("NegativeTest", new TestConfiguration(TEST_DIR, "ACosTest",
+		addTestConfiguration("NegativeTest", new TestConfiguration(TEST_CLASS_DIR, "ACosTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("ZeroTest", new TestConfiguration(TEST_DIR, "ACosTest",
+		addTestConfiguration("ZeroTest", new TestConfiguration(TEST_CLASS_DIR, "ACosTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("RandomTest", new TestConfiguration(TEST_DIR, "ACosTest",
+		addTestConfiguration("RandomTest", new TestConfiguration(TEST_CLASS_DIR, "ACosTest",
 				new String[] { "int", "double" }));
 		
 		// negative tests

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/ASinTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/ASinTest.java
@@ -26,7 +26,6 @@ import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.test.utils.TestUtils;
 
 
-
 /**
  * <p><b>Positive tests:</b></p>
  * <ul>
@@ -40,19 +39,19 @@ import org.apache.sysml.test.utils.TestUtils;
  */
 public class ASinTest extends AutomatedTestBase 
 {
-
 	
-	private String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ASinTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		// positive tests
 		addTestConfiguration("PositiveTest",
-				new TestConfiguration(TEST_DIR, "ASinTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "ASinTest", new String[] { "int", "double" }));
 		addTestConfiguration("NegativeTest",
-				new TestConfiguration(TEST_DIR, "ASinTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "ASinTest", new String[] { "int", "double" }));
 		addTestConfiguration("RandomTest",
-				new TestConfiguration(TEST_DIR, "ASinTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "ASinTest", new String[] { "int", "double" }));
 		
 		// negative tests
 	}

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/ATanTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/ATanTest.java
@@ -26,7 +26,6 @@ import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.test.utils.TestUtils;
 
 
-
 /**
  * <p><b>Positive tests:</b></p>
  * <ul>
@@ -41,19 +40,19 @@ import org.apache.sysml.test.utils.TestUtils;
 public class ATanTest extends AutomatedTestBase 
 {
 
-		
 	private static final String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ATanTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		
 		// positive tests
 		addTestConfiguration("PositiveTest",
-				new TestConfiguration(TEST_DIR, "ATanTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "ATanTest", new String[] { "int", "double" }));
 		addTestConfiguration("NegativeTest",
-				new TestConfiguration(TEST_DIR, "ATanTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "ATanTest", new String[] { "int", "double" }));
 		addTestConfiguration("RandomTest",
-				new TestConfiguration(TEST_DIR, "ATanTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "ATanTest", new String[] { "int", "double" }));
 		
 		// negative tests
 	}

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/AbsTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/AbsTest.java
@@ -26,7 +26,6 @@ import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.test.utils.TestUtils;
 
 
-
 /**
  * <p><b>Positive tests:</b></p>
  * <ul>
@@ -43,17 +42,18 @@ public class AbsTest extends AutomatedTestBase
 {
 
 	private static final String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + AbsTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		// positive tests
-		addTestConfiguration("PositiveTest", new TestConfiguration(TEST_DIR, "AbsTest",
+		addTestConfiguration("PositiveTest", new TestConfiguration(TEST_CLASS_DIR, "AbsTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("NegativeTest", new TestConfiguration(TEST_DIR, "AbsTest",
+		addTestConfiguration("NegativeTest", new TestConfiguration(TEST_CLASS_DIR, "AbsTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("ZeroTest", new TestConfiguration(TEST_DIR, "AbsTest",
+		addTestConfiguration("ZeroTest", new TestConfiguration(TEST_CLASS_DIR, "AbsTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("RandomTest", new TestConfiguration(TEST_DIR, "AbsTest",
+		addTestConfiguration("RandomTest", new TestConfiguration(TEST_CLASS_DIR, "AbsTest",
 				new String[] { "int", "double" }));
 		
 		// negative tests

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/BooleanTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/BooleanTest.java
@@ -25,19 +25,17 @@ import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
 
 
-
 public class BooleanTest extends AutomatedTestBase 
 {
-
 	
 	private static final String TEST_DIR = "functions/unary/scalar/";
-	
+	private static final String TEST_CLASS_DIR = TEST_DIR + BooleanTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		
 		// positive tests
-		addTestConfiguration("WhileTest", new TestConfiguration(TEST_DIR, "BooleanWhileTest",
+		addTestConfiguration("WhileTest", new TestConfiguration(TEST_CLASS_DIR, "BooleanWhileTest",
 				new String[] { "true", "false" }));
 		
 		// negative tests

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/CosTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/CosTest.java
@@ -26,7 +26,6 @@ import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.test.utils.TestUtils;
 
 
-
 /**
  * <p><b>Positive tests:</b></p>
  * <ul>
@@ -43,19 +42,20 @@ public class CosTest extends AutomatedTestBase
 {
 	
 	private static final String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + CosTest.class.getSimpleName() + "/";
 	private static final double EPS = 1e-14;
 	
 	@Override
 	public void setUp() {
 		
 		// positive tests
-		addTestConfiguration("PositiveTest", new TestConfiguration(TEST_DIR, "CosTest",
+		addTestConfiguration("PositiveTest", new TestConfiguration(TEST_CLASS_DIR, "CosTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("NegativeTest", new TestConfiguration(TEST_DIR, "CosTest",
+		addTestConfiguration("NegativeTest", new TestConfiguration(TEST_CLASS_DIR, "CosTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("ZeroTest", new TestConfiguration(TEST_DIR, "CosTest",
+		addTestConfiguration("ZeroTest", new TestConfiguration(TEST_CLASS_DIR, "CosTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("RandomTest", new TestConfiguration(TEST_DIR, "CosTest",
+		addTestConfiguration("RandomTest", new TestConfiguration(TEST_CLASS_DIR, "CosTest",
 				new String[] { "int", "double" }));
 		
 		// negative tests

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/ExponentTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/ExponentTest.java
@@ -27,7 +27,6 @@ import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.test.utils.TestUtils;
 
 
-
 /**
  * <p><b>Positive tests:</b></p>
  * <ul>
@@ -48,23 +47,24 @@ public class ExponentTest extends AutomatedTestBase
 {
 		
 	private static final String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ExponentTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		// positive tests
-		addTestConfiguration("ConstTest", new TestConfiguration(TEST_DIR, "ExponentTest",
+		addTestConfiguration("ConstTest", new TestConfiguration(TEST_CLASS_DIR, "ExponentTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("VarTest", new TestConfiguration(TEST_DIR, "ExponentTest",
+		addTestConfiguration("VarTest", new TestConfiguration(TEST_CLASS_DIR, "ExponentTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("RandomConstTest", new TestConfiguration(TEST_DIR, "ExponentTest",
+		addTestConfiguration("RandomConstTest", new TestConfiguration(TEST_CLASS_DIR, "ExponentTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("RandomVarTest", new TestConfiguration(TEST_DIR, "ExponentTest",
+		addTestConfiguration("RandomVarTest", new TestConfiguration(TEST_CLASS_DIR, "ExponentTest",
 				new String[] { "int", "double" }));
-		addTestConfiguration("NegativeTest", new TestConfiguration(TEST_DIR, "ExponentTest",
+		addTestConfiguration("NegativeTest", new TestConfiguration(TEST_CLASS_DIR, "ExponentTest",
 				new String[] { "int", "double" }));
 		
 		// negative tests
-		addTestConfiguration("TwoParametersTest", new TestConfiguration(TEST_DIR, "ExponentBinaryTest",
+		addTestConfiguration("TwoParametersTest", new TestConfiguration(TEST_CLASS_DIR, "ExponentBinaryTest",
 				new String[] { "computed" }));
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/FullDistributionTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/FullDistributionTest.java
@@ -37,11 +37,12 @@ public class FullDistributionTest extends AutomatedTestBase
 	enum TEST_TYPE { NORMAL, NORMAL_NOPARAMS, NORMAL_MEAN, NORMAL_SD, F, T, CHISQ, EXP, EXP_NOPARAMS };
 	
 	private final static String TEST_DIR = "functions/unary/scalar/";
-
+	private final static String TEST_CLASS_DIR = TEST_DIR + FullDistributionTest.class.getSimpleName() + "/";
+	
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_DIR, TEST_NAME, new String[] { "dfout" }));
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "dfout" }));
 	}
 	
 	@Test
@@ -85,7 +86,7 @@ public class FullDistributionTest extends AutomatedTestBase
 	}
 	
 	private void runDFTest(TEST_TYPE type, boolean inverse, Double param1, Double param2) {
-		TestConfiguration config = getTestConfiguration(TEST_NAME);
+		getAndLoadTestConfiguration(TEST_NAME);
 
 		double in = (new Random(System.nanoTime())).nextDouble();
 		
@@ -93,8 +94,8 @@ public class FullDistributionTest extends AutomatedTestBase
 		fullDMLScriptName = HOME + TEST_NAME + "_" + type.toString() + ".dml";
 		fullRScriptName = HOME + TEST_NAME + "_" + type.toString() + ".R";
 		
-		String DMLout = HOME + OUTPUT_DIR + "dfout";
-		String Rout = HOME + EXPECTED_DIR + "dfout";
+		String DMLout = output("dfout");
+		String Rout = expected("dfout");
 		
 		switch(type) {
 		case NORMAL_NOPARAMS:
@@ -120,8 +121,6 @@ public class FullDistributionTest extends AutomatedTestBase
 			default: 
 				throw new RuntimeException("Invalid distribution function: " + type);
 		}
-		
-		loadTestConfiguration(config);
 		
 		runTest(true, false, null, -1); 
 		runRScript(true); 

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/NegationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/NegationTest.java
@@ -26,7 +26,6 @@ import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.test.utils.TestUtils;
 
 
-
 /**
  * <p><b>Positive tests:</b></p>
  * <ul>
@@ -40,13 +39,14 @@ public class NegationTest extends AutomatedTestBase
 {
 	
 	private static String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + NegationTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
 		
 		// positive tests
-		addTestConfiguration("NegationTest", new TestConfiguration(TEST_DIR, "NegationTest", new String[] { }));
+		addTestConfiguration("NegationTest", new TestConfiguration(TEST_CLASS_DIR, "NegationTest", new String[] { }));
 		
 		// negative tests
 	}

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/NotTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/NotTest.java
@@ -25,7 +25,6 @@ import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
 
 
-
 /**
  * <p><b>Positive tests:</b></p>
  * <ul>
@@ -39,11 +38,12 @@ public class NotTest extends AutomatedTestBase
 {
 
 	private static final String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + NotTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		// positive tests
-		addTestConfiguration("NotTest", new TestConfiguration(TEST_DIR, "NotTest",
+		addTestConfiguration("NotTest", new TestConfiguration(TEST_CLASS_DIR, "NotTest",
 				new String[] { "true_true", "true_false", "false_false", "false_true" }));
 		
 		// negative tests

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/PrintTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/PrintTest.java
@@ -32,13 +32,14 @@ public class PrintTest extends AutomatedTestBase
 {
 	
 	private static final String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + PrintTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		
-		addTestConfiguration("PrintTest", new TestConfiguration(TEST_DIR, "PrintTest", new String[] {}));
-		addTestConfiguration("PrintTest2", new TestConfiguration(TEST_DIR, "PrintTest2", new String[] {}));
-		addTestConfiguration("PrintTest3", new TestConfiguration(TEST_DIR, "PrintTest3", new String[] {}));
+		addTestConfiguration("PrintTest", new TestConfiguration(TEST_CLASS_DIR, "PrintTest", new String[] {}));
+		addTestConfiguration("PrintTest2", new TestConfiguration(TEST_CLASS_DIR, "PrintTest2", new String[] {}));
+		addTestConfiguration("PrintTest3", new TestConfiguration(TEST_CLASS_DIR, "PrintTest3", new String[] {}));
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/RoundTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/RoundTest.java
@@ -33,26 +33,24 @@ public class RoundTest extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "RoundTest";
 	private final static String TEST_DIR = "functions/unary/scalar/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + RoundTest.class.getSimpleName() + "/";
 
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration("RoundTest", new TestConfiguration(TEST_DIR,"RoundTest", new String[] { "scalar" }));
+		addTestConfiguration("RoundTest", new TestConfiguration(TEST_CLASS_DIR, "RoundTest", new String[] { "scalar" }));
 	}
 	
 	@Test
 	public void testRound() {
-		TestConfiguration config = getTestConfiguration(TEST_NAME);
+		getAndLoadTestConfiguration(TEST_NAME);
 
 		double scalar = 10.7;
 		
 		/* This is for running the junit test the new way, i.e., construct the arguments directly */
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[]{"-args", Double.toString(scalar), 
-				                        HOME + OUTPUT_DIR + "scalar" };
-
-		loadTestConfiguration(config);
+		programArgs = new String[]{"-args", Double.toString(scalar), output("scalar") };
 		
 		double roundScalar = Math.round(scalar);
 

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/SinTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/SinTest.java
@@ -26,7 +26,6 @@ import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.test.utils.TestUtils;
 
 
-
 /**
  * <p><b>Positive tests:</b></p>
  * <ul>
@@ -41,7 +40,8 @@ import org.apache.sysml.test.utils.TestUtils;
 public class SinTest extends AutomatedTestBase 
 {
 	
-	private static String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + SinTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
@@ -49,11 +49,11 @@ public class SinTest extends AutomatedTestBase
 		
 		// positive tests
 		addTestConfiguration("PositiveTest",
-				new TestConfiguration(TEST_DIR, "SinTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "SinTest", new String[] { "int", "double" }));
 		addTestConfiguration("NegativeTest",
-				new TestConfiguration(TEST_DIR, "SinTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "SinTest", new String[] { "int", "double" }));
 		addTestConfiguration("RandomTest",
-				new TestConfiguration(TEST_DIR, "SinTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "SinTest", new String[] { "int", "double" }));
 		
 		// negative tests
 	}

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/SqrtTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/SqrtTest.java
@@ -26,7 +26,6 @@ import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.test.utils.TestUtils;
 
 
-
 /**
  * <p><b>Positive tests:</b></p>
  * <ul>
@@ -46,28 +45,28 @@ import org.apache.sysml.test.utils.TestUtils;
  */
 public class SqrtTest extends AutomatedTestBase 
 {
-
 	
 	private static final String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + SqrtTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
 		
 		// positive tests
 		addTestConfiguration("PositiveTest",
-				new TestConfiguration(TEST_DIR, "SqrtTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "SqrtTest", new String[] { "int", "double" }));
 		
 		// random tests
 		addTestConfiguration("RandomIntTest",
-				new TestConfiguration(TEST_DIR, "SqrtSingleTest", new String[] { "computed" }));
+				new TestConfiguration(TEST_CLASS_DIR, "SqrtSingleTest", new String[] { "computed" }));
 		addTestConfiguration("RandomDoubleTest",
-				new TestConfiguration(TEST_DIR, "SqrtSingleTest", new String[] { "computed" }));
+				new TestConfiguration(TEST_CLASS_DIR, "SqrtSingleTest", new String[] { "computed" }));
 		
 		// negative tests
 		addTestConfiguration("NegativeIntTest",
-				new TestConfiguration(TEST_DIR, "SqrtSingleTest", new String[] { "computed" }));
+				new TestConfiguration(TEST_CLASS_DIR, "SqrtSingleTest", new String[] { "computed" }));
 		addTestConfiguration("NegativeDoubleTest",
-				new TestConfiguration(TEST_DIR, "SqrtSingleTest", new String[] { "computed" }));
+				new TestConfiguration(TEST_CLASS_DIR, "SqrtSingleTest", new String[] { "computed" }));
 	}
 	
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/StopTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/StopTest.java
@@ -32,13 +32,14 @@ public class StopTest extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/unary/scalar/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + StopTest.class.getSimpleName() + "/";
 	private final static String TEST_STOP = "StopTest";
 	
 	@Override
 	public void setUp() {
 		baseDirectory = SCRIPT_DIR + "functions/unary/scalar/";
 
-		availableTestConfigurations.put(TEST_STOP, new TestConfiguration(TEST_DIR, TEST_STOP, new String[] {}));
+		availableTestConfigurations.put(TEST_STOP, new TestConfiguration(TEST_CLASS_DIR, TEST_STOP, new String[] {}));
 	}
 
 	String errMessage = "M is all 0 matrix.";

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/StopTest2.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/StopTest2.java
@@ -32,13 +32,12 @@ public class StopTest2 extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/unary/scalar/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + StopTest2.class.getSimpleName() + "/";
 	private final static String TEST_STOP = "StopTest";
 	
 	@Override
 	public void setUp() {
-		baseDirectory = SCRIPT_DIR + "functions/unary/scalar/";
-
-		availableTestConfigurations.put(TEST_STOP, new TestConfiguration(TEST_DIR, TEST_STOP, new String[] {}));
+		availableTestConfigurations.put(TEST_STOP, new TestConfiguration(TEST_CLASS_DIR, TEST_STOP, new String[] {}));
 	}
 
 	String errMessage = "Stop Here.";

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/StopTestCtrlStr.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/StopTestCtrlStr.java
@@ -33,7 +33,8 @@ public class StopTestCtrlStr extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/unary/scalar/";
-	private final static String TEST_STOP = "StopTestLoops";
+	private final static String TEST_CLASS_DIR = TEST_DIR + StopTestCtrlStr.class.getSimpleName() + "/";
+	private final static String TEST_NAME = "StopTestLoops";
 	
 	private final static int rows = 100;
 	private final static String inputName = "in";
@@ -41,21 +42,18 @@ public class StopTestCtrlStr extends AutomatedTestBase
 	
 	@Override
 	public void setUp() {
-		baseDirectory = SCRIPT_DIR + "functions/unary/scalar/";
-
-		availableTestConfigurations.put(TEST_STOP, new TestConfiguration(TEST_DIR, TEST_STOP, new String[] {}));
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {}));
 	}
 
 	@Test
 	public void testStopParfor() {
 		
-		TestConfiguration config = availableTestConfigurations.get(TEST_STOP);
+		getAndLoadTestConfiguration(TEST_NAME);
 		
 		String STOP_HOME = SCRIPT_DIR + TEST_DIR;
-		fullDMLScriptName = STOP_HOME + TEST_STOP + "_parfor.dml";
+		fullDMLScriptName = STOP_HOME + TEST_NAME + "_parfor.dml";
 		programArgs = new String[]{};
 		
-		loadTestConfiguration(config);
 		boolean exceptionExpected = true;
 		int expectedNumberOfJobs = 0;
 		
@@ -97,16 +95,15 @@ public class StopTestCtrlStr extends AutomatedTestBase
 		RUNTIME_PLATFORM oldRT = rtplatform;
 		rtplatform = rt;
 		
-		TestConfiguration config = availableTestConfigurations.get(TEST_STOP);
+		getAndLoadTestConfiguration(TEST_NAME);
 		String STOP_HOME = SCRIPT_DIR + TEST_DIR;
 		
-		fullDMLScriptName = STOP_HOME + TEST_STOP + "_" + loop + ".dml";
-		programArgs = new String[]{"-args", STOP_HOME + INPUT_DIR + inputName, Integer.toString(rows), Double.toString(cutoff)};
+		fullDMLScriptName = STOP_HOME + TEST_NAME + "_" + loop + ".dml";
+		programArgs = new String[]{"-args", input(inputName), Integer.toString(rows), Double.toString(cutoff)};
 		
         double[][] vector = getRandomMatrix(rows, 1, 0, 1, 1, System.currentTimeMillis());
         writeInputMatrix(inputName, vector);
 
-		loadTestConfiguration(config);
 		boolean exceptionExpected = false;
 		
         int cutoffIndex = findIndexAtCutoff(vector, cutoff);

--- a/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/TanTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/unary/scalar/TanTest.java
@@ -26,7 +26,6 @@ import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.test.utils.TestUtils;
 
 
-
 /**
  * <p><b>Positive tests:</b></p>
  * <ul>
@@ -42,6 +41,7 @@ public class TanTest extends AutomatedTestBase
 {
 		
 	private static final String TEST_DIR = "functions/unary/scalar/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + TanTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
@@ -49,11 +49,11 @@ public class TanTest extends AutomatedTestBase
 		
 		// positive tests
 		addTestConfiguration("PositiveTest",
-				new TestConfiguration(TEST_DIR, "TanTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "TanTest", new String[] { "int", "double" }));
 		addTestConfiguration("NegativeTest",
-				new TestConfiguration(TEST_DIR, "TanTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "TanTest", new String[] { "int", "double" }));
 		addTestConfiguration("RandomTest",
-				new TestConfiguration(TEST_DIR, "TanTest", new String[] { "int", "double" }));
+				new TestConfiguration(TEST_CLASS_DIR, "TanTest", new String[] { "int", "double" }));
 		
 		// negative tests
 	}
@@ -63,7 +63,7 @@ public class TanTest extends AutomatedTestBase
 		int intValue = 5;
 		double doubleValue = 5.0;
 		
-		TestConfiguration config = availableTestConfigurations.get("PositiveTest");
+		TestConfiguration config = getTestConfiguration("PositiveTest");
 		config.addVariable("int", intValue);
 		config.addVariable("double", doubleValue);
 		
@@ -86,7 +86,7 @@ public class TanTest extends AutomatedTestBase
 		int intValue = -5;
 		double doubleValue = -5.0;
 		
-		TestConfiguration config = availableTestConfigurations.get("NegativeTest");
+		TestConfiguration config = getTestConfiguration("NegativeTest");
 		config.addVariable("int", intValue);
 		config.addVariable("double", doubleValue);
 		
@@ -109,7 +109,7 @@ public class TanTest extends AutomatedTestBase
 		int intValue = TestUtils.getRandomInt();
 		double doubleValue = TestUtils.getRandomDouble();
 		
-		TestConfiguration config = availableTestConfigurations.get("RandomTest");
+		TestConfiguration config = getTestConfiguration("RandomTest");
 		config.addVariable("int", intValue);
 		config.addVariable("double", doubleValue);
 		


### PR DESCRIPTION
Updated unit tests for binary.scalar, unary.scalar, blocks, caching, external, and gdfo packages
such that in/out/expected test data won't be generated under src directory. The gdfo refactoring also included utilizing base class getRCmd().
The AutomatedTestBase.writeExpectedScalar method, which is only called from unary.scalar.RoundTest, was modified to ensure expected directory path exists.

Tests completed successfully [here](https://sparktc.ibmcloud.com/jenkins/job/SystemML-OnDemand/36/).
