### PR TITLE
[Systemml-475] [WIP] Add Implicit Conversion Between Scalar Values and 1x1 Matrices

### DIFF
--- a/src/main/java/org/apache/sysml/parser/PrintStatement.java
+++ b/src/main/java/org/apache/sysml/parser/PrintStatement.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysml.parser;
 
+import org.apache.commons.math3.analysis.function.Exp;
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.debug.DMLBreakpointManager;
 
@@ -114,6 +115,10 @@ public class PrintStatement extends Statement
 
 	public Expression getExpression(){
 		return _expr;
+	}
+
+	public void setExpression(Expression e) {
+		_expr = e;
 	}
 	
 	public PRINTTYPE getType() {

--- a/src/main/java/org/apache/sysml/parser/StatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/StatementBlock.java
@@ -763,8 +763,24 @@ public class StatementBlock extends LiveVariableAnalysis
 				expr.validateExpression(ids.getVariables(), currConstVars, conditional);
 				
 				// check that variables referenced in print statement expression are scalars
-				if (expr.getOutput().getDataType() != Expression.DataType.SCALAR){
-				   raiseValidateError("print statement can only print scalars", conditional);
+				Identifier out = expr.getOutput();
+				if (out.getDataType() != DataType.SCALAR) {
+					if (out.getValueType() != ValueType.STRING && out.getDataType() == DataType.MATRIX
+							&& out.getDim1() == 1 && out.getDim2() == 1) {
+						// Create a cast from a 1x1 matrix to a scalar.
+						// Note, we use the same line/column data as the
+						// current built-in function expression since
+						// this cast is implicitly tied to the
+						// function, rather than the function argument.
+						Expression[] castArgs = {expr};
+						BuiltinFunctionExpression cast =
+								new BuiltinFunctionExpression(Expression.BuiltinFunctionOp.CAST_AS_SCALAR,
+										castArgs, this.getFilename(), this.getBeginLine(), this.getBeginColumn(),
+										this.getEndLine(), this.getEndColumn());
+						pstmt.setExpression(cast);
+					} else {
+						raiseValidateError("print statement can only print scalars", conditional);
+					}
 				}
 			}
 			


### PR DESCRIPTION
**Work in progress**

---

Currently, any DML functions that require scalars will not accept 1x1 matrices.  Matrix indexing always returns a matrix, so a statement such as `A[1,1]` from the following simple example will return a single-valued matrix, even though it logically represents a scalar.  Thus, in order to use this value as a scalar, the `as.scalar(...)` function is required.

```r
A = matrix(7, rows=10, cols=10)                                                                                                                
print( "A[1,1]: " + as.scalar(A[1,1]))  // 7
```

In this scenario, the required usage of `as.scalar(...)` can cause confusion, and can be viewed as a violation of SystemML's goal of hiding the underlying data representation from the user.

Additionally, many of the built-in functions, such as `rowVars(...)`, accept matrices without other requirements of dimensionality, and thus will accept a 1x1 matrix, yet will not accept a scalar value.  We should allow any such functions that accept 1x1 matrices to also accept scalar values.

```r
a = 4
print("Row variances of scalar are: " + as.scalar(rowVars(as.matrix(a))))  // 0
```

In order to achieve this, we can add implicit casting between scalar values and 1x1 matrices within the parser during the validation stage as needed.

With this PR, the following can be done:

```r
A = matrix(7, rows=10, cols=10)
print( "A[1,1]: " + A[1,1])  // 7
```

```r
a = 4
print("Row variances of scalar are: " + rowVars(a))  // 0
```

---

**Note:  This is still a work in progress**, as there are likely additional fixes/improvements/changes that can be made, such as determining side-effects on other operations, or HOP rewrites such as removing unnecessary casting.