### PR TITLE
Updated dml script class path from ibm to apache

### DIFF
--- a/bin/systemml.bat
+++ b/bin/systemml.bat
@@ -36,7 +36,7 @@ popd
 
 SET BUILD_DIR=%PROJECT_ROOT_DIR%\target
 SET HADOOP_LIB_DIR=%BUILD_DIR%\lib
-SET DML_SCRIPT_CLASS=%BUILD_DIR%\classes\com\ibm\bi\dml\api\DMLScript.class
+SET DML_SCRIPT_CLASS=%BUILD_DIR%\classes\org\apache\sysml\api\DMLScript.class
 
 SET BUILD_ERR_MSG=You must build the project before running this script.
 SET BUILD_DIR_ERR_MSG=Could not find target directory "%BUILD_DIR%". %BUILD_ERR_MSG%


### PR DESCRIPTION
Only systemml.bat referenced previous ibm path instead of new apache path which resulted in 'Could not find DMLScript.class. You must build the project.' error message.  I left java memory options as-is although I did have to lower to get to run on my local system.