### PR TITLE
Add scratch_space to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,8 +52,9 @@ src/test/scripts/**/in
 src/test/scripts/**/out
 src/test/scripts/**/expected
 
-# Working directory
+# Working directory and scratch space
 temp/*
+scratch_space/
 
 # Ruby
 Gemfile.lock


### PR DESCRIPTION
If SystemML executed from project root directory, such as
in an IDE, scratch_space directory created in root of project,
so add scratch_space directory to .gitignore.