### PR TITLE
Run unit tests in functions packages without suites.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,38 +326,13 @@
 						-Djava.awt.headless=true</argLine>
 
 					<includes>
-						<include>**/integration/**/*Suite.java</include>
-						<!-- <include>**/integration/functions/aggregate/*Test.java</include> -->
-						<include>**/integration/functions/append/*Test.java</include>
-						<include>**/integration/functions/binary/matrix/*Test.java</include>
-						<include>**/integration/functions/binary/matrix_full_cellwise/*Test.java</include>
-						<include>**/integration/functions/binary/matrix_full_other/*Test.java</include>
-						<include>**/integration/functions/data/*Test*.java</include>
-						<include>**/integration/functions/indexing/*Test.java</include>
-						<include>**/integration/functions/parfor/*Test.java</include>
-						<include>**/integration/functions/quaternary/*Test.java</include>
-						<include>**/integration/functions/recompile/*Test.java</include>
-						<include>**/integration/functions/reorg/*Test.java</include>
-						<include>**/integration/functions/ternary/*Test.java</include>
-						<include>**/integration/functions/transform/*Test.java</include>
-						<include>**/integration/functions/unary/matrix/*Test.java</include>
+						<include>**/integration/applications/**/*Suite.java</include>
+						<include>**/integration/functions/**/*Test*.java</include>
+						<include>**/integration/functions/gdfo/*.java</include>
+						<include>**/integration/scalability/**/*Test.java</include>
 					</includes>
 
 					<excludes>
-						<!-- <exclude>**/integration/functions/aggregate/*Suite.java</exclude> -->
-						<exclude>**/integration/functions/append/*Suite.java</exclude>
-						<exclude>**/integration/functions/binary/matrix/*Suite.java</exclude>
-						<exclude>**/integration/functions/binary/matrix_full_cellwise/*Suite.java</exclude>
-						<exclude>**/integration/functions/binary/matrix_full_other/*Suite.java</exclude>
-						<exclude>**/integration/functions/data/*Suite.java</exclude>
-						<exclude>**/integration/functions/indexing/*Suite.java</exclude>
-						<exclude>**/integration/functions/parfor/*Suite.java</exclude>
-						<exclude>**/integration/functions/quaternary/*Suite.java</exclude>
-						<exclude>**/integration/functions/recompile/*Suite.java</exclude>
-						<exclude>**/integration/functions/reorg/*Suite.java</exclude>
-						<exclude>**/integration/functions/ternary/*Suite.java</exclude>
-						<exclude>**/integration/functions/transform/*Suite.java</exclude>
-						<exclude>**/integration/functions/unary/matrix/*Suite.java</exclude>
 						<exclude>**/slowtest/**</exclude>
 					</excludes>
 

--- a/pom.xml
+++ b/pom.xml
@@ -327,8 +327,8 @@
 
 					<includes>
 						<include>**/integration/applications/**/*Suite.java</include>
+						<include>**/integration/functions/gdfo/*Suite.java</include>
 						<include>**/integration/functions/**/*Test*.java</include>
-						<include>**/integration/functions/gdfo/*.java</include>
 						<include>**/integration/scalability/**/*Test.java</include>
 					</includes>
 

--- a/src/test_suites/java/org/apache/sysml/test/integration/functions/misc/ZPackageSuite.java
+++ b/src/test_suites/java/org/apache/sysml/test/integration/functions/misc/ZPackageSuite.java
@@ -42,6 +42,7 @@ import org.junit.runners.Suite;
 	PrintMatrixTest.class,
 	ReadAfterWriteTest.class,
 	RewriteSimplifyRowColSumMVMultTest.class,
+	RewriteSlicedMatrixMultTest.class,
 	ScalarAssignmentTest.class,
 	ScalarFunctionTest.class,
 	SetWorkingDirTest.class,


### PR DESCRIPTION
Updated pom.xml to run unit tests under functions without using Suite wrapper (previously refactored packages listed individually).  For consistency, also added missing test class with 4 test cases to misc package suite which I missed when refactoring that package.

Note the package gdfo was kept as suite since a failure was reported in on-demand build 41 although not observed on local windows development environment.

Tests completed successfully [here](https://sparktc.ibmcloud.com/jenkins/job/SystemML-OnDemand/42/) which includes latest commit.

