### PR TITLE
Refactor unit tests in misc, io and other packages.

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/functions/dmlscript/DMLScriptTest1.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/dmlscript/DMLScriptTest1.java
@@ -43,72 +43,53 @@ import org.apache.sysml.test.integration.TestConfiguration;
  */
 public class DMLScriptTest1 extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_DIR = "functions/dmlscript/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + DMLScriptTest1.class.getSimpleName() + "/";
+	private final static String TEST_NAME = "DMLScriptTest";
 	
 	@Override
 	public void setUp() {
-		baseDirectory = SCRIPT_DIR + "functions/dmlscript/";
-
 		// positive tests
-		availableTestConfigurations.put("DMLScriptTest", new TestConfiguration("functions/dmlscript/", "DMLScriptTest", new String[] { "a" }));
+		TestConfiguration config = new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "a" });
+		addTestConfiguration(TEST_NAME, config);
 		
-
-		// negative tests
-		
+		// negative tests		
 	}
 
 	@Test
 	public void testWithFile() {
 		int rows = 10;
 		int cols = 10;
-		String HOME = SCRIPT_DIR + TEST_DIR;
 
-		TestConfiguration config = availableTestConfigurations.get("DMLScriptTest");
+		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
 		config.addVariable("format", "text");
-		
-		fullDMLScriptName = baseDirectory + "DMLScriptTest.dml";
-		
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "a" ,
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a"};
-	
 		loadTestConfiguration(config);
+		
+		String HOME = SCRIPT_DIR + TEST_DIR;
+		fullDMLScriptName = HOME + "DMLScriptTest.dml";
+		
+		programArgs = new String[]{"-args", input("a"),
+			Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 
 		double[][] a = getRandomMatrix(rows, cols, -1, 1, 0.5, -1);
 		writeInputMatrix("a", a, true);
 
 		runTest(true, false, null, -1);
 
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "a" ,
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a"};
+		programArgs = new String[]{"-args", input("a"),
+			Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 		runTest(true, false, null, -1);
 		
-		
-		programArgs = new String[]{"-exec", "hybrid",
-	               "-args", HOME + INPUT_DIR + "a" ,
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a"};
+		programArgs = new String[]{"-exec", "hybrid", "-args", input("a"),
+			Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 		runTest(true, false, null, -1);
 		
-		programArgs = new String[]{"-exec", "hybrid", "-config=" + baseDirectory + "SystemML-config.xml",
-	               "-args", HOME + INPUT_DIR + "a" ,
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a"};
+		programArgs = new String[]{"-exec", "hybrid", "-config=" + HOME + "SystemML-config.xml",
+			"-args", input("a"), Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 		runTest(true, false, null, -1);
-		
 	}
 
 	@Test
@@ -119,39 +100,26 @@ public class DMLScriptTest1 extends AutomatedTestBase
 		int cols = 10;
 		String HOME = SCRIPT_DIR + TEST_DIR;
 
-		TestConfiguration config = availableTestConfigurations.get("DMLScriptTest");
+		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
 		config.addVariable("format", "text");
-		
-		programArgs = new String[]{"-s", s, 
-	               "-args", HOME + INPUT_DIR + "a" ,
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a"};
-	
 		loadTestConfiguration(config);
+		
+		programArgs = new String[]{"-s", s, "-args", input("a"),
+			Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 
 		double[][] a = getRandomMatrix(rows, cols, -1, 1, 0.5, -1);
 		writeInputMatrix("a", a, true);
 
 		runTest(true, false, null, -1);
 		
-		programArgs = new String[]{"-s", s,
-	               "-args", HOME + INPUT_DIR + "a" ,
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a"};
+		programArgs = new String[]{"-s", s, "-args", input("a"),
+			Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 		runTest(true, false, null, -1);
 		
-		programArgs = new String[]{"-s", s, "-config=" + baseDirectory + "SystemML-config.xml", "-exec", "hybrid", 
-	               "-args", HOME + INPUT_DIR + "a" ,
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a"};
+		programArgs = new String[]{"-s", s, "-config=" + HOME + "SystemML-config.xml", "-exec", "hybrid",
+			"-args", input("a"), Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 		runTest(true, false, null, -1);
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/dmlscript/DMLScriptTest2.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/dmlscript/DMLScriptTest2.java
@@ -46,7 +46,8 @@ public class DMLScriptTest2 extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/dmlscript/";
-	
+	private final static String TEST_CLASS_DIR = TEST_DIR + DMLScriptTest2.class.getSimpleName() + "/";
+	private final static String TEST_NAME = "DMLScriptTest2";
 	
 	/**
 	 * Main method for running one test at a time.
@@ -66,14 +67,11 @@ public class DMLScriptTest2 extends AutomatedTestBase
 	
 	@Override
 	public void setUp() {
-		baseDirectory = SCRIPT_DIR + "functions/dmlscript/";
-
 		// positive tests
 		
-		
-
 		// negative tests
-		availableTestConfigurations.put("DMLScriptTest2", new TestConfiguration("functions/dmlscript/", "DMLScriptTest2", new String[] { "a" }));
+		TestConfiguration config = new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "a" });
+		addTestConfiguration(TEST_NAME, config);
 	}
 
 	@Test
@@ -82,53 +80,35 @@ public class DMLScriptTest2 extends AutomatedTestBase
 		int cols = 10;
 		String HOME = SCRIPT_DIR + TEST_DIR;
 
-		TestConfiguration config = availableTestConfigurations.get("DMLScriptTest2");
+		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
 		config.addVariable("format", "text");
-		
 		loadTestConfiguration(config);
 
 		double[][] a = getRandomMatrix(rows, cols, -1, 1, 0.5, -1);
 		writeInputMatrix("a", a, true);
 		
 		//Expect to print out an ERROR message. -f or -s must be the first argument.
-		fullDMLScriptName = baseDirectory + "DMLScriptTest.dml";
-		programArgs = new String[]{ "-exec", "hybrid", "-args", HOME + INPUT_DIR + "a" , 
-		                       Integer.toString(rows),
-		                       Integer.toString(cols),
-		                       "text",
-		                       HOME + OUTPUT_DIR + "a"
-		                       };
+		fullDMLScriptName = HOME + "DMLScriptTest.dml";
+		programArgs = new String[]{ "-exec", "hybrid", "-args", input("a"),
+			Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 		runTest(true, false, null, -1);
 
 		//Expect to print out an ERROR message. -args should be the last argument.
-		programArgs = new String[]{"-args", HOME + INPUT_DIR + "a" , 
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a",
-	                        "-exec", "hybrid"};
+		programArgs = new String[]{"-args", input("a"),
+			Integer.toString(rows), Integer.toString(cols), "text", output("a"), "-exec", "hybrid"};
 		runTest(true, true, DMLException.class, -1);
 		
 		//Expect to print out an ERROR message, -de is an unknown argument
-		programArgs = new String[]{"-de", "-exec", "hybrid", "-config=" + baseDirectory + "SystemML-config.xml",
-	               "-args", HOME + INPUT_DIR + "a" ,
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a"};
+		programArgs = new String[]{"-de", "-exec", "hybrid", "-config=" + HOME + "SystemML-config.xml",
+			"-args", input("a"), Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 		runTest(true, false, null, -1);
 		
 		//Expect to print out an ERROR message, -config syntax is -config=<config file>
-		programArgs = new String[]{"-exec", "hybrid", "-config", baseDirectory + "SystemML-config.xml",
-			               "-args", HOME + INPUT_DIR + "a" ,
-			                        Integer.toString(rows),
-			                        Integer.toString(cols),
-			                        "text",
-			                        HOME + OUTPUT_DIR + "a"};
+		programArgs = new String[]{"-exec", "hybrid", "-config", HOME + "SystemML-config.xml",
+			"-args", input("a"), Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 		runTest(true, false, null, -1);
-		
 	}
 
 	@Test
@@ -143,52 +123,29 @@ public class DMLScriptTest2 extends AutomatedTestBase
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
 		config.addVariable("format", "text");
-		
 		loadTestConfiguration(config);
 
 		double[][] a = getRandomMatrix(rows, cols, -1, 1, 0.5, -1);
 		writeInputMatrix("a", a, true);
-
 		
 		//Expect to print out an ERROR message. -f or -s must be the first argument.
-		programArgs = new String[]{ "-v", "-s", s, 
-	               "-args", HOME + INPUT_DIR + "a" ,
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a"};
-	
-		
+		programArgs = new String[]{ "-v", "-s", s, "-args", input("a"),
+			Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 		runTest(true, false, null, -1);
 		
-		
 		//Expect to print out an ERROR message. -args should be the last argument.
-		programArgs = new String[]{"-s", s, 
-	               "-args", "-v", HOME + INPUT_DIR + "a" ,
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a"};
-	
-		
+		programArgs = new String[]{"-s", s, "-args", "-v", input("a"),
+			Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 		runTest(true, false, null, -1);
 		
 		//Expect to print out an ERROR message, -de is an unknown argument
-		programArgs = new String[]{"-s", s, "-de",
-	               "-args", HOME + INPUT_DIR + "a" ,
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a"};
+		programArgs = new String[]{"-s", s, "-de", "-args", input("a"),
+			Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 		runTest(true, false, null, -1);
 		
 		//Expect to print out an ERROR message, -config syntax is -config=<config file>
-		programArgs = new String[]{"-s", s, "-config", baseDirectory + "SystemML-config.xml", "-exec", "hybrid", 
-	               "-args", HOME + INPUT_DIR + "a" ,
-	                        Integer.toString(rows),
-	                        Integer.toString(cols),
-	                        "text",
-	                        HOME + OUTPUT_DIR + "a"};
+		programArgs = new String[]{"-s", s, "-config", HOME + "SystemML-config.xml", "-exec", "hybrid",
+			"-args", input("a"), Integer.toString(rows), Integer.toString(cols), "text", output("a")};
 		runTest(true, false, null, -1);
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/FullDynWriteTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/FullDynWriteTest.java
@@ -45,6 +45,7 @@ public class FullDynWriteTest extends AutomatedTestBase
 	private final static String TEST_NAME1 = "DynWriteScalar";
 	private final static String TEST_NAME2 = "DynWriteMatrix";
 	private final static String TEST_DIR = "functions/io/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + FullDynWriteTest.class.getSimpleName() + "/";
 	private final static double eps = 1e-10;
 	
 	private final static int rows = 350;
@@ -59,8 +60,8 @@ public class FullDynWriteTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "B" })   );
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] { "B" })   );
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "B" }) );
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "B" }) );
 	}
 
 	@Test
@@ -138,26 +139,25 @@ public class FullDynWriteTest extends AutomatedTestBase
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
+		loadTestConfiguration(config);
 		
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[]{ "-explain","-args", HOME + INPUT_DIR + "A",
-				                           getFormatString(fmt),
-				                           HOME + OUTPUT_DIR};
-		loadTestConfiguration(config);
+		programArgs = new String[]{ "-explain","-args",
+			input("A"), getFormatString(fmt), outputDir()};
 		
 		try 
 		{		
 			long seed1 = System.nanoTime();
 		    double[][] A = getRandomMatrix(rows, cols, 0, 1, 1.0, seed1);
-		    writeMatrix(A, HOME + INPUT_DIR + "A", fmt, rows, cols, 1000, 1000, rows*cols);
+		    writeMatrix(A, input("A"), fmt, rows, cols, 1000, 1000, rows*cols);
 		    
 		    //run testcase
 			runTest(true, false, null, -1);
 		    
 			//check existing file and compare results
 			long sum =  computeSum(A);
-			String fname = HOME + OUTPUT_DIR + sum;
+			String fname = output(Long.toString(sum));
 			
 			if( type == Type.Scalar ) {
 				long val = MapReduceTool.readIntegerFromHDFSFile(fname);

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/IOTest1.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/IOTest1.java
@@ -20,7 +20,6 @@
 package org.apache.sysml.test.integration.functions.io;
 
 import org.junit.Test;
-
 import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
 
@@ -43,16 +42,16 @@ import org.apache.sysml.test.integration.TestConfiguration;
  */
 public class IOTest1 extends AutomatedTestBase 
 {
-
+	private final static String TEST_DIR = "functions/io/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + IOTest1.class.getSimpleName() + "/";
+	private final static String TEST_NAME = "SimpleTest";
 	
 	@Override
 	public void setUp() {
-		baseDirectory = SCRIPT_DIR + "functions/io/";
-
 		// positive tests
-		availableTestConfigurations.put("SimpleTest", new TestConfiguration("functions/io/", "IOTest1", new String[] { "a" }));
+		addTestConfiguration(TEST_NAME,
+			new TestConfiguration(TEST_CLASS_DIR, "IOTest1", new String[] { "a" }));
 		
-
 		// negative tests
 		
 	}
@@ -62,7 +61,7 @@ public class IOTest1 extends AutomatedTestBase
 		int rows = 10;
 		int cols = 10;
 
-		TestConfiguration config = availableTestConfigurations.get("SimpleTest");
+		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
 		config.addVariable("format", "text");

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/IOTest2.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/IOTest2.java
@@ -20,7 +20,6 @@
 package org.apache.sysml.test.integration.functions.io;
 
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLException;
 import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
@@ -44,17 +43,17 @@ import org.apache.sysml.test.integration.TestConfiguration;
  */
 public class IOTest2 extends AutomatedTestBase 
 {
-	
+	private final static String TEST_DIR = "functions/io/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + IOTest2.class.getSimpleName() + "/";
+	private final static String TEST_NAME = "SimpleTest";
+
 	@Override
 	public void setUp() {
-		baseDirectory = SCRIPT_DIR + "functions/io/";
-
 		// positive tests
-		
-		
 
 		// negative tests
-		availableTestConfigurations.put("SimpleTest", new TestConfiguration("functions/io/", "IOTest2", new String[] { "a" }));
+		addTestConfiguration(TEST_NAME,
+			new TestConfiguration(TEST_CLASS_DIR, "IOTest2", new String[] { "a" }));
 	}
 
 	@Test
@@ -62,7 +61,7 @@ public class IOTest2 extends AutomatedTestBase
 		int rows = 10;
 		int cols = 10;
 
-		TestConfiguration config = availableTestConfigurations.get("SimpleTest");
+		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
 		config.addVariable("format", "text");

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/IOTest3.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/IOTest3.java
@@ -20,7 +20,6 @@
 package org.apache.sysml.test.integration.functions.io;
 
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLException;
 import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
@@ -44,17 +43,17 @@ import org.apache.sysml.test.integration.TestConfiguration;
  */
 public class IOTest3 extends AutomatedTestBase 
 {
-	
+	private final static String TEST_DIR = "functions/io/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + IOTest3.class.getSimpleName() + "/";
+	private final static String TEST_NAME = "SimpleTest";
+
 	@Override
 	public void setUp() {
-		baseDirectory = SCRIPT_DIR + "functions/io/";
-
 		// positive tests
 		
-		
-
 		// negative tests
-		availableTestConfigurations.put("SimpleTest", new TestConfiguration("functions/io/", "IOTest3", new String[] { "a" }));
+		addTestConfiguration(TEST_NAME,
+			new TestConfiguration(TEST_CLASS_DIR, "IOTest3", new String[] { "a" }));
 	}
 
 	@Test
@@ -62,7 +61,7 @@ public class IOTest3 extends AutomatedTestBase
 		int rows = 10;
 		int cols = 10;
 
-		TestConfiguration config = availableTestConfigurations.get("SimpleTest");
+		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
 		config.addVariable("format", "text");

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/IOTest4.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/IOTest4.java
@@ -20,7 +20,6 @@
 package org.apache.sysml.test.integration.functions.io;
 
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLException;
 import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
@@ -44,17 +43,17 @@ import org.apache.sysml.test.integration.TestConfiguration;
  */
 public class IOTest4 extends AutomatedTestBase 
 {
-	
+	private final static String TEST_DIR = "functions/io/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + IOTest4.class.getSimpleName() + "/";
+	private final static String TEST_NAME = "SimpleTest";
+
 	@Override
 	public void setUp() {
-		baseDirectory = SCRIPT_DIR + "functions/io/";
-
 		// positive tests
-		
-		
-
+				
 		// negative tests
-		availableTestConfigurations.put("SimpleTest", new TestConfiguration("functions/io/", "IOTest4", new String[] { "a" }));
+		addTestConfiguration(TEST_NAME,
+			new TestConfiguration(TEST_CLASS_DIR, "IOTest4", new String[] { "a" }));
 	}
 
 	@Test
@@ -62,7 +61,7 @@ public class IOTest4 extends AutomatedTestBase
 		int rows = 10;
 		int cols = 10;
 
-		TestConfiguration config = availableTestConfigurations.get("SimpleTest");
+		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
 		config.addVariable("format", "text");

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/IOTest5.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/IOTest5.java
@@ -20,7 +20,6 @@
 package org.apache.sysml.test.integration.functions.io;
 
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLException;
 import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
@@ -44,17 +43,17 @@ import org.apache.sysml.test.integration.TestConfiguration;
  */
 public class IOTest5 extends AutomatedTestBase 
 {
-	
+	private final static String TEST_DIR = "functions/io/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + IOTest5.class.getSimpleName() + "/";
+	private final static String TEST_NAME = "SimpleTest";
+
 	@Override
 	public void setUp() {
-		baseDirectory = SCRIPT_DIR + "functions/io/";
-
 		// positive tests
-		
-		
 
 		// negative tests
-		availableTestConfigurations.put("SimpleTest", new TestConfiguration("functions/io/", "IOTest5", new String[] { "a" }));
+		addTestConfiguration(TEST_NAME,
+			new TestConfiguration(TEST_CLASS_DIR, "IOTest5", new String[] { "a" }));
 	}
 
 	@Test
@@ -62,7 +61,7 @@ public class IOTest5 extends AutomatedTestBase
 		int rows = 10;
 		int cols = 10;
 
-		TestConfiguration config = availableTestConfigurations.get("SimpleTest");
+		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
 		config.addVariable("format", "text");

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/ScalarIOTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/ScalarIOTest.java
@@ -32,15 +32,16 @@ public class ScalarIOTest extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "scalarIOTest";
 	private final static String TEST_DIR = "functions/io/";
-	private final static String OUT_FILE = SCRIPT_DIR + TEST_DIR + OUTPUT_DIR + "a.scalar";
+	private final static String OUT_FILE = "a.scalar";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ScalarIOTest.class.getSimpleName() + "/";
+	private final static String HOME = SCRIPT_DIR + TEST_DIR;
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "a.scalar" })   );  
-		//baseDirectory = SCRIPT_DIR + "functions/io/";
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "a.scalar" }) );
+		
+		getAndLoadTestConfiguration(TEST_NAME);
 	}
 
 	@Test
@@ -48,49 +49,38 @@ public class ScalarIOTest extends AutomatedTestBase
 
 		int int_scalar = 464;
 		
-		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
-		loadTestConfiguration(config);
-
-		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + "ScalarWrite.dml";
-		programArgs = new String[]{	"-args", 
-									String.valueOf(int_scalar),
-									HOME + OUTPUT_DIR + "a.scalar"
-                				  };
+		programArgs = new String[]{	"-args", String.valueOf(int_scalar), output("a.scalar") };
 		runTest(true, false, null, -1);
-		int int_out_scalar = TestUtils.readDMLScalarFromHDFS(OUT_FILE).get(new CellIndex(1,1)).intValue();
+		
+		int int_out_scalar = TestUtils.readDMLScalarFromHDFS(output(OUT_FILE)).get(new CellIndex(1,1)).intValue();
 		Assert.assertEquals("Values not equal: " + int_scalar + "!=" + int_out_scalar, int_scalar, int_out_scalar);
 		
 		// Invoke the DML script that does computations and then writes scalar to HDFS
 		fullDMLScriptName = HOME + "ScalarComputeWrite.dml";
 		runTest(true, false, null, -1);
-		int_out_scalar = TestUtils.readDMLScalarFromHDFS(OUT_FILE).get(new CellIndex(1,1)).intValue();
-		Assert.assertEquals("Computation test for Integers failed: Values not equal: " + int_scalar + "!=" + int_out_scalar, int_scalar, int_out_scalar);
 		
+		int_out_scalar = TestUtils.readDMLScalarFromHDFS(output(OUT_FILE)).get(new CellIndex(1,1)).intValue();
+		Assert.assertEquals("Computation test for Integers failed: Values not equal: " + int_scalar + "!=" + int_out_scalar, int_scalar, int_out_scalar);
 	}
 
 	@Test
 	public void testDoubleScalarWrite() 
 	{
 		Double double_scalar = 464.55;
-		
-		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
-		loadTestConfiguration(config);
 
-		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + "ScalarWrite.dml";
-		programArgs = new String[]{	"-args", 
-									String.valueOf(double_scalar),
-									HOME + OUTPUT_DIR + "a.scalar"
-                				  };
+		programArgs = new String[]{	"-args", String.valueOf(double_scalar), output("a.scalar") };
 		runTest(true, false, null, -1);
-		Double double_out_scalar = TestUtils.readDMLScalarFromHDFS(OUT_FILE).get(new CellIndex(1,1)).doubleValue();
+		
+		Double double_out_scalar = TestUtils.readDMLScalarFromHDFS(output(OUT_FILE)).get(new CellIndex(1,1)).doubleValue();
 		Assert.assertEquals("Values not equal: " + double_scalar + "!=" + double_out_scalar, double_scalar, double_out_scalar);
 
 		// Invoke the DML script that does computations and then writes scalar to HDFS
 		fullDMLScriptName = HOME + "ScalarComputeWrite.dml";
 		runTest(true, false, null, -1);
-		double_out_scalar = TestUtils.readDMLScalarFromHDFS(OUT_FILE).get(new CellIndex(1,1)).doubleValue();
+		
+		double_out_scalar = TestUtils.readDMLScalarFromHDFS(output(OUT_FILE)).get(new CellIndex(1,1)).doubleValue();
 		Assert.assertEquals("Computation test for Integers failed: Values not equal: " + double_scalar + "!=" + double_out_scalar, double_scalar, double_out_scalar);
 	}
 
@@ -98,19 +88,12 @@ public class ScalarIOTest extends AutomatedTestBase
 	public void testBooleanScalarWrite() {
 
 		boolean boolean_scalar = true;
-		
-		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
-		loadTestConfiguration(config);
 
-		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + "ScalarWrite.dml";
-		programArgs = new String[]{	"-args", 
-									String.valueOf(boolean_scalar),
-									HOME + OUTPUT_DIR + "a.scalar"
-                				  };
+		programArgs = new String[]{	"-args", String.valueOf(boolean_scalar), output("a.scalar") };
 		runTest(true, false, null, -1);
 
-		boolean boolean_out_scalar = TestUtils.readDMLBoolean(OUT_FILE);
+		boolean boolean_out_scalar = TestUtils.readDMLBoolean(output(OUT_FILE));
 		
 		Assert.assertEquals("Values not equal: " + boolean_scalar + "!=" + boolean_out_scalar, boolean_scalar, boolean_out_scalar);
 	}
@@ -119,19 +102,12 @@ public class ScalarIOTest extends AutomatedTestBase
 	public void testStringScalarWrite() {
 
 		String string_scalar = "String Test.!";
-		
-		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
-		loadTestConfiguration(config);
 
-		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + "ScalarWrite.dml";
-		programArgs = new String[]{	"-args", 
-									String.valueOf(string_scalar),
-									HOME + OUTPUT_DIR + "a.scalar"
-                				  };
+		programArgs = new String[]{	"-args", String.valueOf(string_scalar), output("a.scalar") };
 		runTest(true, false, null, -1);
 
-		String string_out_scalar = TestUtils.readDMLString(OUT_FILE);
+		String string_out_scalar = TestUtils.readDMLString(output(OUT_FILE));
 		
 		Assert.assertEquals("Values not equal: " + string_scalar + "!=" + string_out_scalar, string_scalar, string_out_scalar);
 	}
@@ -141,29 +117,19 @@ public class ScalarIOTest extends AutomatedTestBase
 
 		int int_scalar = 464;
 		
-		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
-		loadTestConfiguration(config);
-
-		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + "ScalarWrite.dml";
-		programArgs = new String[]{	"-args", 
-									String.valueOf(int_scalar),
-									HOME + OUTPUT_DIR + "a.scalar"
-                				  };
+		programArgs = new String[]{	"-args", String.valueOf(int_scalar), output("a.scalar") };
 		runTest(true, false, null, -1);
-		//int int_out_scalar = TestUtils.readDMLScalarFromHDFS(OUT_FILE).get(new CellIndex(1,1)).intValue();
+		
+		//int int_out_scalar = TestUtils.readDMLScalarFromHDFS(output(OUT_FILE)).get(new CellIndex(1,1)).intValue();
 		//assertEquals("Values not equal: " + int_scalar + "!=" + int_out_scalar, int_scalar, int_out_scalar);
 		
 		// Invoke the DML script that reads the scalar and prints to stdout
 		fullDMLScriptName = HOME + "ScalarRead.dml";
-		programArgs = new String[] { "-args",
-									 HOME + OUTPUT_DIR + "a.scalar",
-									 "int"
-									};
+		programArgs = new String[] { "-args", output("a.scalar"), "int" };
 		
 		setExpectedStdOut(String.valueOf(int_scalar));
 		runTest(true, false, null, -1);
-		
 	}
 
 	@Test
@@ -171,29 +137,19 @@ public class ScalarIOTest extends AutomatedTestBase
 
 		double double_scalar = 464.5;
 		
-		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
-		loadTestConfiguration(config);
-
-		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + "ScalarWrite.dml";
-		programArgs = new String[]{	"-args", 
-									String.valueOf(double_scalar),
-									HOME + OUTPUT_DIR + "a.scalar"
-                				  };
+		programArgs = new String[]{	"-args", String.valueOf(double_scalar), output("a.scalar") };
 		runTest(true, false, null, -1);
-		//double double_out_scalar = TestUtils.readDMLScalarFromHDFS(OUT_FILE).get(new CellIndex(1,1)).doubleValue();
+		
+		//double double_out_scalar = TestUtils.readDMLScalarFromHDFS(output(OUT_FILE)).get(new CellIndex(1,1)).doubleValue();
 		//assertEquals("Values not equal: " + double_scalar + "!=" + double_out_scalar, double_scalar, double_out_scalar);
 		
 		// Invoke the DML script that reads the scalar and prints to stdout
 		fullDMLScriptName = HOME + "ScalarRead.dml";
-		programArgs = new String[] { "-args",
-									 HOME + OUTPUT_DIR + "a.scalar",
-									 "double"
-									};
+		programArgs = new String[] { "-args", output("a.scalar"), "double" };
 		
 		setExpectedStdOut(String.valueOf(double_scalar));
 		runTest(true, false, null, -1);
-		
 	}
 
 	@Test
@@ -201,24 +157,14 @@ public class ScalarIOTest extends AutomatedTestBase
 
 		boolean boolean_scalar = true;
 		
-		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
-		loadTestConfiguration(config);
-
-		// TODO Niketan: Separate these as individual tests
-		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + "ScalarWrite.dml";
 		programArgs = new String[]{	"-args", 
-									String.valueOf(boolean_scalar).toUpperCase(),
-									HOME + OUTPUT_DIR + "a.scalar"
-                				  };
+			String.valueOf(boolean_scalar).toUpperCase(), output("a.scalar") };
 		runTest(true, false, null, -1);
 
 		// Invoke the DML script that reads the scalar and prints to stdout
 		fullDMLScriptName = HOME + "ScalarRead.dml";
-		programArgs = new String[] { "-args",
-									 HOME + OUTPUT_DIR + "a.scalar",
-									 "boolean"
-									};
+		programArgs = new String[] { "-args", output("a.scalar"), "boolean" };
 		
 		setExpectedStdOut(String.valueOf(boolean_scalar).toUpperCase());
 		runTest(true, false, null, -1);
@@ -229,27 +175,16 @@ public class ScalarIOTest extends AutomatedTestBase
 
 		String string_scalar = "String Test.!";
 		
-		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
-		loadTestConfiguration(config);
-
-		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + "ScalarWrite.dml";
-		programArgs = new String[]{	"-args", 
-									String.valueOf(string_scalar),
-									HOME + OUTPUT_DIR + "a.scalar"
-                				  };
+		programArgs = new String[]{	"-args", String.valueOf(string_scalar), output("a.scalar") };
 		runTest(true, false, null, -1);
 
 		// Invoke the DML script that reads the scalar and prints to stdout
 		fullDMLScriptName = HOME + "ScalarRead.dml";
-		programArgs = new String[] { "-args",
-									 HOME + OUTPUT_DIR + "a.scalar",
-									 "string"
-									};
+		programArgs = new String[] { "-args", output("a.scalar"), "string" };
 		
 		setExpectedStdOut(String.valueOf(string_scalar));
 		runTest(true, false, null, -1);
 	}
 	
-
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/SeqParReadTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/SeqParReadTest.java
@@ -38,10 +38,10 @@ import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.test.utils.TestUtils;
 
 public class SeqParReadTest extends AutomatedTestBase {
-
 	
 	private final static String TEST_NAME = "SeqParReadTest";
 	private final static String TEST_DIR = "functions/io/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + SeqParReadTest.class.getSimpleName() + "/";
 	
 	private final static int rowsA = 2000;
 	private final static int colsA = 1000;
@@ -73,10 +73,8 @@ public class SeqParReadTest extends AutomatedTestBase {
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   ); 
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) ); 
 	}
 	
 	@Test
@@ -221,26 +219,25 @@ public class SeqParReadTest extends AutomatedTestBase {
 			OptimizerUtils.PARALLEL_CP_READ_TEXTFORMATS = parallel;
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			
 			loadTestConfiguration(config);
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			
 			//generate actual dataset
 			double[][] A = getRandomMatrix(rowsA, big?colsA:colsB, 0, 1, dense?sparsity2:sparsity1, 7); 
-			writeMatrix(A, HOME + INPUT_DIR + "AX", fmt, rowsA, big?colsA:colsB, 1000, 1000, rowsA*(big?colsA:colsB));
+			writeMatrix(A, input("AX"), fmt, rowsA, big?colsA:colsB, 1000, 1000, rowsA*(big?colsA:colsB));
 			
 			//always write in MM format for R
-			writeMatrix(A, HOME + INPUT_DIR + "BX", OutputInfo.MatrixMarketOutputInfo, rowsA, big?colsA:colsB, 1000, 1000, rowsA*(big?colsA:colsB));
+			writeMatrix(A, input("BX"), OutputInfo.MatrixMarketOutputInfo, rowsA, big?colsA:colsB, 1000, 1000, rowsA*(big?colsA:colsB));
 			
-			String dmlOutput = HOME + OUTPUT_DIR + "dml.scalar";
-			String rOutput = HOME + OUTPUT_DIR + "R.scalar";
+			String dmlOutput = output("dml.scalar");
+			String rOutput = output("R.scalar");
 			
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-args", HOME + INPUT_DIR + "AX", dmlOutput};
+			programArgs = new String[]{"-args", input("AX"), dmlOutput};
 			
 			fullRScriptName = HOME + "matrixmarket/mm_verify.R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + HOME + INPUT_DIR + "BX " + rOutput;
+			rCmd = "Rscript" + " " + fullRScriptName + " " + input("BX") + " " + rOutput;
 			
 			runTest(true, false, null, -1);
 			runRScript(true);

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/binary/SerializeTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/binary/SerializeTest.java
@@ -38,6 +38,7 @@ public class SerializeTest extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "SerializeTest";
 	private final static String TEST_DIR = "functions/io/binary/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + SerializeTest.class.getSimpleName() + "/";
 	
 	public static int rows1 = 746;
 	public static int cols1 = 586;
@@ -49,7 +50,7 @@ public class SerializeTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_DIR, TEST_NAME, new String[] { "X" })   );  
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "X" }) );  
 	}
 	
 	@Test
@@ -93,26 +94,24 @@ public class SerializeTest extends AutomatedTestBase
 		try
 		{	
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config);
 			
 			// This is for running the junit test the new way, i.e., construct the arguments directly
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-args", HOME + INPUT_DIR + "X",
-											    HOME + OUTPUT_DIR + "X"    };
-			
-			loadTestConfiguration(config);
+			programArgs = new String[]{"-args", input("X"), output("X") };
 	
 			//generate actual dataset 
 			double[][] X = getRandomMatrix(rows, cols, -1.0, 1.0, sparsity, 7); 
 			MatrixBlock mb = DataConverter.convertToMatrixBlock(X);
 			MatrixCharacteristics mc = new MatrixCharacteristics(rows, cols, 1000, 1000);
-			DataConverter.writeMatrixToHDFS(mb, HOME + INPUT_DIR + "X", OutputInfo.BinaryBlockOutputInfo, mc);
-			MapReduceTool.writeMetaDataFile(HOME + INPUT_DIR + "X.mtd", ValueType.DOUBLE, mc, OutputInfo.BinaryBlockOutputInfo);
+			DataConverter.writeMatrixToHDFS(mb, input("X"), OutputInfo.BinaryBlockOutputInfo, mc);
+			MapReduceTool.writeMetaDataFile(input("X.mtd"), ValueType.DOUBLE, mc, OutputInfo.BinaryBlockOutputInfo);
 			
 			runTest(true, false, null, -1); //mult 7
 			
 			//compare matrices 
-			MatrixBlock mb2 = DataConverter.readMatrixFromHDFS(HOME + OUTPUT_DIR + "X", InputInfo.BinaryBlockInputInfo, rows, cols, 1000, 1000);
+			MatrixBlock mb2 = DataConverter.readMatrixFromHDFS(output("X"), InputInfo.BinaryBlockInputInfo, rows, cols, 1000, 1000);
 			for( int i=0; i<mb.getNumRows(); i++ )
 				for( int j=0; j<mb.getNumColumns(); j++ )
 				{

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/csv/CSVParametersTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/csv/CSVParametersTest.java
@@ -39,6 +39,7 @@ public class CSVParametersTest extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "csvprop_test";
 	private final static String TEST_DIR = "functions/io/csv/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + CSVParametersTest.class.getSimpleName() + "/";
 	
 	private final static int rows = 1200;
 	private final static int cols = 100;
@@ -54,10 +55,8 @@ public class CSVParametersTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   );  
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) );
 	}
 	
 	public CSVParametersTest(boolean header, String delim, boolean sparse) {
@@ -180,10 +179,10 @@ public class CSVParametersTest extends AutomatedTestBase
 		D = null;
 
 		String HOME = SCRIPT_DIR + TEST_DIR;
-		String txtFile = HOME + INPUT_DIR + "D";
-		//String binFile = HOME + INPUT_DIR + "D.binary";
-		String csvFile  = HOME + OUTPUT_DIR + "D.csv";
-		String scalarFile = HOME + OUTPUT_DIR + "diff.scalar";
+		String txtFile = input("D");
+		//String binFile = input("D.binary");
+		String csvFile  = output("D.csv");
+		String scalarFile = output("diff.scalar");
 		
 		String writeDML = HOME + "csvprop_write.dml";
 		String[] writeArgs = new String[]{"-args", 

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/csv/FormatChangeTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/csv/FormatChangeTest.java
@@ -37,10 +37,10 @@ import org.apache.sysml.test.utils.TestUtils;
 @RunWith(value = Parameterized.class)
 public class FormatChangeTest extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_NAME = "csv_test";
 	private final static String TEST_DIR = "functions/io/csv/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + FormatChangeTest.class.getSimpleName() + "/";
 	
 	//private final static int rows = 1200;
 	//private final static int cols = 100;
@@ -73,10 +73,8 @@ public class FormatChangeTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   );  
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) );
 	}
 	
 	public FormatChangeTest(int r, int c, double sp) {
@@ -86,11 +84,11 @@ public class FormatChangeTest extends AutomatedTestBase
 	}
 
 	@Parameters
-	 public static Collection<Object[]> data() {
-	   Object[][] data = new Object[][] { { 2000, 500, 0.01 }, { 1500, 150, 1 } };
-	   return Arrays.asList(data);
-	 }
-	 
+	public static Collection<Object[]> data() {
+		Object[][] data = new Object[][] { { 2000, 500, 0.01 }, { 1500, 150, 1 } };
+		return Arrays.asList(data);
+	}
+	
 	private void setup() {
 		
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
@@ -144,15 +142,11 @@ public class FormatChangeTest extends AutomatedTestBase
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
 		String[] oldProgramArgs = programArgs = new String[]{"-args", 
-											HOME + INPUT_DIR + "D",
-                							format1,
-                							HOME + INPUT_DIR + "D.binary",
-                							format2
-                							};
+			input("D"), format1, input("D.binary"), format2 };
 		
-		String txtFile = HOME + INPUT_DIR + "D";
-		String binFile = HOME + INPUT_DIR + "D.binary";
-		String csvFile  = HOME + OUTPUT_DIR + "D.csv";
+		String txtFile = input("D");
+		String binFile = input("D.binary");
+		String csvFile  = output("D.csv");
 		
 		// text to binary format
 		programArgs[2] = "text";
@@ -202,7 +196,6 @@ public class FormatChangeTest extends AutomatedTestBase
 		
 		compareFiles(rows, cols, sparsity, binFile, "binary", csvFile);
 
-		
 		//fullRScriptName = HOME + TEST_NAME + ".R";
 		//rCmd = "Rscript" + " " + fullRScriptName + " " + 
 		//      HOME + INPUT_DIR + " " + Integer.toString((int)maxVal) + " " + HOME + EXPECTED_DIR;
@@ -216,16 +209,12 @@ public class FormatChangeTest extends AutomatedTestBase
 		String oldDMLScript = fullDMLScriptName;
 		String oldRScript = fullRScriptName;
 		
-		String dmlOutput = HOME + OUTPUT_DIR + "dml.scalar";
-		String rOutput = HOME + OUTPUT_DIR + "R.scalar";
+		String dmlOutput = output("dml.scalar");
+		String rOutput = output("R.scalar");
 		
 		fullDMLScriptName = HOME + "csv_verify.dml";
 		programArgs = new String[]{"-args", dmlFile,
-                							Integer.toString(rows),
-                							Integer.toString(cols),
-                							dmlFormat,
-                							dmlOutput
-                							};
+			Integer.toString(rows), Integer.toString(cols), dmlFormat, dmlOutput };
 		
 		// Check if input csvFile is a directory
 		try {
@@ -235,8 +224,7 @@ public class FormatChangeTest extends AutomatedTestBase
 		}
 		
 		fullRScriptName = HOME + "csv_verify.R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       csvFile + " " + rOutput;
+		rCmd = "Rscript" + " " + fullRScriptName + " " + csvFile + " " + rOutput;
 		
 		// Run the verify test
 		runTest(true, false, null, -1);	

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/csv/ReadCSVTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/csv/ReadCSVTest.java
@@ -41,6 +41,7 @@ public class ReadCSVTest extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "ReadCSVTest";
 	private final static String TEST_DIR = "functions/io/csv/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ReadCSVTest.class.getSimpleName() + "/";
 	
 	private final static double eps = 1e-9;
 
@@ -48,10 +49,8 @@ public class ReadCSVTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   );  
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) );  
 	}
 	
 	@Test
@@ -152,8 +151,8 @@ public class ReadCSVTest extends AutomatedTestBase
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			String inputMatrixName = HOME + INPUT_DIR + "transfusion_" + testNumber + ".data";
-			String dmlOutput = HOME + OUTPUT_DIR + "dml.scalar";
-			String rOutput = HOME + OUTPUT_DIR + "R.scalar";
+			String dmlOutput = output("dml.scalar");
+			String rOutput = output("R.scalar");
 			
 			fullDMLScriptName = HOME + TEST_NAME + "_" + testNumber + ".dml";
 			programArgs = new String[]{"-args", inputMatrixName, dmlOutput};

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/csv/WriteCSVTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/csv/WriteCSVTest.java
@@ -39,20 +39,18 @@ import org.apache.sysml.test.utils.TestUtils;
 
 public class WriteCSVTest extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_NAME = "WriteCSVTest";
 	private final static String TEST_DIR = "functions/io/csv/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + WriteCSVTest.class.getSimpleName() + "/";
 	
 	private final static double eps = 1e-9;
 
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   );  
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) );  
 	}
 	
 	@Test
@@ -101,19 +99,17 @@ public class WriteCSVTest extends AutomatedTestBase
 		rtplatform = platform;
 		
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
-		
 		loadTestConfiguration(config);
 		
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		String inputMatrixName = HOME + INPUT_DIR + "transfusion_1"; // always read the same data, independent of testNumber
-		String dmlOutput = HOME + OUTPUT_DIR + "dml.scalar";
-		String csvOutputName = HOME + OUTPUT_DIR + "transfusion_dml.data";
-		String rOutput = HOME + OUTPUT_DIR + "R.scalar";
+		String dmlOutput = output("dml.scalar");
+		String csvOutputName = output("transfusion_dml.data");
+		String rOutput = output("R.scalar");
 		
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[]{"-explain" ,
-				"-args", inputMatrixName, dmlOutput, csvOutputName, 
-				Boolean.toString(header), sep, Boolean.toString(sparse) };
+		programArgs = new String[]{"-explain", "-args", inputMatrixName, dmlOutput, csvOutputName,
+			Boolean.toString(header), sep, Boolean.toString(sparse) };
 		
 		runTest(true, false, null, -1);
 

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/matrixmarket/FormatChangeTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/matrixmarket/FormatChangeTest.java
@@ -28,10 +28,10 @@ import org.apache.sysml.test.utils.TestUtils;
 
 public class FormatChangeTest extends AutomatedTestBase 
 {
-
 	
 	private final static String TEST_NAME = "mm_test";
 	private final static String TEST_DIR = "functions/io/matrixmarket/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + FormatChangeTest.class.getSimpleName() + "/";
 	
 	private final static int rows = 2000;
 	private final static int cols = 500;
@@ -42,10 +42,8 @@ public class FormatChangeTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   );  
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) );  
 	}
 	
 	@Test
@@ -69,15 +67,11 @@ public class FormatChangeTest extends AutomatedTestBase
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME +scriptNum + ".dml";
 		String[] oldProgramArgs = programArgs = new String[]{"-args", 
-											HOME + INPUT_DIR + "D",
-                							format1,
-                							HOME + INPUT_DIR + "D.binary",
-                							format2
-                							};
+			input("D"), format1, input("D.binary"), format2 };
 		
-		String txtFile = HOME + INPUT_DIR + "D";
-		String binFile = HOME + INPUT_DIR + "D.binary";
-		String mmFile  = HOME + OUTPUT_DIR + "D.mm";
+		String txtFile = input("D");
+		String binFile = input("D.binary");
+		String mmFile  = output("D.mm");
 		
 		// text to binary format
 		programArgs[2] = "text";
@@ -122,13 +116,10 @@ public class FormatChangeTest extends AutomatedTestBase
 		runTest(true, false, null, -1);
 		
 		verifyDMLandMMFiles(rows, cols, sparsity, binFile, "binary", mmFile);
-
 		
 		//fullRScriptName = HOME + TEST_NAME + ".R";
 		//rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		//      HOME + INPUT_DIR + " " + Integer.toString((int)maxVal) + " " + HOME + EXPECTED_DIR;
-		
-
+		//        inputDir() + " " + Integer.toString((int)maxVal) + " " + expectedDir();
 	}
 	
 	private void verifyDMLandMMFiles(int rows, int cols, double sparsity, String dmlFile, String dmlFormat, String mmFile) {
@@ -138,20 +129,15 @@ public class FormatChangeTest extends AutomatedTestBase
 		String oldDMLScript = fullDMLScriptName;
 		String oldRScript = fullRScriptName;
 		
-		String dmlOutput = HOME + OUTPUT_DIR + "dml.scalar";
-		String rOutput = HOME + OUTPUT_DIR + "R.scalar";
+		String dmlOutput = output("dml.scalar");
+		String rOutput = output("R.scalar");
 		
 		fullDMLScriptName = HOME + "mm_verify.dml";
 		programArgs = new String[]{"-args", dmlFile,
-                							Integer.toString(rows),
-                							Integer.toString(cols),
-                							dmlFormat,
-                							dmlOutput
-                							};
+			Integer.toString(rows), Integer.toString(cols), dmlFormat, dmlOutput };
 		
 		fullRScriptName = HOME + "mm_verify.R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       mmFile + " " + rOutput;
+		rCmd = "Rscript" + " " + fullRScriptName + " " + mmFile + " " + rOutput;
 		
 		// Run the verify test
 		runTest(true, false, null, -1);

--- a/src/test/java/org/apache/sysml/test/integration/functions/io/matrixmarket/ReadMMTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/io/matrixmarket/ReadMMTest.java
@@ -32,16 +32,15 @@ public class ReadMMTest extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "ReadMMTest";
 	private final static String TEST_DIR = "functions/io/matrixmarket/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ReadMMTest.class.getSimpleName() + "/";
 	
 	private final static double eps = 1e-9;
 
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "Rout" })   );  
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "Rout" }) );
 	}
 	
 	@Test
@@ -100,13 +99,12 @@ public class ReadMMTest extends AutomatedTestBase
 			OptimizerUtils.PARALLEL_CP_READ_TEXTFORMATS = parallel;
 			
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			
 			loadTestConfiguration(config);
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			String inputMatrixName = HOME + INPUT_DIR + "ReadMMTest.mtx";
-			String dmlOutput = HOME + OUTPUT_DIR + "dml.scalar";
-			String rOutput = HOME + OUTPUT_DIR + "R.scalar";
+			String dmlOutput = output("dml.scalar");
+			String rOutput = output("R.scalar");
 			
 			fullDMLScriptName = HOME + TEST_NAME + "_1.dml";
 			programArgs = new String[]{"-args", inputMatrixName, dmlOutput};

--- a/src/test/java/org/apache/sysml/test/integration/functions/jmlc/SystemTMulticlassSVMScoreTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/jmlc/SystemTMulticlassSVMScoreTest.java
@@ -49,6 +49,7 @@ public class SystemTMulticlassSVMScoreTest extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/jmlc/";
 	private final static String MODEL_FILE = "sentiment_model.mtx";
 	private final static double eps = 1e-10;
+	private final static String TEST_CLASS_DIR = TEST_DIR + SystemTMulticlassSVMScoreTest.class.getSimpleName() + "/";
 	
 	private final static int rows = 107;
 	private final static int cols = 46; //fixed
@@ -62,7 +63,7 @@ public class SystemTMulticlassSVMScoreTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_DIR, TEST_NAME, new String[] { "predicted_y" })   ); 
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "predicted_y" }) ); 
 	}
 
 	
@@ -94,6 +95,7 @@ public class SystemTMulticlassSVMScoreTest extends AutomatedTestBase
 		throws IOException
 	{	
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
+		loadTestConfiguration(config);
 	
 		//generate inputs
 		ArrayList<double[][]> Xset = generateInputs(nRuns, rows, cols, sparse?sparsity2:sparsity1); 
@@ -104,10 +106,7 @@ public class SystemTMulticlassSVMScoreTest extends AutomatedTestBase
 		//run R and compare results to DML result
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullRScriptName = HOME + TEST_NAME + ".R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       HOME + INPUT_DIR + " " + HOME + EXPECTED_DIR;
-		
-		loadTestConfiguration(config);
+		rCmd = getRCmd(inputDir(), expectedDir());
 
 		//write model data once
 		MatrixBlock mb = DataConverter.readMatrixFromHDFS(SCRIPT_DIR + TEST_DIR + MODEL_FILE, 
@@ -151,7 +150,7 @@ public class SystemTMulticlassSVMScoreTest extends AutomatedTestBase
 				
 		try
 		{
-			// Note for Matthias: For now, JMLC pipeline only allows dml
+			// For now, JMLC pipeline only allows dml
 			boolean parsePyDML = false;
 			
 			//read and precompile script

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/ConditionalValidateTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/ConditionalValidateTest.java
@@ -39,6 +39,7 @@ public class ConditionalValidateTest extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/misc/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ConditionalValidateTest.class.getSimpleName() + "/";
 
 	private final static String TEST_NAME1 = "conditionalValidate1"; //plain
 	private final static String TEST_NAME2 = "conditionalValidate2"; //if
@@ -49,10 +50,10 @@ public class ConditionalValidateTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_DIR, TEST_NAME3, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_DIR, TEST_NAME4, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[] {"R"}));
 	}
 	
 	@Test
@@ -104,8 +105,6 @@ public class ConditionalValidateTest extends AutomatedTestBase
 	}
 	
 	
-	
-	
 	/**
 	 * 
 	 * @param cfc
@@ -118,14 +117,13 @@ public class ConditionalValidateTest extends AutomatedTestBase
 		try
 		{		
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config);
 
 		    String HOME = SCRIPT_DIR + TEST_DIR;
-		    String input = HOME + INPUT_DIR + "Y";
+		    String input = input("Y");
 			
 		    fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{"-args", input };
-			
-			loadTestConfiguration(config);
 			
 			//write input
 			double[][] Y = getRandomMatrix(10, 15, 0, 1, 1.0, 7);

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/DataTypeCastingTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/DataTypeCastingTest.java
@@ -38,16 +38,16 @@ public class DataTypeCastingTest extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/misc/";
-
+	private final static String TEST_CLASS_DIR = TEST_DIR + DataTypeCastingTest.class.getSimpleName() + "/";
+	
 	private final static String TEST_NAME1 = "castMatrixScalar";
 	private final static String TEST_NAME2 = "castScalarMatrix";
 	
 	
-	
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {"R"}));
 	}
 	
 	@Test
@@ -93,16 +93,14 @@ public class DataTypeCastingTest extends AutomatedTestBase
 		
 		try
 		{		
-			TestConfiguration config = getTestConfiguration(TEST_NAME);
-		    
+			TestConfiguration config = getTestConfiguration(TEST_NAME);	
+			loadTestConfiguration(config);
+   
 		    String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-args", HOME + INPUT_DIR + "V" , 
-								                Integer.toString(numVals),
-								                Integer.toString(numVals),
-								                HOME + OUTPUT_DIR + "R", };
-			
-			loadTestConfiguration(config);
+			programArgs = new String[]{"-args", input("V"), 
+				Integer.toString(numVals), Integer.toString(numVals),
+				output("R") };
 			
 			//write input
 			double[][] V = getRandomMatrix(numVals, numVals, 0, 1, 1.0, 7);
@@ -110,10 +108,9 @@ public class DataTypeCastingTest extends AutomatedTestBase
 				writeInputMatrix("V", V, false);	
 			}
 			else{
-				MapReduceTool.writeDoubleToHDFS(V[0][0], HOME + INPUT_DIR + "V");
-				MapReduceTool.writeScalarMetaDataFile(HOME + INPUT_DIR + "V.mtd", ValueType.DOUBLE);
+				MapReduceTool.writeDoubleToHDFS(V[0][0], input("V"));
+				MapReduceTool.writeScalarMetaDataFile(input("V.mtd"), ValueType.DOUBLE);
 			}
-			
 			
 			//run tests
 	        runTest(true, exceptionExpected, DMLException.class, -1);

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/DataTypeChangeTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/DataTypeChangeTest.java
@@ -58,7 +58,7 @@ public class DataTypeChangeTest extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/misc/";
-
+	private final static String TEST_CLASS_DIR = TEST_DIR + DataTypeChangeTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
@@ -178,8 +178,8 @@ public class DataTypeChangeTest extends AutomatedTestBase
 		{
 			// Tell the superclass about the name of this test, so that the superclass can
 			// create temporary directories.
-			TestConfiguration testConfig = new TestConfiguration(TEST_DIR, fullTestName, 
-						new String[] {});
+			TestConfiguration testConfig = new TestConfiguration(TEST_CLASS_DIR, fullTestName,
+				new String[] {});
 			addTestConfiguration(fullTestName, testConfig);
 			loadTestConfiguration(testConfig);
 			

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionInliningTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionInliningTest.java
@@ -35,6 +35,7 @@ public class FunctionInliningTest extends AutomatedTestBase
 	private final static String TEST_NAME1 = "function_chain_inlining";
 	private final static String TEST_NAME2 = "function_chain_non_inlining";
 	private final static String TEST_NAME3 = "function_recursive_inlining";
+	private final static String TEST_CLASS_DIR = TEST_DIR + FunctionInliningTest.class.getSimpleName() + "/";
 	
 	private final static long rows = 3400;
 	private final static long cols = 2700;
@@ -43,10 +44,9 @@ public class FunctionInliningTest extends AutomatedTestBase
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration( TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "Rout" })   );
-		addTestConfiguration( TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] { "Rout" })   );
-		addTestConfiguration( TEST_NAME3, new TestConfiguration(TEST_DIR, TEST_NAME3, new String[] { "Rout" })   );
-		
+		addTestConfiguration( TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "Rout" }) );
+		addTestConfiguration( TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "Rout" }) );
+		addTestConfiguration( TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] { "Rout" }) );
 	}
 
 	@Test
@@ -97,14 +97,12 @@ public class FunctionInliningTest extends AutomatedTestBase
 		try
 		{
 			TestConfiguration config = getTestConfiguration(testname);
+			loadTestConfiguration(config);
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
 			programArgs = new String[]{/*"-explain",*/"-args",String.valueOf(rows),
-					                           String.valueOf(cols),
-					                           String.valueOf(val),
-					                           HOME + OUTPUT_DIR + "Rout" };
-			loadTestConfiguration(config);
+				String.valueOf(cols), String.valueOf(val), output("Rout") };
 
 			OptimizerUtils.ALLOW_INTER_PROCEDURAL_ANALYSIS = IPA;
 			
@@ -112,9 +110,8 @@ public class FunctionInliningTest extends AutomatedTestBase
 			runTest(true, false, null, -1); 
 			
 			//compare output
-			double ret = MapReduceTool.readDoubleFromHDFSFile(HOME + OUTPUT_DIR + "Rout");
+			double ret = MapReduceTool.readDoubleFromHDFSFile(output("Rout"));
 			Assert.assertEquals(Double.valueOf(rows*cols*val*6), Double.valueOf(ret));
-			
 			
 			//compiled MR jobs
 			int expectNumCompiled = IPA ? 0 : (testname.equals(TEST_NAME1)?2: //2GMR in foo1 and foo2 (not removed w/o IPA)

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/IPALiteralReplacementTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/IPALiteralReplacementTest.java
@@ -39,13 +39,14 @@ public class IPALiteralReplacementTest extends AutomatedTestBase
 	private final static String TEST_NAME1 = "IPALiteralReplacement_While";
 	private final static String TEST_NAME2 = "IPALiteralReplacement_ForIf";
 	private final static String TEST_DIR = "functions/misc/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + IPALiteralReplacementTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration( TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "R" })   );
-		addTestConfiguration( TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] { "R" })   );
+		addTestConfiguration( TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "R" })   );
+		addTestConfiguration( TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "R" })   );
 	}
 
 	@Test
@@ -85,13 +86,13 @@ public class IPALiteralReplacementTest extends AutomatedTestBase
 		try
 		{
 			TestConfiguration config = getTestConfiguration(testname);
+			loadTestConfiguration(config);
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
-			programArgs = new String[]{"-args",HOME + OUTPUT_DIR + "R" };
+			programArgs = new String[]{"-args", output("R") };
 			fullRScriptName = HOME + testname + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + HOME + EXPECTED_DIR;			
-			loadTestConfiguration(config);
+			rCmd = "Rscript" + " " + fullRScriptName + " " + expectedDir();			
 
 			OptimizerUtils.ALLOW_INTER_PROCEDURAL_ANALYSIS = IPA;
 

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/IPAScalarRecursionTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/IPAScalarRecursionTest.java
@@ -33,11 +33,11 @@ public class IPAScalarRecursionTest extends AutomatedTestBase
 	
 	private final static String TEST_DIR = "functions/misc/";
 	private final static String TEST_NAME1 = "IPAScalarRecursion";
-	
+	private final static String TEST_CLASS_DIR = TEST_DIR + IPAScalarRecursionTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {}));
 	}
 	
 	@Test
@@ -47,13 +47,11 @@ public class IPAScalarRecursionTest extends AutomatedTestBase
 		
 		try
 		{		
-			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			getAndLoadTestConfiguration(TEST_NAME);
 		    
 		    String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{"-args", Integer.toString(7) };
-			
-			loadTestConfiguration(config);
 			
 			//run tests
 	        runTest(true, false, null, 0);

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/IPAUnknownRecursionTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/IPAUnknownRecursionTest.java
@@ -34,13 +34,14 @@ public class IPAUnknownRecursionTest extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "IPAUnknownRecursion";
 	private final static String TEST_DIR = "functions/misc/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + IPAUnknownRecursionTest.class.getSimpleName() + "/";
 	
 	private final static int val = 7;
 	
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration( TEST_NAME, new TestConfiguration(TEST_DIR, TEST_NAME, new String[] { "R" })   );
+		addTestConfiguration( TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "R" }) );
 	}
 
 	@Test
@@ -68,15 +69,14 @@ public class IPAUnknownRecursionTest extends AutomatedTestBase
 		try
 		{
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config);
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-args",Integer.toString(val),
-					                           HOME + OUTPUT_DIR + "R" };
+			programArgs = new String[]{"-args", Integer.toString(val), output("R") };
+			
 			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + 
-			             val + " " + HOME + EXPECTED_DIR;			
-			loadTestConfiguration(config);
+			rCmd = getRCmd(Integer.toString(val), expectedDir());			
 
 			OptimizerUtils.ALLOW_INTER_PROCEDURAL_ANALYSIS = IPA;
 

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/InvalidFunctionSignatureTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/InvalidFunctionSignatureTest.java
@@ -33,11 +33,12 @@ public class InvalidFunctionSignatureTest extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/misc/";
 	private final static String TEST_NAME1 = "InvalidFunctionSignatureTest1";
 	private final static String TEST_NAME2 = "InvalidFunctionSignatureTest2";
+	private final static String TEST_CLASS_DIR = TEST_DIR + InvalidFunctionSignatureTest.class.getSimpleName() + "/";
     
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {}));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] {}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {}));
 	}
 	
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/LongOverflowTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/LongOverflowTest.java
@@ -33,6 +33,7 @@ public class LongOverflowTest extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/misc/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + LongOverflowTest.class.getSimpleName() + "/";
 
 	private final static String TEST_NAME1 = "LongOverflowMult";
 	private final static String TEST_NAME2 = "LongOverflowPlus";
@@ -49,9 +50,9 @@ public class LongOverflowTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {}));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] {}));
-		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_DIR, TEST_NAME3, new String[] {}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] {}));
 	}
 	
 	@Test
@@ -85,7 +86,6 @@ public class LongOverflowTest extends AutomatedTestBase
 	}
 	
 	
-	
 	/**
 	 * 
 	 * @param cfc
@@ -97,7 +97,7 @@ public class LongOverflowTest extends AutomatedTestBase
 		
 		try
 		{		
-			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			getAndLoadTestConfiguration(TEST_NAME);
 		    
 			//generate input data;
 			long input1 = (TEST_NAME.equals(TEST_NAME3)? val5 : val1);
@@ -105,10 +105,7 @@ public class LongOverflowTest extends AutomatedTestBase
 			
 		    String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-args", Long.toString(input1), 
-								                Long.toString(input2) };
-			
-			loadTestConfiguration(config);
+			programArgs = new String[]{"-args", Long.toString(input1), Long.toString(input2) };
 			
 			//run tests
 	        runTest(true, error, DMLException.class, -1);

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/NrowNcolStringTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/NrowNcolStringTest.java
@@ -31,6 +31,7 @@ public class NrowNcolStringTest extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/misc/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + NrowNcolStringTest.class.getSimpleName() + "/";
 
 	private final static String TEST_NAME1 = "NrowStringTest";
 	private final static String TEST_NAME2 = "NcolStringTest";
@@ -38,9 +39,9 @@ public class NrowNcolStringTest extends AutomatedTestBase
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {}));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] {}));
-		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_DIR, TEST_NAME3, new String[] {}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] {}));
 	}
 	
 	@Test
@@ -74,11 +75,10 @@ public class NrowNcolStringTest extends AutomatedTestBase
 		try
 		{	
 			//test configuration
-			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			getAndLoadTestConfiguration(TEST_NAME);
 		    String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{"-args", "100", "10"};
-			loadTestConfiguration(config);
 			
 			//run tests
 	        runTest(true, false, null, -1);

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/NrowNcolUnknownCSVReadTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/NrowNcolUnknownCSVReadTest.java
@@ -40,6 +40,7 @@ public class NrowNcolUnknownCSVReadTest extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/misc/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + NrowNcolUnknownCSVReadTest.class.getSimpleName() + "/";
 
 	private final static String TEST_NAME1 = "NrowUnknownCSVTest";
 	private final static String TEST_NAME2 = "NcolUnknownCSVTest";
@@ -48,9 +49,9 @@ public class NrowNcolUnknownCSVReadTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {}));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] {}));
-		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_DIR, TEST_NAME3, new String[] {}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] {}));
 	}
 	
 	@Test
@@ -87,21 +88,19 @@ public class NrowNcolUnknownCSVReadTest extends AutomatedTestBase
 			rtplatform = RUNTIME_PLATFORM.SINGLE_NODE;
 			
 			//test configuration
-			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			getAndLoadTestConfiguration(TEST_NAME);
 		    String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-args", HOME + INPUT_DIR + "A"};
-			
-			loadTestConfiguration(config);
+			programArgs = new String[]{"-args", input("A")};
 			
 			//generate input data w/o mtd file (delete any mtd file from previous runs)
 			int rows = 1034;
 			int cols = 73;
 			double[][] A = getRandomMatrix(rows, cols, 0, 1, 1.0, 7);
 			MatrixBlock mb = DataConverter.convertToMatrixBlock(A);
-			DataConverter.writeMatrixToHDFS(mb, HOME + INPUT_DIR + "A", OutputInfo.CSVOutputInfo, 
-					                        new MatrixCharacteristics(rows,cols,-1,-1));
-	        MapReduceTool.deleteFileIfExistOnHDFS(HOME + INPUT_DIR + "A.mtd");
+			DataConverter.writeMatrixToHDFS(mb, input("A"), OutputInfo.CSVOutputInfo, 
+				new MatrixCharacteristics(rows,cols,-1,-1));
+	        MapReduceTool.deleteFileIfExistOnHDFS(input("A.mtd"));
 			
 			//run tests
 	        runTest(true, false, null, -1);

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/OuterTableExpandTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/OuterTableExpandTest.java
@@ -42,6 +42,7 @@ public class OuterTableExpandTest extends AutomatedTestBase
 	private final static String TEST_NAME2 = "TableExpandTest";
 	
 	private final static String TEST_DIR = "functions/misc/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + OuterTableExpandTest.class.getSimpleName() + "/";
 	private final static double eps = 1e-8;
 	
 	private final static int rows = 5191;
@@ -54,8 +55,8 @@ public class OuterTableExpandTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "C" })); 
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] { "C" })); 
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "C" })); 
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "C" })); 
 	}
 	
 	// outer tests ----------------
@@ -223,19 +224,16 @@ public class OuterTableExpandTest extends AutomatedTestBase
 		{
 			String TEST_NAME = testname;
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config);
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;			
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{"-explain","-args", 
-					                            HOME + INPUT_DIR + "A",
-					                            String.valueOf(cols2),
-					                            String.valueOf(left).toUpperCase(),
-					                            HOME + OUTPUT_DIR + "C"};
-			fullRScriptName = HOME + TEST_NAME +".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + 
-			       HOME + INPUT_DIR + " " + cols2 + " " + String.valueOf(left).toUpperCase() + " " + HOME + EXPECTED_DIR;
+				input("A"), String.valueOf(cols2), String.valueOf(left).toUpperCase(), output("C")};
 			
-			loadTestConfiguration(config);
+			fullRScriptName = HOME + TEST_NAME +".R";
+			rCmd = getRCmd(inputDir(), Integer.toString(cols2),
+				String.valueOf(left).toUpperCase(), expectedDir());
 	
 			//generate actual datasets
 			double sparsity = sparse?sparsity2:sparsity1;

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/PrintExpressionTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/PrintExpressionTest.java
@@ -34,13 +34,14 @@ public class PrintExpressionTest extends AutomatedTestBase
 	private final static String TEST_NAME1 = "PrintExpressionTest1";
 	private final static String TEST_NAME2 = "PrintExpressionTest2";
 	private final static String TEST_DIR = "functions/misc/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + PrintExpressionTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "R" })); 
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] { "R" })); 
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "R" })); 
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "R" })); 
 	}
 		
 	@Test
@@ -72,6 +73,7 @@ public class PrintExpressionTest extends AutomatedTestBase
 	{
 		String TEST_NAME = testname;
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
+		loadTestConfiguration(config);
 		
 		//set rewrite configuration
 		boolean oldRewriteFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
@@ -81,11 +83,10 @@ public class PrintExpressionTest extends AutomatedTestBase
 		{
 			String HOME = SCRIPT_DIR + TEST_DIR;			
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-args", HOME + OUTPUT_DIR + "R"};
-			fullRScriptName = HOME + TEST_NAME +".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + HOME + EXPECTED_DIR;
+			programArgs = new String[]{"-args", output("R")};
 			
-			loadTestConfiguration(config);
+			fullRScriptName = HOME + TEST_NAME +".R";
+			rCmd = getRCmd(expectedDir());
 	
 			//run Tests
 			runTest(true, false, null, -1);

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/PrintMatrixTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/PrintMatrixTest.java
@@ -32,10 +32,11 @@ public class PrintMatrixTest extends AutomatedTestBase
 {	
 	private final static String TEST_DIR = "functions/misc/";
 	private final static String TEST_NAME1 = "PrintMatrixTest";
+	private final static String TEST_CLASS_DIR = TEST_DIR + PrintMatrixTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {}));
 	}
 	
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/ReadAfterWriteTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/ReadAfterWriteTest.java
@@ -35,6 +35,7 @@ public class ReadAfterWriteTest extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/misc/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ReadAfterWriteTest.class.getSimpleName() + "/";
 
 	private final static String TEST_NAME1 = "ReadAfterWriteMatrix1";
 	private final static String TEST_NAME2 = "ReadAfterWriteMatrix2";
@@ -43,10 +44,10 @@ public class ReadAfterWriteTest extends AutomatedTestBase
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {}));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] {}));
-		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_DIR, TEST_NAME3, new String[] {}));
-		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_DIR, TEST_NAME4, new String[] {}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] {}));
+		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[] {}));
 	}
 	
 	@Test
@@ -109,17 +110,18 @@ public class ReadAfterWriteTest extends AutomatedTestBase
 		
 		try
 		{	
-			//generate random file suffix
-			int suffix = Math.abs(new Random().nextInt());
-			String filename = SCRIPT_DIR + TEST_DIR + OUTPUT_DIR + suffix;
-			String filename2 = positive ? filename : filename+"_nonexisting";
-			
 			//test configuration
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config);
+			
+			//generate random file suffix
+			int suffix = Math.abs(new Random().nextInt());
+			String filename = output(Integer.toString(suffix));
+			String filename2 = positive ? filename : filename+"_nonexisting";
+			
 		    String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{"-args", filename, filename2};
-			loadTestConfiguration(config);
 			
 			//run tests
 	        runTest(true, !positive, DMLException.class, -1);
@@ -131,7 +133,7 @@ public class ReadAfterWriteTest extends AutomatedTestBase
 		finally
 		{
 	        //cleanup
-	        TestUtils.clearDirectory(SCRIPT_DIR + TEST_DIR + OUTPUT_DIR);
+	        TestUtils.clearDirectory(outputDir());
 		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/RewriteSimplifyRowColSumMVMultTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/RewriteSimplifyRowColSumMVMultTest.java
@@ -41,6 +41,7 @@ public class RewriteSimplifyRowColSumMVMultTest extends AutomatedTestBase
 	private static final String TEST_NAME1 = "RewriteRowSumsMVMult";
 	private static final String TEST_NAME2 = "RewriteRowSumsMVMult";
 	private static final String TEST_DIR = "functions/misc/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + RewriteSimplifyRowColSumMVMultTest.class.getSimpleName() + "/";
 	
 	private static final int rows = 1234;
 	private static final int cols = 567;
@@ -50,8 +51,8 @@ public class RewriteSimplifyRowColSumMVMultTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration( TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "R" })   );
-		addTestConfiguration( TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] { "R" })   );
+		addTestConfiguration( TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "R" }) );
+		addTestConfiguration( TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "R" }) );
 	}
 
 	@Test
@@ -91,16 +92,14 @@ public class RewriteSimplifyRowColSumMVMultTest extends AutomatedTestBase
 		try
 		{
 			TestConfiguration config = getTestConfiguration(testname);
+			loadTestConfiguration(config);
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
-			programArgs = new String[]{ "-stats","-args", 
-					                  HOME + INPUT_DIR + "X",
-					                  HOME + OUTPUT_DIR + "R" };
+			programArgs = new String[]{ "-stats","-args", input("X"), output("R") };
+			
 			fullRScriptName = HOME + testname + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " +
-			          HOME + INPUT_DIR + " " + HOME + EXPECTED_DIR;			
-			loadTestConfiguration(config);
+			rCmd = getRCmd(inputDir(), expectedDir());			
 
 			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = rewrites;
 

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/RewriteSlicedMatrixMultTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/RewriteSlicedMatrixMultTest.java
@@ -38,6 +38,7 @@ public class RewriteSlicedMatrixMultTest extends AutomatedTestBase
 	
 	private static final String TEST_NAME1 = "RewriteSlicedMatrixMult";
 	private static final String TEST_DIR = "functions/misc/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + RewriteSlicedMatrixMultTest.class.getSimpleName() + "/";
 	
 	private static final int dim1 = 1234;
 	private static final int dim2 = 567;
@@ -50,7 +51,7 @@ public class RewriteSlicedMatrixMultTest extends AutomatedTestBase
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration( TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "R" })   );
+		addTestConfiguration( TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "R" }) );
 	}
 
 	@Test
@@ -87,17 +88,15 @@ public class RewriteSlicedMatrixMultTest extends AutomatedTestBase
 		try
 		{
 			TestConfiguration config = getTestConfiguration(testname);
+			loadTestConfiguration(config);
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
 			programArgs = new String[]{ "-stats","-args", 
-					                  HOME + INPUT_DIR + "A",
-					                  HOME + INPUT_DIR + "B",
-					                  HOME + OUTPUT_DIR + "R" };
+				input("A"), input("B"), output("R") };
+			
 			fullRScriptName = HOME + testname + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " +
-			          HOME + INPUT_DIR + " " + HOME + EXPECTED_DIR;			
-			loadTestConfiguration(config);
+			rCmd = getRCmd(inputDir(), expectedDir());			
 
 			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = rewrites;
 

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/ScalarAssignmentTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/ScalarAssignmentTest.java
@@ -36,6 +36,7 @@ public class ScalarAssignmentTest extends AutomatedTestBase
 	private final static String TEST_NAME4 = "IfScalarAssignmentTest";
 	
 	private final static String TEST_DIR = "functions/misc/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ScalarAssignmentTest.class.getSimpleName() + "/";
 
 	public enum ControlFlowConstruct{
 		FOR,
@@ -46,10 +47,10 @@ public class ScalarAssignmentTest extends AutomatedTestBase
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {}));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] {}));
-		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_DIR, TEST_NAME3, new String[] {}));
-		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_DIR, TEST_NAME4, new String[] {}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] {}));
+		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[] {}));
 	}
 	
 	@Test
@@ -176,15 +177,14 @@ public class ScalarAssignmentTest extends AutomatedTestBase
 		}
 		
 	    TestConfiguration config = getTestConfiguration(TEST_NAME);
+		loadTestConfiguration(config);
 	    
         String RI_HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = RI_HOME + TEST_NAME + ".dml";
 		programArgs = new String[]{"-args",  value.toString() };
+		
 		fullRScriptName = RI_HOME + TEST_NAME + ".R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + 
-		       RI_HOME + INPUT_DIR + " " + RI_HOME + EXPECTED_DIR;
-
-		loadTestConfiguration(config);
+		rCmd = getRCmd(inputDir(), expectedDir());
 		
         boolean exceptionExpected = (cfc==ControlFlowConstruct.PARFOR)? true : false; //dependency analysis
         int expectedNumberOfJobs = -1;

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/ScalarFunctionTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/ScalarFunctionTest.java
@@ -38,14 +38,15 @@ public class ScalarFunctionTest extends AutomatedTestBase
 	private final static String TEST_NAME2 = "ScalarFunctionTest2";
 	
 	private final static String TEST_DIR = "functions/misc/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ScalarFunctionTest.class.getSimpleName() + "/";
 	private final static double eps = 1e-8;
 	
 	@Override
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] { "R" })); 
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] { "R" })); 
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "R" })); 
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "R" })); 
 	}
 	
 	
@@ -70,14 +71,14 @@ public class ScalarFunctionTest extends AutomatedTestBase
 	{
 		String TEST_NAME = testname;
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
+		loadTestConfiguration(config);
 		
 		String HOME = SCRIPT_DIR + TEST_DIR;			
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[]{"-args", HOME + OUTPUT_DIR + "R"};
-		fullRScriptName = HOME + TEST_NAME +".R";
-		rCmd = "Rscript" + " " + fullRScriptName + " " + HOME + EXPECTED_DIR;
+		programArgs = new String[]{"-args", output("R")};
 		
-		loadTestConfiguration(config);
+		fullRScriptName = HOME + TEST_NAME +".R";
+		rCmd = getRCmd(expectedDir());
 
 		//run Tests
 		runTest(true, false, null, -1); 

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/SetWorkingDirTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/SetWorkingDirTest.java
@@ -39,11 +39,12 @@ public class SetWorkingDirTest extends AutomatedTestBase
 	private final static String TEST_NAME1 = "PackageFunCall1";
 	private final static String TEST_NAME2 = "PackageFunCall2";
 	private final static String TEST_NAME0 = "PackageFunLib";
+	private static final String TEST_CLASS_DIR = TEST_DIR + SetWorkingDirTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {}));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] {}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {}));
 	}
 	
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/ValueTypeAutoCastingTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/ValueTypeAutoCastingTest.java
@@ -33,6 +33,7 @@ public class ValueTypeAutoCastingTest extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/misc/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ValueTypeAutoCastingTest.class.getSimpleName() + "/";
 
 	private final static String TEST_NAME1 = "iterablePredicate";
 	private final static String TEST_NAME2 = "conditionalPredicateWhile";
@@ -42,11 +43,11 @@ public class ValueTypeAutoCastingTest extends AutomatedTestBase
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_DIR, TEST_NAME3, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_DIR, TEST_NAME4, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_DIR, TEST_NAME5, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5, new String[] {"R"}));
 	}
 	
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/ValueTypeCastingTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/ValueTypeCastingTest.java
@@ -37,6 +37,7 @@ public class ValueTypeCastingTest extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/misc/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ValueTypeCastingTest.class.getSimpleName() + "/";
 
 	private final static String TEST_NAME1 = "castDouble";
 	private final static String TEST_NAME2 = "castInteger";
@@ -45,9 +46,9 @@ public class ValueTypeCastingTest extends AutomatedTestBase
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_DIR, TEST_NAME3, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] {"R"}));
 	}
 	
 	@Test
@@ -143,14 +144,11 @@ public class ValueTypeCastingTest extends AutomatedTestBase
 		
 		try
 		{		
-			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			getAndLoadTestConfiguration(TEST_NAME);
 		    
 		    String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-args", HOME + INPUT_DIR + "V" , 
-								                HOME + OUTPUT_DIR + "R", };
-			
-			loadTestConfiguration(config);
+			programArgs = new String[]{"-args", input("V"), output("R") };
 			
 			//write input
 			double[][] V = getRandomMatrix(numVals, numVals, 0, 1, 1.0, 7);
@@ -158,34 +156,33 @@ public class ValueTypeCastingTest extends AutomatedTestBase
 			if( matrixInput ){
 				writeInputMatrix("V", V, false);	
 				MatrixCharacteristics mc = new MatrixCharacteristics(numVals,numVals,1000,1000);
-				MapReduceTool.writeMetaDataFile(HOME + INPUT_DIR + "V.mtd", vtIn, mc, OutputInfo.TextCellOutputInfo);
+				MapReduceTool.writeMetaDataFile(input("V.mtd"), vtIn, mc, OutputInfo.TextCellOutputInfo);
 			}
 			else{
-				MapReduceTool.deleteFileIfExistOnHDFS(HOME + INPUT_DIR + "V");
+				MapReduceTool.deleteFileIfExistOnHDFS(input("V"));
 				switch( vtIn ) 
 				{
 					case DOUBLE: 
-						MapReduceTool.writeDoubleToHDFS(V[0][0], HOME + INPUT_DIR + "V"); 
+						MapReduceTool.writeDoubleToHDFS(V[0][0], input("V")); 
 						inVal = V[0][0]; break;
 					case INT:    
-						MapReduceTool.writeIntToHDFS((int)V[0][0], HOME + INPUT_DIR + "V"); 
+						MapReduceTool.writeIntToHDFS((int)V[0][0], input("V")); 
 						inVal = ((int)V[0][0]); break;
 					case BOOLEAN: 
-						MapReduceTool.writeBooleanToHDFS(V[0][0]!=0, HOME + INPUT_DIR + "V"); 
+						MapReduceTool.writeBooleanToHDFS(V[0][0]!=0, input("V")); 
 						inVal = (V[0][0]!=0)?1:0; break;
 					default: 
 						//do nothing	
 				}				
-				MapReduceTool.writeScalarMetaDataFile(HOME + INPUT_DIR + "V.mtd", vtIn);
+				MapReduceTool.writeScalarMetaDataFile(input("V.mtd"), vtIn);
 			}
-			
 			
 			//run tests
 	        runTest(true, exceptionExpected, DMLException.class, -1);
 	        
 	        if( !exceptionExpected ){		        
 		        //compare results
-	        	String outName = HOME + OUTPUT_DIR + "R";
+	        	String outName = output("R");
 		        switch( vtOut ) {
 					case DOUBLE:  Assert.assertEquals(inVal, MapReduceTool.readDoubleFromHDFSFile(outName), 1e-16); break;
 					case INT:     Assert.assertEquals((int) inVal, MapReduceTool.readIntegerFromHDFSFile(outName)); break;

--- a/src/test/java/org/apache/sysml/test/integration/functions/mlcontext/GNMFTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/mlcontext/GNMFTest.java
@@ -59,6 +59,7 @@ public class GNMFTest extends AutomatedTestBase
 {
 	private final static String TEST_DIR = "applications/gnmf/";
 	private final static String TEST_NAME = "GNMF";
+	private final static String TEST_CLASS_DIR = TEST_DIR + GNMFTest.class.getSimpleName() + "/";
 	
 	int numRegisteredInputs;
 	int numRegisteredOutputs;
@@ -76,7 +77,7 @@ public class GNMFTest extends AutomatedTestBase
 	 
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_DIR, TEST_NAME);
+		addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
 	}
 	
 	@Test

--- a/src/test/java/org/apache/sysml/test/integration/functions/piggybacking/PiggybackingTest1.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/piggybacking/PiggybackingTest1.java
@@ -34,6 +34,7 @@ public class PiggybackingTest1 extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "Piggybacking1";
 	private final static String TEST_DIR = "functions/piggybacking/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + PiggybackingTest1.class.getSimpleName() + "/";
 
 	private final static int rows = 500;
 	private final static int cols = 500;
@@ -60,10 +61,9 @@ public class PiggybackingTest1 extends AutomatedTestBase
 	public void setUp() 
 	{
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "z", "appendTestOut.scalar" })   ); 
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,
+				new String[] { "z", "appendTestOut.scalar" }) ); 
 	}
 	
 	/**
@@ -88,20 +88,17 @@ public class PiggybackingTest1 extends AutomatedTestBase
 		try
 		{
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config);
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + "_mvmult.dml";
-			programArgs = new String[]{"-args", HOME + INPUT_DIR + "A" , 
-												HOME + INPUT_DIR + "x", 
-												HOME + OUTPUT_DIR + config.getOutputFiles()[0] };
+			programArgs = new String[]{"-args", input("A"), 
+				input("x"), output(config.getOutputFiles()[0]) };
 	
 			fullRScriptName = HOME + TEST_NAME + "_mvmult.R";
 			rCmd = "Rscript" + " " + fullRScriptName + " " + 
-				       HOME + INPUT_DIR + "A.mtx" + " " + 
-				       HOME + INPUT_DIR + "x.mtx" + " " + 
-				       HOME + EXPECTED_DIR + config.getOutputFiles()[0];
-	
-			loadTestConfiguration(config);
+				input("A.mtx") + " " + input("x.mtx") + " " + 
+				expected(config.getOutputFiles()[0]);
 			
 			double[][] A = getRandomMatrix(rows, cols, 0, 1, sparsity, 10);
 			MatrixCharacteristics mc = new MatrixCharacteristics(rows, cols, -1, -1, -1);
@@ -131,13 +128,12 @@ public class PiggybackingTest1 extends AutomatedTestBase
 		rtplatform = RUNTIME_PLATFORM.HADOOP;
 		
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
+		loadTestConfiguration(config);
 		
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME + "_append.dml";
-		String OUT_FILE = HOME + OUTPUT_DIR + config.getOutputFiles()[1];
+		String OUT_FILE = output(config.getOutputFiles()[1]);
 		programArgs = new String[]{"-args", OUT_FILE };
-
-		loadTestConfiguration(config);
 		
 		boolean exceptionExpected = false;
 		int numMRJobs = 4;
@@ -149,7 +145,5 @@ public class PiggybackingTest1 extends AutomatedTestBase
 		
 		rtplatform = rtold;
 	}
-	
-
 	
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/piggybacking/PiggybackingTest2.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/piggybacking/PiggybackingTest2.java
@@ -35,14 +35,13 @@ public class PiggybackingTest2 extends AutomatedTestBase
 	
 	private final static String TEST_NAME = "Piggybacking_iqm";
 	private final static String TEST_DIR = "functions/piggybacking/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + PiggybackingTest2.class.getSimpleName() + "/";
 
 	@Override
 	public void setUp() 
 	{
-		addTestConfiguration(
-				TEST_NAME, 
-				new TestConfiguration(TEST_DIR, TEST_NAME, 
-				new String[] { "x", "iqm.scalar" })   ); 
+		addTestConfiguration(TEST_NAME, 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "x", "iqm.scalar" }) ); 
 	}
 	
 	/**
@@ -61,17 +60,16 @@ public class PiggybackingTest2 extends AutomatedTestBase
 		rtplatform = RUNTIME_PLATFORM.HADOOP;
 		
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
+		loadTestConfiguration(config);
 		
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[]{"-args", HOME + OUTPUT_DIR + config.getOutputFiles()[0] };
-
-		loadTestConfiguration(config);
+		programArgs = new String[]{"-args", output(config.getOutputFiles()[0]) };
 		
 		boolean exceptionExpected = false;
 		runTest(true, exceptionExpected, null, -1);
 	
-		HashMap<CellIndex, Double> d = TestUtils.readDMLScalarFromHDFS(HOME + OUTPUT_DIR + config.getOutputFiles()[0]);
+		HashMap<CellIndex, Double> d = TestUtils.readDMLScalarFromHDFS(output(config.getOutputFiles()[0]));
 		
 		Assert.assertEquals(d.get(new CellIndex(1,1)), Double.valueOf(1.0), 1e-10);
 		

--- a/src/test/java/org/apache/sysml/test/integration/functions/terms/ScalarMatrixUnaryBinaryTermTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/terms/ScalarMatrixUnaryBinaryTermTest.java
@@ -29,17 +29,19 @@ import org.apache.sysml.test.utils.TestUtils;
 public class ScalarMatrixUnaryBinaryTermTest extends AutomatedTestBase 
 {
 	private static final String TEST_DIR = "functions/terms/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ScalarMatrixUnaryBinaryTermTest.class.getSimpleName() + "/";
+	private static final String TEST_NAME = "TestTerm1";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration("TestTerm1", new TestConfiguration(TEST_DIR, "TestTerm1", new String[] {}));
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {}));
 	}
 
 	@Test
 	public void testTerm1() {
 		int rows = 5, cols = 5;
 
-		TestConfiguration config = getTestConfiguration("TestTerm1");
+		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
 

--- a/src/test/java/org/apache/sysml/test/integration/functions/terms/ScalarToMatrixInLoopTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/terms/ScalarToMatrixInLoopTest.java
@@ -28,17 +28,19 @@ import org.apache.sysml.test.integration.TestConfiguration;
 public class ScalarToMatrixInLoopTest extends AutomatedTestBase 
 {
 	private static final String TEST_DIR = "functions/terms/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ScalarToMatrixInLoopTest.class.getSimpleName() + "/";
+	private static final String TEST_NAME = "ScalarToMatrixInLoop";
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration("ScalarToMatrixInLoop", new TestConfiguration(TEST_DIR, "TestScalarToMatrixInLoop", new String[] {}));
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, "TestScalarToMatrixInLoop", new String[] {}));
 	}
 
 	@Test
 	public void testScalarToMatrixInLoop() {
 		int rows = 5, cols = 5;
 
-		TestConfiguration config = getTestConfiguration("ScalarToMatrixInLoop");
+		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);
 		config.addVariable("cols", cols);
 

--- a/src/test/java/org/apache/sysml/test/integration/functions/vect/AutoVectorizationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/vect/AutoVectorizationTest.java
@@ -35,6 +35,7 @@ public class AutoVectorizationTest extends AutomatedTestBase
 {
 	
 	private final static String TEST_DIR = "functions/vect/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + AutoVectorizationTest.class.getSimpleName() + "/";
 
 	private final static String TEST_NAME1 = "VectorizeRixRowPos";
 	private final static String TEST_NAME2 = "VectorizeRixRowNeg";
@@ -67,30 +68,30 @@ public class AutoVectorizationTest extends AutomatedTestBase
 	
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_DIR, TEST_NAME1, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_DIR, TEST_NAME2, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_DIR, TEST_NAME3, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_DIR, TEST_NAME4, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_DIR, TEST_NAME5, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME6, new TestConfiguration(TEST_DIR, TEST_NAME6, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME7, new TestConfiguration(TEST_DIR, TEST_NAME7, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME8, new TestConfiguration(TEST_DIR, TEST_NAME8, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME9, new TestConfiguration(TEST_DIR, TEST_NAME9, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME10, new TestConfiguration(TEST_DIR, TEST_NAME10, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME11, new TestConfiguration(TEST_DIR, TEST_NAME11, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME12, new TestConfiguration(TEST_DIR, TEST_NAME12, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME13, new TestConfiguration(TEST_DIR, TEST_NAME13, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME14, new TestConfiguration(TEST_DIR, TEST_NAME14, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME15, new TestConfiguration(TEST_DIR, TEST_NAME15, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME16, new TestConfiguration(TEST_DIR, TEST_NAME16, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME17, new TestConfiguration(TEST_DIR, TEST_NAME17, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME18, new TestConfiguration(TEST_DIR, TEST_NAME18, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME19, new TestConfiguration(TEST_DIR, TEST_NAME19, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME20, new TestConfiguration(TEST_DIR, TEST_NAME20, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME21, new TestConfiguration(TEST_DIR, TEST_NAME21, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME22, new TestConfiguration(TEST_DIR, TEST_NAME22, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME23, new TestConfiguration(TEST_DIR, TEST_NAME23, new String[] {"R"}));
-		addTestConfiguration(TEST_NAME24, new TestConfiguration(TEST_DIR, TEST_NAME24, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME7, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME7, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME8, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME8, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME9, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME9, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME10, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME10, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME11, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME11, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME12, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME12, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME13, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME13, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME14, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME14, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME15, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME15, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME16, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME16, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME17, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME17, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME18, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME18, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME19, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME19, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME20, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME20, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME21, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME21, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME22, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME22, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME23, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME23, new String[] {"R"}));
+		addTestConfiguration(TEST_NAME24, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME24, new String[] {"R"}));
 	}
 	
 	@Test
@@ -225,16 +226,14 @@ public class AutoVectorizationTest extends AutomatedTestBase
 		try
 		{		
 			TestConfiguration config = getTestConfiguration(TEST_NAME);
-			
+			loadTestConfiguration(config);
+
 		    String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-explain","-args", HOME + INPUT_DIR + "A" , 
-								                HOME + OUTPUT_DIR + "R", };
-			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + 
-					 HOME + INPUT_DIR + " " + HOME + EXPECTED_DIR;		
+			programArgs = new String[]{"-explain","-args", input("A"), output("R") };
 			
-			loadTestConfiguration(config);
+			fullRScriptName = HOME + TEST_NAME + ".R";
+			rCmd = getRCmd(inputDir(), expectedDir());		
 			
 			//generate input
 			double[][] A = getRandomMatrix(rows, cols, 0, 1, 1.0, 7);

--- a/src/test/java/org/apache/sysml/test/integration/scalability/LinearRegressionTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/scalability/LinearRegressionTest.java
@@ -31,11 +31,13 @@ public class LinearRegressionTest extends AutomatedScalabilityTestBase
 {
 	
 	private static final String TEST_DIR = "test/scripts/scalability/linear_regression/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + LinearRegressionTest.class.getSimpleName() + "/";
+
 	
     @Override
     public void setUp() {
     	TestUtils.clearAssertionInformation();
-        addTestConfiguration("LinearRegressionTest", new TestConfiguration(TEST_DIR, "LinearRegressionTest", new String[] { "w" }));
+        addTestConfiguration("LinearRegressionTest", new TestConfiguration(TEST_CLASS_DIR, "LinearRegressionTest", new String[] { "w" }));
         matrixSizes = new int[][] {
                 { 19004, 15436 }
         };

--- a/src/test/java/org/apache/sysml/test/integration/scalability/PageRankTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/scalability/PageRankTest.java
@@ -29,11 +29,12 @@ import org.apache.sysml.test.integration.TestConfiguration;
 public class PageRankTest extends AutomatedScalabilityTestBase 
 {
 	private static final String TEST_DIR = "test/scripts/scalability/page_rank/";
-	
+	private static final String TEST_CLASS_DIR = TEST_DIR + PageRankTest.class.getSimpleName() + "/";
+
 	
     @Override
     public void setUp() {
-        addTestConfiguration("PageRankTest", new TestConfiguration(TEST_DIR, "PageRankTest", new String[] { "p" }));
+        addTestConfiguration("PageRankTest", new TestConfiguration(TEST_CLASS_DIR, "PageRankTest", new String[] { "p" }));
         matrixSizes = new int[][] {
                 { 9914 }
         };


### PR DESCRIPTION
Similar refactoring of unit tests in functions.io, functions.misc and a several other packages that contain a few test classes so expected/in/out test data no longer generated in src/test/scripts folder.   This refactoring also allows these tests to be run in parallel.

Tests completed successfully [here](https://sparktc.ibmcloud.com/jenkins/job/SystemML-OnDemand/37/).