### PR TITLE
Upgrading Spark version to 1.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
 	<properties>
 		<hadoop.version>2.4.1</hadoop.version>
 		<antlr.version>4.3</antlr.version>
+		<spark.version>1.4.1</spark.version>
 
 		<!-- OS-specific JVM arguments for running integration tests -->
 		<integrationTestExtraJVMArgs />
@@ -526,14 +527,14 @@
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-core_2.10</artifactId>
-			<version>1.4.0</version>
+			<version>${spark.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-mllib_2.10</artifactId>
-			<version>1.4.0</version>
+			<version>${spark.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -541,7 +542,7 @@
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-sql_2.10</artifactId>
-			<version>1.3.1</version>
+			<version>${spark.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/java/org/apache/sysml/api/MLBlock.java
+++ b/src/main/java/org/apache/sysml/api/MLBlock.java
@@ -88,6 +88,12 @@ public class MLBlock implements Row {
 	}
 
 	@Override
+	public <T> T getAs(String arg0) {
+		// TODO
+		return null;
+	}
+
+	@Override
 	public boolean getBoolean(int arg0) {
 		// TODO
 		return false;
@@ -151,7 +157,19 @@ public class MLBlock implements Row {
 	}
 
 	@Override
+	public int fieldIndex(String arg0) {
+		// TODO
+		return 0;
+	}
+
+	@Override
 	public <K, V> scala.collection.Map<K, V> getMap(int arg0) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public <T> scala.collection.immutable.Map<String, T> getValuesMap(Seq<String> arg0) {
 		// TODO Auto-generated method stub
 		return null;
 	}
@@ -216,6 +234,7 @@ public class MLBlock implements Row {
 	public StructType schema() {
 		return getDefaultSchemaForBinaryBlock();
 	}
+
 
 	@Override
 	public int size() {


### PR DESCRIPTION
Making the versions of spark-related dependencies consistent.