### PR TITLE
[SYSTEMML-158] Update deprecated Hadoop properties

### DIFF
--- a/src/main/java/org/apache/sysml/api/DMLScript.java
+++ b/src/main/java/org/apache/sysml/api/DMLScript.java
@@ -76,7 +76,7 @@ import org.apache.sysml.runtime.controlprogram.parfor.ProgramConverter;
 import org.apache.sysml.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
 import org.apache.sysml.runtime.controlprogram.parfor.util.IDHandler;
 import org.apache.sysml.runtime.matrix.CleanupMR;
-import org.apache.sysml.runtime.matrix.mapred.MRProp;
+import org.apache.sysml.runtime.matrix.mapred.MRConfigurationNames;
 import org.apache.sysml.runtime.matrix.mapred.MRJobConfiguration;
 import org.apache.sysml.runtime.util.LocalFileUtils;
 import org.apache.sysml.runtime.util.MapReduceTool;
@@ -834,9 +834,9 @@ public class DMLScript
 		//analyze hadoop configuration
 		JobConf job = ConfigurationManager.getCachedJobConf();
 		boolean localMode     = InfrastructureAnalyzer.isLocalMode(job);
-		String taskController = job.get(MRProp.MR_TASKTRACKER_TASKCONTROLLER, "org.apache.hadoop.mapred.DefaultTaskController");
+		String taskController = job.get(MRConfigurationNames.MR_TASKTRACKER_TASKCONTROLLER, "org.apache.hadoop.mapred.DefaultTaskController");
 		String ttGroupName    = job.get("mapreduce.tasktracker.group","null");
-		String perm           = job.get(MRProp.DFS_PERMISSIONS_ENABLED,"null"); //note: job.get("dfs.permissions.supergroup",null);
+		String perm           = job.get(MRConfigurationNames.DFS_PERMISSIONS_ENABLED,"null"); //note: job.get("dfs.permissions.supergroup",null);
 		URI fsURI             = FileSystem.getDefaultUri(job);
 
 		//determine security states
@@ -849,11 +849,11 @@ public class DMLScript
 		LOG.debug("SystemML security check: "
 				+ "local.user.name = " + userName + ", "
 				+ "local.user.groups = " + ProgramConverter.serializeStringCollection(groupNames) + ", "
-				+ MRProp.MR_JOBTRACKER_ADDRESS + " = " + job.get(MRProp.MR_JOBTRACKER_ADDRESS) + ", "
-				+ MRProp.MR_TASKTRACKER_TASKCONTROLLER + " = " + taskController + ","
+				+ MRConfigurationNames.MR_JOBTRACKER_ADDRESS + " = " + job.get(MRConfigurationNames.MR_JOBTRACKER_ADDRESS) + ", "
+				+ MRConfigurationNames.MR_TASKTRACKER_TASKCONTROLLER + " = " + taskController + ","
 				+ "mapreduce.tasktracker.group = " + ttGroupName + ", "
 				+ "fs.default.name = " + ((fsURI!=null) ? fsURI.getScheme() : "null") + ", "
-				+ MRProp.DFS_PERMISSIONS_ENABLED + " = " + perm );
+				+ MRConfigurationNames.DFS_PERMISSIONS_ENABLED + " = " + perm );
 
 		//print warning if permission issues possible
 		if( flagDiffUser && ( flagLocalFS || flagSecurity ) )

--- a/src/main/java/org/apache/sysml/api/DMLScript.java
+++ b/src/main/java/org/apache/sysml/api/DMLScript.java
@@ -834,7 +834,7 @@ public class DMLScript
 		//analyze hadoop configuration
 		JobConf job = ConfigurationManager.getCachedJobConf();
 		boolean localMode     = InfrastructureAnalyzer.isLocalMode(job);
-		String taskController = job.get(MRConfigurationNames.MAPREDUCE_TASKTRACKER_TASKCONTROLLER, "org.apache.hadoop.mapred.DefaultTaskController");
+		String taskController = job.get(MRConfigurationNames.MR_TASKTRACKER_TASKCONTROLLER, "org.apache.hadoop.mapred.DefaultTaskController");
 		String ttGroupName    = job.get("mapreduce.tasktracker.group","null");
 		String perm           = job.get(MRConfigurationNames.DFS_PERMISSIONS,"null"); //note: job.get("dfs.permissions.supergroup",null);
 		URI fsURI             = FileSystem.getDefaultUri(job);
@@ -849,8 +849,8 @@ public class DMLScript
 		LOG.debug("SystemML security check: "
 				+ "local.user.name = " + userName + ", "
 				+ "local.user.groups = " + ProgramConverter.serializeStringCollection(groupNames) + ", "
-				+ MRConfigurationNames.MAPREDUCE_JOBTRACKER_ADDRESS + " = " + job.get(MRConfigurationNames.MAPREDUCE_JOBTRACKER_ADDRESS) + ", "
-				+ MRConfigurationNames.MAPREDUCE_TASKTRACKER_TASKCONTROLLER + " = " + taskController + ","
+				+ MRConfigurationNames.MR_JOBTRACKER_ADDRESS + " = " + job.get(MRConfigurationNames.MR_JOBTRACKER_ADDRESS) + ", "
+				+ MRConfigurationNames.MR_TASKTRACKER_TASKCONTROLLER + " = " + taskController + ","
 				+ "mapreduce.tasktracker.group = " + ttGroupName + ", "
 				+ "fs.default.name = " + ((fsURI!=null) ? fsURI.getScheme() : "null") + ", "
 				+ MRConfigurationNames.DFS_PERMISSIONS + " = " + perm );

--- a/src/main/java/org/apache/sysml/api/DMLScript.java
+++ b/src/main/java/org/apache/sysml/api/DMLScript.java
@@ -834,7 +834,7 @@ public class DMLScript
 		//analyze hadoop configuration
 		JobConf job = ConfigurationManager.getCachedJobConf();
 		boolean localMode     = InfrastructureAnalyzer.isLocalMode(job);
-		String taskController = job.get("mapreduce.tasktracker.taskcontroller", "org.apache.hadoop.mapred.DefaultTaskController");
+		String taskController = job.get(MRConfigurationNames.MAPREDUCE_TASKTRACKER_TASKCONTROLLER, "org.apache.hadoop.mapred.DefaultTaskController");
 		String ttGroupName    = job.get("mapreduce.tasktracker.group","null");
 		String perm           = job.get(MRConfigurationNames.DFS_PERMISSIONS,"null"); //note: job.get("dfs.permissions.supergroup",null);
 		URI fsURI             = FileSystem.getDefaultUri(job);
@@ -846,9 +846,14 @@ public class DMLScript
 		boolean flagLocalFS = fsURI==null || fsURI.getScheme().equals("file");
 		boolean flagSecurity = perm.equals("yes"); 
 		
-		LOG.debug("SystemML security check: " + "local.user.name = " + userName + ", " + "local.user.groups = " + ProgramConverter.serializeStringCollection(groupNames) + ", "
-				        + "mapreduce.jobtracker.address = " + job.get("mapreduce.jobtracker.address") + ", " + "mapreduce.tasktracker.taskcontroller = " + taskController + "," + "mapreduce.tasktracker.group = " + ttGroupName + ", "
-				        + "fs.default.name = " + ((fsURI!=null)?fsURI.getScheme():"null") + ", " + MRConfigurationNames.DFS_PERMISSIONS+" = " + perm );
+		LOG.debug("SystemML security check: "
+				+ "local.user.name = " + userName + ", "
+				+ "local.user.groups = " + ProgramConverter.serializeStringCollection(groupNames) + ", "
+				+ MRConfigurationNames.MAPREDUCE_JOBTRACKER_ADDRESS + " = " + job.get(MRConfigurationNames.MAPREDUCE_JOBTRACKER_ADDRESS) + ", "
+				+ MRConfigurationNames.MAPREDUCE_TASKTRACKER_TASKCONTROLLER + " = " + taskController + ","
+				+ "mapreduce.tasktracker.group = " + ttGroupName + ", "
+				+ "fs.default.name = " + ((fsURI!=null) ? fsURI.getScheme() : "null") + ", "
+				+ MRConfigurationNames.DFS_PERMISSIONS + " = " + perm );
 
 		//print warning if permission issues possible
 		if( flagDiffUser && ( flagLocalFS || flagSecurity ) )

--- a/src/main/java/org/apache/sysml/api/DMLScript.java
+++ b/src/main/java/org/apache/sysml/api/DMLScript.java
@@ -834,7 +834,7 @@ public class DMLScript
 		//analyze hadoop configuration
 		JobConf job = ConfigurationManager.getCachedJobConf();
 		boolean localMode     = InfrastructureAnalyzer.isLocalMode(job);
-		String taskController = job.get("mapred.task.tracker.task-controller", "org.apache.hadoop.mapred.DefaultTaskController");
+		String taskController = job.get("mapreduce.tasktracker.taskcontroller", "org.apache.hadoop.mapred.DefaultTaskController");
 		String ttGroupName    = job.get("mapreduce.tasktracker.group","null");
 		String perm           = job.get(MRConfigurationNames.DFS_PERMISSIONS,"null"); //note: job.get("dfs.permissions.supergroup",null);
 		URI fsURI             = FileSystem.getDefaultUri(job);
@@ -847,7 +847,7 @@ public class DMLScript
 		boolean flagSecurity = perm.equals("yes"); 
 		
 		LOG.debug("SystemML security check: " + "local.user.name = " + userName + ", " + "local.user.groups = " + ProgramConverter.serializeStringCollection(groupNames) + ", "
-				        + "mapred.job.tracker = " + job.get("mapred.job.tracker") + ", " + "mapred.task.tracker.task-controller = " + taskController + "," + "mapreduce.tasktracker.group = " + ttGroupName + ", "
+				        + "mapreduce.jobtracker.address = " + job.get("mapreduce.jobtracker.address") + ", " + "mapreduce.tasktracker.taskcontroller = " + taskController + "," + "mapreduce.tasktracker.group = " + ttGroupName + ", "
 				        + "fs.default.name = " + ((fsURI!=null)?fsURI.getScheme():"null") + ", " + MRConfigurationNames.DFS_PERMISSIONS+" = " + perm );
 
 		//print warning if permission issues possible

--- a/src/main/java/org/apache/sysml/api/DMLScript.java
+++ b/src/main/java/org/apache/sysml/api/DMLScript.java
@@ -76,7 +76,7 @@ import org.apache.sysml.runtime.controlprogram.parfor.ProgramConverter;
 import org.apache.sysml.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
 import org.apache.sysml.runtime.controlprogram.parfor.util.IDHandler;
 import org.apache.sysml.runtime.matrix.CleanupMR;
-import org.apache.sysml.runtime.matrix.mapred.MRConfigurationNames;
+import org.apache.sysml.runtime.matrix.mapred.MRProp;
 import org.apache.sysml.runtime.matrix.mapred.MRJobConfiguration;
 import org.apache.sysml.runtime.util.LocalFileUtils;
 import org.apache.sysml.runtime.util.MapReduceTool;
@@ -834,9 +834,9 @@ public class DMLScript
 		//analyze hadoop configuration
 		JobConf job = ConfigurationManager.getCachedJobConf();
 		boolean localMode     = InfrastructureAnalyzer.isLocalMode(job);
-		String taskController = job.get(MRConfigurationNames.MR_TASKTRACKER_TASKCONTROLLER, "org.apache.hadoop.mapred.DefaultTaskController");
+		String taskController = job.get(MRProp.MR_TASKTRACKER_TASKCONTROLLER, "org.apache.hadoop.mapred.DefaultTaskController");
 		String ttGroupName    = job.get("mapreduce.tasktracker.group","null");
-		String perm           = job.get(MRConfigurationNames.DFS_PERMISSIONS,"null"); //note: job.get("dfs.permissions.supergroup",null);
+		String perm           = job.get(MRProp.DFS_PERMISSIONS_ENABLED,"null"); //note: job.get("dfs.permissions.supergroup",null);
 		URI fsURI             = FileSystem.getDefaultUri(job);
 
 		//determine security states
@@ -849,11 +849,11 @@ public class DMLScript
 		LOG.debug("SystemML security check: "
 				+ "local.user.name = " + userName + ", "
 				+ "local.user.groups = " + ProgramConverter.serializeStringCollection(groupNames) + ", "
-				+ MRConfigurationNames.MR_JOBTRACKER_ADDRESS + " = " + job.get(MRConfigurationNames.MR_JOBTRACKER_ADDRESS) + ", "
-				+ MRConfigurationNames.MR_TASKTRACKER_TASKCONTROLLER + " = " + taskController + ","
+				+ MRProp.MR_JOBTRACKER_ADDRESS + " = " + job.get(MRProp.MR_JOBTRACKER_ADDRESS) + ", "
+				+ MRProp.MR_TASKTRACKER_TASKCONTROLLER + " = " + taskController + ","
 				+ "mapreduce.tasktracker.group = " + ttGroupName + ", "
 				+ "fs.default.name = " + ((fsURI!=null) ? fsURI.getScheme() : "null") + ", "
-				+ MRConfigurationNames.DFS_PERMISSIONS + " = " + perm );
+				+ MRProp.DFS_PERMISSIONS_ENABLED + " = " + perm );
 
 		//print warning if permission issues possible
 		if( flagDiffUser && ( flagLocalFS || flagSecurity ) )

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForMR.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForMR.java
@@ -51,7 +51,7 @@ import org.apache.sysml.runtime.controlprogram.parfor.stat.Stat;
 import org.apache.sysml.runtime.instructions.cp.Data;
 import org.apache.sysml.runtime.io.MatrixReader;
 import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
-import org.apache.sysml.runtime.matrix.mapred.MRConfigurationNames;
+import org.apache.sysml.runtime.matrix.mapred.MRProp;
 import org.apache.sysml.runtime.matrix.mapred.MRJobConfiguration;
 import org.apache.sysml.runtime.util.MapReduceTool;
 import org.apache.sysml.utils.Statistics;
@@ -182,7 +182,7 @@ public class RemoteParForMR
 				job.setNumTasksToExecutePerJvm(-1); //unlimited
 			
 			//set sort io buffer (reduce unnecessary large io buffer, guaranteed memory consumption)
-			job.setInt(MRConfigurationNames.MR_TASK_IO_SORT_MB, 8); //8MB
+			job.setInt(MRProp.MR_TASK_IO_SORT_MB, 8); //8MB
 			
 			//set the replication factor for the results
 			job.setInt("dfs.replication", replication);

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForMR.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForMR.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RunningJob;
 import org.apache.hadoop.mapred.SequenceFileOutputFormat;
 import org.apache.hadoop.mapred.lib.NLineInputFormat;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.conf.ConfigurationManager;
 import org.apache.sysml.conf.DMLConfig;
@@ -52,6 +51,7 @@ import org.apache.sysml.runtime.controlprogram.parfor.stat.Stat;
 import org.apache.sysml.runtime.instructions.cp.Data;
 import org.apache.sysml.runtime.io.MatrixReader;
 import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
+import org.apache.sysml.runtime.matrix.mapred.MRConfigurationNames;
 import org.apache.sysml.runtime.matrix.mapred.MRJobConfiguration;
 import org.apache.sysml.runtime.util.MapReduceTool;
 import org.apache.sysml.utils.Statistics;
@@ -182,7 +182,7 @@ public class RemoteParForMR
 				job.setNumTasksToExecutePerJvm(-1); //unlimited
 			
 			//set sort io buffer (reduce unnecessary large io buffer, guaranteed memory consumption)
-			job.setInt("mapreduce.task.io.sort.mb", 8); //8MB
+			job.setInt(MRConfigurationNames.MAPREDUCE_TASK_IO_SORT_MB, 8); //8MB
 			
 			//set the replication factor for the results
 			job.setInt("dfs.replication", replication);

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForMR.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForMR.java
@@ -51,7 +51,7 @@ import org.apache.sysml.runtime.controlprogram.parfor.stat.Stat;
 import org.apache.sysml.runtime.instructions.cp.Data;
 import org.apache.sysml.runtime.io.MatrixReader;
 import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
-import org.apache.sysml.runtime.matrix.mapred.MRProp;
+import org.apache.sysml.runtime.matrix.mapred.MRConfigurationNames;
 import org.apache.sysml.runtime.matrix.mapred.MRJobConfiguration;
 import org.apache.sysml.runtime.util.MapReduceTool;
 import org.apache.sysml.utils.Statistics;
@@ -182,7 +182,7 @@ public class RemoteParForMR
 				job.setNumTasksToExecutePerJvm(-1); //unlimited
 			
 			//set sort io buffer (reduce unnecessary large io buffer, guaranteed memory consumption)
-			job.setInt(MRProp.MR_TASK_IO_SORT_MB, 8); //8MB
+			job.setInt(MRConfigurationNames.MR_TASK_IO_SORT_MB, 8); //8MB
 			
 			//set the replication factor for the results
 			job.setInt("dfs.replication", replication);

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForMR.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForMR.java
@@ -182,7 +182,7 @@ public class RemoteParForMR
 				job.setNumTasksToExecutePerJvm(-1); //unlimited
 			
 			//set sort io buffer (reduce unnecessary large io buffer, guaranteed memory consumption)
-			job.setInt(MRConfigurationNames.MAPREDUCE_TASK_IO_SORT_MB, 8); //8MB
+			job.setInt(MRConfigurationNames.MR_TASK_IO_SORT_MB, 8); //8MB
 			
 			//set the replication factor for the results
 			job.setInt("dfs.replication", replication);

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForMR.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForMR.java
@@ -182,7 +182,7 @@ public class RemoteParForMR
 				job.setNumTasksToExecutePerJvm(-1); //unlimited
 			
 			//set sort io buffer (reduce unnecessary large io buffer, guaranteed memory consumption)
-			job.setInt("io.sort.mb", 8); //8MB
+			job.setInt("mapreduce.task.io.sort.mb", 8); //8MB
 			
 			//set the replication factor for the results
 			job.setInt("dfs.replication", replication);

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
@@ -265,7 +265,7 @@ public class InfrastructureAnalyzer
 		// Due to a bug in HDP related to fetching the "mode" of execution within mappers,
 		// we explicitly probe the relevant properties instead of relying on results from 
 		// analyzeHadoopCluster().
-		String jobTracker = job.get("mapreduce.jobtracker.address", "local");
+		String jobTracker = job.get(MRConfigurationNames.MAPREDUCE_JOBTRACKER_ADDRESS, "local");
 		String framework = job.get("mapreduce.framework.name", "local");
 		boolean isYarnEnabled = (framework!=null && framework.equals("yarn"));
 		
@@ -509,7 +509,7 @@ public class InfrastructureAnalyzer
 	{
 		JobConf job = ConfigurationManager.getCachedJobConf();
 		
-		_remoteMRSortMem = (1024*1024) * job.getLong("mapreduce.task.io.sort.mb",100); //1MB
+		_remoteMRSortMem = (1024*1024) * job.getLong(MRConfigurationNames.MAPREDUCE_TASK_IO_SORT_MB,100); //1MB
 			
 		//handle jvm max mem (map mem budget is relevant for map-side distcache and parfor)
 		//(for robustness we probe both: child and map configuration parameters)
@@ -546,7 +546,7 @@ public class InfrastructureAnalyzer
 	{
 		//analyze if local mode (if yarn enabled, we always assume cluster mode
 		//in order to workaround configuration issues on >=Hadoop 2.6)
-		String jobTracker = job.get("mapreduce.jobtracker.address", "local");
+		String jobTracker = job.get(MRConfigurationNames.MAPREDUCE_JOBTRACKER_ADDRESS, "local");
 		return "local".equals(jobTracker)
 			   & !isYarnEnabled();
 	}

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.mapred.ClusterStatus;
 import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.sysml.conf.ConfigurationManager;
-import org.apache.sysml.runtime.matrix.mapred.MRConfigurationNames;
+import org.apache.sysml.runtime.matrix.mapred.MRProp;
 
 /**
  * Central place for analyzing and obtaining static infrastructure properties
@@ -265,7 +265,7 @@ public class InfrastructureAnalyzer
 		// Due to a bug in HDP related to fetching the "mode" of execution within mappers,
 		// we explicitly probe the relevant properties instead of relying on results from 
 		// analyzeHadoopCluster().
-		String jobTracker = job.get(MRConfigurationNames.MR_JOBTRACKER_ADDRESS, "local");
+		String jobTracker = job.get(MRProp.MR_JOBTRACKER_ADDRESS, "local");
 		String framework = job.get("mapreduce.framework.name", "local");
 		boolean isYarnEnabled = (framework!=null && framework.equals("yarn"));
 		
@@ -509,7 +509,7 @@ public class InfrastructureAnalyzer
 	{
 		JobConf job = ConfigurationManager.getCachedJobConf();
 		
-		_remoteMRSortMem = (1024*1024) * job.getLong(MRConfigurationNames.MR_TASK_IO_SORT_MB,100); //1MB
+		_remoteMRSortMem = (1024*1024) * job.getLong(MRProp.MR_TASK_IO_SORT_MB,100); //1MB
 			
 		//handle jvm max mem (map mem budget is relevant for map-side distcache and parfor)
 		//(for robustness we probe both: child and map configuration parameters)
@@ -526,7 +526,7 @@ public class InfrastructureAnalyzer
 			_remoteJVMMaxMemReduce = extractMaxMemoryOpt(javaOpts1);
 		
 		//HDFS blocksize
-		String blocksize = job.get(MRConfigurationNames.DFS_BLOCK_SIZE, "134217728");
+		String blocksize = job.get(MRProp.DFS_BLOCKSIZE, "134217728");
 		_blocksize = Long.parseLong(blocksize);
 		
 		//is yarn enabled
@@ -546,7 +546,7 @@ public class InfrastructureAnalyzer
 	{
 		//analyze if local mode (if yarn enabled, we always assume cluster mode
 		//in order to workaround configuration issues on >=Hadoop 2.6)
-		String jobTracker = job.get(MRConfigurationNames.MR_JOBTRACKER_ADDRESS, "local");
+		String jobTracker = job.get(MRProp.MR_JOBTRACKER_ADDRESS, "local");
 		return "local".equals(jobTracker)
 			   & !isYarnEnabled();
 	}

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.mapred.ClusterStatus;
 import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.sysml.conf.ConfigurationManager;
-import org.apache.sysml.runtime.matrix.mapred.MRProp;
+import org.apache.sysml.runtime.matrix.mapred.MRConfigurationNames;
 
 /**
  * Central place for analyzing and obtaining static infrastructure properties
@@ -265,7 +265,7 @@ public class InfrastructureAnalyzer
 		// Due to a bug in HDP related to fetching the "mode" of execution within mappers,
 		// we explicitly probe the relevant properties instead of relying on results from 
 		// analyzeHadoopCluster().
-		String jobTracker = job.get(MRProp.MR_JOBTRACKER_ADDRESS, "local");
+		String jobTracker = job.get(MRConfigurationNames.MR_JOBTRACKER_ADDRESS, "local");
 		String framework = job.get("mapreduce.framework.name", "local");
 		boolean isYarnEnabled = (framework!=null && framework.equals("yarn"));
 		
@@ -509,7 +509,7 @@ public class InfrastructureAnalyzer
 	{
 		JobConf job = ConfigurationManager.getCachedJobConf();
 		
-		_remoteMRSortMem = (1024*1024) * job.getLong(MRProp.MR_TASK_IO_SORT_MB,100); //1MB
+		_remoteMRSortMem = (1024*1024) * job.getLong(MRConfigurationNames.MR_TASK_IO_SORT_MB,100); //1MB
 			
 		//handle jvm max mem (map mem budget is relevant for map-side distcache and parfor)
 		//(for robustness we probe both: child and map configuration parameters)
@@ -526,7 +526,7 @@ public class InfrastructureAnalyzer
 			_remoteJVMMaxMemReduce = extractMaxMemoryOpt(javaOpts1);
 		
 		//HDFS blocksize
-		String blocksize = job.get(MRProp.DFS_BLOCKSIZE, "134217728");
+		String blocksize = job.get(MRConfigurationNames.DFS_BLOCKSIZE, "134217728");
 		_blocksize = Long.parseLong(blocksize);
 		
 		//is yarn enabled
@@ -546,7 +546,7 @@ public class InfrastructureAnalyzer
 	{
 		//analyze if local mode (if yarn enabled, we always assume cluster mode
 		//in order to workaround configuration issues on >=Hadoop 2.6)
-		String jobTracker = job.get(MRProp.MR_JOBTRACKER_ADDRESS, "local");
+		String jobTracker = job.get(MRConfigurationNames.MR_JOBTRACKER_ADDRESS, "local");
 		return "local".equals(jobTracker)
 			   & !isYarnEnabled();
 	}

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
@@ -265,7 +265,7 @@ public class InfrastructureAnalyzer
 		// Due to a bug in HDP related to fetching the "mode" of execution within mappers,
 		// we explicitly probe the relevant properties instead of relying on results from 
 		// analyzeHadoopCluster().
-		String jobTracker = job.get("mapred.job.tracker", "local");
+		String jobTracker = job.get("mapreduce.jobtracker.address", "local");
 		String framework = job.get("mapreduce.framework.name", "local");
 		boolean isYarnEnabled = (framework!=null && framework.equals("yarn"));
 		
@@ -509,7 +509,7 @@ public class InfrastructureAnalyzer
 	{
 		JobConf job = ConfigurationManager.getCachedJobConf();
 		
-		_remoteMRSortMem = (1024*1024) * job.getLong("io.sort.mb",100); //1MB
+		_remoteMRSortMem = (1024*1024) * job.getLong("mapreduce.task.io.sort.mb",100); //1MB
 			
 		//handle jvm max mem (map mem budget is relevant for map-side distcache and parfor)
 		//(for robustness we probe both: child and map configuration parameters)
@@ -546,7 +546,7 @@ public class InfrastructureAnalyzer
 	{
 		//analyze if local mode (if yarn enabled, we always assume cluster mode
 		//in order to workaround configuration issues on >=Hadoop 2.6)
-		String jobTracker = job.get("mapred.job.tracker", "local");
+		String jobTracker = job.get("mapreduce.jobtracker.address", "local");
 		return "local".equals(jobTracker)
 			   & !isYarnEnabled();
 	}

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
@@ -265,7 +265,7 @@ public class InfrastructureAnalyzer
 		// Due to a bug in HDP related to fetching the "mode" of execution within mappers,
 		// we explicitly probe the relevant properties instead of relying on results from 
 		// analyzeHadoopCluster().
-		String jobTracker = job.get(MRConfigurationNames.MAPREDUCE_JOBTRACKER_ADDRESS, "local");
+		String jobTracker = job.get(MRConfigurationNames.MR_JOBTRACKER_ADDRESS, "local");
 		String framework = job.get("mapreduce.framework.name", "local");
 		boolean isYarnEnabled = (framework!=null && framework.equals("yarn"));
 		
@@ -509,7 +509,7 @@ public class InfrastructureAnalyzer
 	{
 		JobConf job = ConfigurationManager.getCachedJobConf();
 		
-		_remoteMRSortMem = (1024*1024) * job.getLong(MRConfigurationNames.MAPREDUCE_TASK_IO_SORT_MB,100); //1MB
+		_remoteMRSortMem = (1024*1024) * job.getLong(MRConfigurationNames.MR_TASK_IO_SORT_MB,100); //1MB
 			
 		//handle jvm max mem (map mem budget is relevant for map-side distcache and parfor)
 		//(for robustness we probe both: child and map configuration parameters)
@@ -546,7 +546,7 @@ public class InfrastructureAnalyzer
 	{
 		//analyze if local mode (if yarn enabled, we always assume cluster mode
 		//in order to workaround configuration issues on >=Hadoop 2.6)
-		String jobTracker = job.get(MRConfigurationNames.MAPREDUCE_JOBTRACKER_ADDRESS, "local");
+		String jobTracker = job.get(MRConfigurationNames.MR_JOBTRACKER_ADDRESS, "local");
 		return "local".equals(jobTracker)
 			   & !isYarnEnabled();
 	}

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MMCJMRCache.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MMCJMRCache.java
@@ -90,7 +90,7 @@ public abstract class MMCJMRCache
 	protected void constructLocalFilePrefix(String fname)
 	{
 		//get random localdir (to spread load across available disks)
-		String[] localDirs = _job.get("mapred.local.dir").split(",");
+		String[] localDirs = _job.get("mapreduce.cluster.local.dir").split(",");
 		Random rand = new Random();
 		int randPos = rand.nextInt(localDirs.length);
 				

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MMCJMRCache.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MMCJMRCache.java
@@ -90,7 +90,7 @@ public abstract class MMCJMRCache
 	protected void constructLocalFilePrefix(String fname)
 	{
 		//get random localdir (to spread load across available disks)
-		String[] localDirs = _job.get(MRConfigurationNames.MAPREDUCE_CLUSTER_LOCAL_DIR).split(",");
+		String[] localDirs = _job.get(MRConfigurationNames.MR_CLUSTER_LOCAL_DIR).split(",");
 		Random rand = new Random();
 		int randPos = rand.nextInt(localDirs.length);
 				

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MMCJMRCache.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MMCJMRCache.java
@@ -90,7 +90,7 @@ public abstract class MMCJMRCache
 	protected void constructLocalFilePrefix(String fname)
 	{
 		//get random localdir (to spread load across available disks)
-		String[] localDirs = _job.get(MRConfigurationNames.MR_CLUSTER_LOCAL_DIR).split(",");
+		String[] localDirs = _job.get(MRProp.MR_CLUSTER_LOCAL_DIR).split(",");
 		Random rand = new Random();
 		int randPos = rand.nextInt(localDirs.length);
 				

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MMCJMRCache.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MMCJMRCache.java
@@ -90,7 +90,7 @@ public abstract class MMCJMRCache
 	protected void constructLocalFilePrefix(String fname)
 	{
 		//get random localdir (to spread load across available disks)
-		String[] localDirs = _job.get(MRProp.MR_CLUSTER_LOCAL_DIR).split(",");
+		String[] localDirs = _job.get(MRConfigurationNames.MR_CLUSTER_LOCAL_DIR).split(",");
 		Random rand = new Random();
 		int randPos = rand.nextInt(localDirs.length);
 				

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MMCJMRCache.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MMCJMRCache.java
@@ -90,7 +90,7 @@ public abstract class MMCJMRCache
 	protected void constructLocalFilePrefix(String fname)
 	{
 		//get random localdir (to spread load across available disks)
-		String[] localDirs = _job.get("mapreduce.cluster.local.dir").split(",");
+		String[] localDirs = _job.get(MRConfigurationNames.MAPREDUCE_CLUSTER_LOCAL_DIR).split(",");
 		Random rand = new Random();
 		int randPos = rand.nextInt(localDirs.length);
 				

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRConfigurationNames.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRConfigurationNames.java
@@ -37,11 +37,11 @@ public abstract class MRConfigurationNames {
 	public static String DFS_BLOCK_SIZE = INVALID;
 	public static String DFS_METRICS_SESSION_ID = INVALID;
 	public static String DFS_PERMISSIONS = INVALID;
-	public static String MAPREDUCE_CLUSTER_LOCAL_DIR = INVALID;
-	public static String MAPREDUCE_JOBTRACKER_ADDRESS = INVALID;
-	public static String MAPREDUCE_JOBTRACKER_SYSTEM_DIR = INVALID;
-	public static String MAPREDUCE_TASK_IO_SORT_MB = INVALID;
-	public static String MAPREDUCE_TASKTRACKER_TASKCONTROLLER = INVALID;
+	public static String MR_CLUSTER_LOCAL_DIR = INVALID;
+	public static String MR_JOBTRACKER_ADDRESS = INVALID;
+	public static String MR_JOBTRACKER_SYSTEM_DIR = INVALID;
+	public static String MR_TASK_IO_SORT_MB = INVALID;
+	public static String MR_TASKTRACKER_TASKCONTROLLER = INVALID;
 
 	// initialize to currently used cluster
 	static {
@@ -58,22 +58,22 @@ public abstract class MRConfigurationNames {
 			DFS_BLOCK_SIZE = "dfs.blocksize";
 			DFS_METRICS_SESSION_ID = "dfs.metrics.session-id";
 			DFS_PERMISSIONS = "dfs.permissions.enabled";
-			MAPREDUCE_CLUSTER_LOCAL_DIR = "mapreduce.cluster.local.dir";
-			MAPREDUCE_JOBTRACKER_ADDRESS = "mapreduce.jobtracker.address";
-			MAPREDUCE_JOBTRACKER_SYSTEM_DIR = "mapreduce.jobtracker.system.dir";
-			MAPREDUCE_TASK_IO_SORT_MB = "mapreduce.task.io.sort.mb";
-			MAPREDUCE_TASKTRACKER_TASKCONTROLLER = "mapreduce.tasktracker.taskcontroller";
+			MR_CLUSTER_LOCAL_DIR = "mapreduce.cluster.local.dir";
+			MR_JOBTRACKER_ADDRESS = "mapreduce.jobtracker.address";
+			MR_JOBTRACKER_SYSTEM_DIR = "mapreduce.jobtracker.system.dir";
+			MR_TASK_IO_SORT_MB = "mapreduce.task.io.sort.mb";
+			MR_TASKTRACKER_TASKCONTROLLER = "mapreduce.tasktracker.taskcontroller";
 		} else // any older version
 		{
 			LOG.debug("Using hadoop 1.x configuration properties.");
 			DFS_BLOCK_SIZE = "dfs.block.size";
 			DFS_METRICS_SESSION_ID = "session.id";
 			DFS_PERMISSIONS = "dfs.permissions";
-			MAPREDUCE_CLUSTER_LOCAL_DIR = "mapred.local.dir";
-			MAPREDUCE_JOBTRACKER_ADDRESS = "mapred.job.tracker";
-			MAPREDUCE_JOBTRACKER_SYSTEM_DIR = "mapred.system.dir";
-			MAPREDUCE_TASK_IO_SORT_MB = "io.sort.mb";
-			MAPREDUCE_TASKTRACKER_TASKCONTROLLER = "mapred.task.tracker.task-controller";
+			MR_CLUSTER_LOCAL_DIR = "mapred.local.dir";
+			MR_JOBTRACKER_ADDRESS = "mapred.job.tracker";
+			MR_JOBTRACKER_SYSTEM_DIR = "mapred.system.dir";
+			MR_TASK_IO_SORT_MB = "io.sort.mb";
+			MR_TASKTRACKER_TASKCONTROLLER = "mapred.task.tracker.task-controller";
 		}
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRConfigurationNames.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRConfigurationNames.java
@@ -17,54 +17,63 @@
  * under the License.
  */
 
-
 package org.apache.sysml.runtime.matrix.mapred;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.util.VersionInfo;
 
-
 /**
- * This class provides a central local for used hadoop configuration properties.
- * For portability, we support both hadoop 1.x and 2.x and automatically map to 
- * the currently used cluster.
+ * This class provides a central local for used hadoop configuration properties. For portability, we support both hadoop
+ * 1.x and 2.x and automatically map to the currently used cluster.
  * 
  */
-public abstract class MRConfigurationNames 
-{
+public abstract class MRConfigurationNames {
 
-	
 	protected static final Log LOG = LogFactory.getLog(MRConfigurationNames.class.getName());
-	
-	//name definitions
-	public static final String INVALID = "null";
-	public static String DFS_SESSION_ID = INVALID;
-	public static String DFS_BLOCK_SIZE = INVALID;
-	public static String DFS_PERMISSIONS = INVALID;
 
-	//initialize to used cluster 
-	static{
-		
-		//determine hadoop version
-		//e.g., 2.0.4-alpha from 0a11e32419bd4070f28c6d96db66c2abe9fd6d91 by jenkins source checksum f3c1bf36ae3aa5a6f6d3447fcfadbba
+	// name definitions
+	public static final String INVALID = "null";
+	public static String DFS_BLOCK_SIZE = INVALID;
+	public static String DFS_METRICS_SESSION_ID = INVALID;
+	public static String DFS_PERMISSIONS = INVALID;
+	public static String MAPREDUCE_CLUSTER_LOCAL_DIR = INVALID;
+	public static String MAPREDUCE_JOBTRACKER_ADDRESS = INVALID;
+	public static String MAPREDUCE_JOBTRACKER_SYSTEM_DIR = INVALID;
+	public static String MAPREDUCE_TASK_IO_SORT_MB = INVALID;
+	public static String MAPREDUCE_TASKTRACKER_TASKCONTROLLER = INVALID;
+
+	// initialize to currently used cluster
+	static {
+
+		// determine hadoop version
+		// e.g., 2.0.4-alpha from 0a11e32419bd4070f28c6d96db66c2abe9fd6d91 by jenkins source checksum
+		// f3c1bf36ae3aa5a6f6d3447fcfadbba
 		String version = VersionInfo.getBuildVersion();
 		boolean hadoopVersion2 = version.startsWith("2");
-		LOG.debug("Hadoop build version: "+version);
-		
-		if( hadoopVersion2 )
-		{
+		LOG.debug("Hadoop build version: " + version);
+
+		if (hadoopVersion2) {
 			LOG.debug("Using hadoop 2.x configuration properties.");
-			DFS_SESSION_ID  = "dfs.metrics.session-id";
-			DFS_BLOCK_SIZE  = "dfs.blocksize";
+			DFS_BLOCK_SIZE = "dfs.blocksize";
+			DFS_METRICS_SESSION_ID = "dfs.metrics.session-id";
 			DFS_PERMISSIONS = "dfs.permissions.enabled";
-		}
-		else //any older version
+			MAPREDUCE_CLUSTER_LOCAL_DIR = "mapreduce.cluster.local.dir";
+			MAPREDUCE_JOBTRACKER_ADDRESS = "mapreduce.jobtracker.address";
+			MAPREDUCE_JOBTRACKER_SYSTEM_DIR = "mapreduce.jobtracker.system.dir";
+			MAPREDUCE_TASK_IO_SORT_MB = "mapreduce.task.io.sort.mb";
+			MAPREDUCE_TASKTRACKER_TASKCONTROLLER = "mapreduce.tasktracker.taskcontroller";
+		} else // any older version
 		{
 			LOG.debug("Using hadoop 1.x configuration properties.");
-			DFS_SESSION_ID  = "session.id";
-			DFS_BLOCK_SIZE  = "dfs.block.size";
+			DFS_BLOCK_SIZE = "dfs.block.size";
+			DFS_METRICS_SESSION_ID = "session.id";
 			DFS_PERMISSIONS = "dfs.permissions";
+			MAPREDUCE_CLUSTER_LOCAL_DIR = "mapred.local.dir";
+			MAPREDUCE_JOBTRACKER_ADDRESS = "mapred.job.tracker";
+			MAPREDUCE_JOBTRACKER_SYSTEM_DIR = "mapred.system.dir";
+			MAPREDUCE_TASK_IO_SORT_MB = "io.sort.mb";
+			MAPREDUCE_TASKTRACKER_TASKCONTROLLER = "mapred.task.tracker.task-controller";
 		}
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRConfigurationNames.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRConfigurationNames.java
@@ -28,9 +28,9 @@ import org.apache.hadoop.util.VersionInfo;
  * 1.x and 2.x and automatically map to the currently used cluster.
  * 
  */
-public abstract class MRProp {
+public abstract class MRConfigurationNames {
 
-	protected static final Log LOG = LogFactory.getLog(MRProp.class.getName());
+	protected static final Log LOG = LogFactory.getLog(MRConfigurationNames.class.getName());
 
 	public static final String DFS_BLOCKSIZE;
 	public static final String DFS_METRICS_SESSION_ID;

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
@@ -424,7 +424,7 @@ public class MRJobConfiguration
 			String uniqueSubdir = tmp.toString();
 			
 			//unique local dir
-			String[] dirlist = job.get(MRProp.MR_CLUSTER_LOCAL_DIR,"/tmp").split(",");
+			String[] dirlist = job.get(MRConfigurationNames.MR_CLUSTER_LOCAL_DIR,"/tmp").split(",");
 			StringBuilder sb2 = new StringBuilder();
 			for( String dir : dirlist ) {
 				if( sb2.length()>0 )
@@ -432,10 +432,10 @@ public class MRJobConfiguration
 				sb2.append(dir);
 				sb2.append( uniqueSubdir );
 			}
-			job.set(MRProp.MR_CLUSTER_LOCAL_DIR, sb2.toString() );
+			job.set(MRConfigurationNames.MR_CLUSTER_LOCAL_DIR, sb2.toString() );
 			
 			//unique system dir 
-			job.set(MRProp.MR_JOBTRACKER_SYSTEM_DIR, job.get(MRProp.MR_JOBTRACKER_SYSTEM_DIR) + uniqueSubdir);
+			job.set(MRConfigurationNames.MR_JOBTRACKER_SYSTEM_DIR, job.get(MRConfigurationNames.MR_JOBTRACKER_SYSTEM_DIR) + uniqueSubdir);
 			
 			//unique staging dir 
 			job.set( "mapreduce.jobtracker.staging.root.dir",  job.get("mapreduce.jobtracker.staging.root.dir") + uniqueSubdir );
@@ -444,12 +444,12 @@ public class MRJobConfiguration
 	
 	public static String getLocalWorkingDirPrefix(JobConf job)
 	{
-		return job.get(MRProp.MR_CLUSTER_LOCAL_DIR);
+		return job.get(MRConfigurationNames.MR_CLUSTER_LOCAL_DIR);
 	}
 	
 	public static String getSystemWorkingDirPrefix(JobConf job)
 	{
-		return job.get(MRProp.MR_JOBTRACKER_SYSTEM_DIR);
+		return job.get(MRConfigurationNames.MR_JOBTRACKER_SYSTEM_DIR);
 	}
 	
 	public static String getStagingWorkingDirPrefix(JobConf job)

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
@@ -424,7 +424,7 @@ public class MRJobConfiguration
 			String uniqueSubdir = tmp.toString();
 			
 			//unique local dir
-			String[] dirlist = job.get(MRConfigurationNames.MR_CLUSTER_LOCAL_DIR,"/tmp").split(",");
+			String[] dirlist = job.get(MRProp.MR_CLUSTER_LOCAL_DIR,"/tmp").split(",");
 			StringBuilder sb2 = new StringBuilder();
 			for( String dir : dirlist ) {
 				if( sb2.length()>0 )
@@ -432,10 +432,10 @@ public class MRJobConfiguration
 				sb2.append(dir);
 				sb2.append( uniqueSubdir );
 			}
-			job.set(MRConfigurationNames.MR_CLUSTER_LOCAL_DIR, sb2.toString() );
+			job.set(MRProp.MR_CLUSTER_LOCAL_DIR, sb2.toString() );
 			
 			//unique system dir 
-			job.set(MRConfigurationNames.MR_JOBTRACKER_SYSTEM_DIR, job.get(MRConfigurationNames.MR_JOBTRACKER_SYSTEM_DIR) + uniqueSubdir);
+			job.set(MRProp.MR_JOBTRACKER_SYSTEM_DIR, job.get(MRProp.MR_JOBTRACKER_SYSTEM_DIR) + uniqueSubdir);
 			
 			//unique staging dir 
 			job.set( "mapreduce.jobtracker.staging.root.dir",  job.get("mapreduce.jobtracker.staging.root.dir") + uniqueSubdir );
@@ -444,12 +444,12 @@ public class MRJobConfiguration
 	
 	public static String getLocalWorkingDirPrefix(JobConf job)
 	{
-		return job.get(MRConfigurationNames.MR_CLUSTER_LOCAL_DIR);
+		return job.get(MRProp.MR_CLUSTER_LOCAL_DIR);
 	}
 	
 	public static String getSystemWorkingDirPrefix(JobConf job)
 	{
-		return job.get(MRConfigurationNames.MR_JOBTRACKER_SYSTEM_DIR);
+		return job.get(MRProp.MR_JOBTRACKER_SYSTEM_DIR);
 	}
 	
 	public static String getStagingWorkingDirPrefix(JobConf job)

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
@@ -424,7 +424,7 @@ public class MRJobConfiguration
 			String uniqueSubdir = tmp.toString();
 			
 			//unique local dir
-			String[] dirlist = job.get("mapred.local.dir","/tmp").split(",");
+			String[] dirlist = job.get("mapreduce.cluster.local.dir","/tmp").split(",");
 			StringBuilder sb2 = new StringBuilder();
 			for( String dir : dirlist ) {
 				if( sb2.length()>0 )
@@ -432,10 +432,10 @@ public class MRJobConfiguration
 				sb2.append(dir);
 				sb2.append( uniqueSubdir );
 			}
-			job.set("mapred.local.dir", sb2.toString() );			
+			job.set("mapreduce.cluster.local.dir", sb2.toString() );
 			
 			//unique system dir 
-			job.set("mapred.system.dir", job.get("mapred.system.dir") + uniqueSubdir);
+			job.set("mapreduce.jobtracker.system.dir", job.get("mapreduce.jobtracker.system.dir") + uniqueSubdir);
 			
 			//unique staging dir 
 			job.set( "mapreduce.jobtracker.staging.root.dir",  job.get("mapreduce.jobtracker.staging.root.dir") + uniqueSubdir );
@@ -444,12 +444,12 @@ public class MRJobConfiguration
 	
 	public static String getLocalWorkingDirPrefix(JobConf job)
 	{
-		return job.get("mapred.local.dir");
+		return job.get("mapreduce.cluster.local.dir");
 	}
 	
 	public static String getSystemWorkingDirPrefix(JobConf job)
 	{
-		return job.get("mapred.system.dir");
+		return job.get("mapreduce.jobtracker.system.dir");
 	}
 	
 	public static String getStagingWorkingDirPrefix(JobConf job)

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
@@ -424,7 +424,7 @@ public class MRJobConfiguration
 			String uniqueSubdir = tmp.toString();
 			
 			//unique local dir
-			String[] dirlist = job.get(MRConfigurationNames.MAPREDUCE_CLUSTER_LOCAL_DIR,"/tmp").split(",");
+			String[] dirlist = job.get(MRConfigurationNames.MR_CLUSTER_LOCAL_DIR,"/tmp").split(",");
 			StringBuilder sb2 = new StringBuilder();
 			for( String dir : dirlist ) {
 				if( sb2.length()>0 )
@@ -432,10 +432,10 @@ public class MRJobConfiguration
 				sb2.append(dir);
 				sb2.append( uniqueSubdir );
 			}
-			job.set(MRConfigurationNames.MAPREDUCE_CLUSTER_LOCAL_DIR, sb2.toString() );
+			job.set(MRConfigurationNames.MR_CLUSTER_LOCAL_DIR, sb2.toString() );
 			
 			//unique system dir 
-			job.set(MRConfigurationNames.MAPREDUCE_JOBTRACKER_SYSTEM_DIR, job.get(MRConfigurationNames.MAPREDUCE_JOBTRACKER_SYSTEM_DIR) + uniqueSubdir);
+			job.set(MRConfigurationNames.MR_JOBTRACKER_SYSTEM_DIR, job.get(MRConfigurationNames.MR_JOBTRACKER_SYSTEM_DIR) + uniqueSubdir);
 			
 			//unique staging dir 
 			job.set( "mapreduce.jobtracker.staging.root.dir",  job.get("mapreduce.jobtracker.staging.root.dir") + uniqueSubdir );
@@ -444,12 +444,12 @@ public class MRJobConfiguration
 	
 	public static String getLocalWorkingDirPrefix(JobConf job)
 	{
-		return job.get(MRConfigurationNames.MAPREDUCE_CLUSTER_LOCAL_DIR);
+		return job.get(MRConfigurationNames.MR_CLUSTER_LOCAL_DIR);
 	}
 	
 	public static String getSystemWorkingDirPrefix(JobConf job)
 	{
-		return job.get(MRConfigurationNames.MAPREDUCE_JOBTRACKER_SYSTEM_DIR);
+		return job.get(MRConfigurationNames.MR_JOBTRACKER_SYSTEM_DIR);
 	}
 	
 	public static String getStagingWorkingDirPrefix(JobConf job)

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
@@ -424,7 +424,7 @@ public class MRJobConfiguration
 			String uniqueSubdir = tmp.toString();
 			
 			//unique local dir
-			String[] dirlist = job.get("mapreduce.cluster.local.dir","/tmp").split(",");
+			String[] dirlist = job.get(MRConfigurationNames.MAPREDUCE_CLUSTER_LOCAL_DIR,"/tmp").split(",");
 			StringBuilder sb2 = new StringBuilder();
 			for( String dir : dirlist ) {
 				if( sb2.length()>0 )
@@ -432,10 +432,10 @@ public class MRJobConfiguration
 				sb2.append(dir);
 				sb2.append( uniqueSubdir );
 			}
-			job.set("mapreduce.cluster.local.dir", sb2.toString() );
+			job.set(MRConfigurationNames.MAPREDUCE_CLUSTER_LOCAL_DIR, sb2.toString() );
 			
 			//unique system dir 
-			job.set("mapreduce.jobtracker.system.dir", job.get("mapreduce.jobtracker.system.dir") + uniqueSubdir);
+			job.set(MRConfigurationNames.MAPREDUCE_JOBTRACKER_SYSTEM_DIR, job.get(MRConfigurationNames.MAPREDUCE_JOBTRACKER_SYSTEM_DIR) + uniqueSubdir);
 			
 			//unique staging dir 
 			job.set( "mapreduce.jobtracker.staging.root.dir",  job.get("mapreduce.jobtracker.staging.root.dir") + uniqueSubdir );
@@ -444,12 +444,12 @@ public class MRJobConfiguration
 	
 	public static String getLocalWorkingDirPrefix(JobConf job)
 	{
-		return job.get("mapreduce.cluster.local.dir");
+		return job.get(MRConfigurationNames.MAPREDUCE_CLUSTER_LOCAL_DIR);
 	}
 	
 	public static String getSystemWorkingDirPrefix(JobConf job)
 	{
-		return job.get("mapreduce.jobtracker.system.dir");
+		return job.get(MRConfigurationNames.MAPREDUCE_JOBTRACKER_SYSTEM_DIR);
 	}
 	
 	public static String getStagingWorkingDirPrefix(JobConf job)

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRProp.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRProp.java
@@ -28,47 +28,41 @@ import org.apache.hadoop.util.VersionInfo;
  * 1.x and 2.x and automatically map to the currently used cluster.
  * 
  */
-public abstract class MRConfigurationNames {
+public abstract class MRProp {
 
-	protected static final Log LOG = LogFactory.getLog(MRConfigurationNames.class.getName());
+	protected static final Log LOG = LogFactory.getLog(MRProp.class.getName());
 
-	// name definitions
-	public static final String INVALID = "null";
-	public static String DFS_BLOCK_SIZE = INVALID;
-	public static String DFS_METRICS_SESSION_ID = INVALID;
-	public static String DFS_PERMISSIONS = INVALID;
-	public static String MR_CLUSTER_LOCAL_DIR = INVALID;
-	public static String MR_JOBTRACKER_ADDRESS = INVALID;
-	public static String MR_JOBTRACKER_SYSTEM_DIR = INVALID;
-	public static String MR_TASK_IO_SORT_MB = INVALID;
-	public static String MR_TASKTRACKER_TASKCONTROLLER = INVALID;
+	public static final String DFS_BLOCKSIZE;
+	public static final String DFS_METRICS_SESSION_ID;
+	public static final String DFS_PERMISSIONS_ENABLED;
+	public static final String MR_CLUSTER_LOCAL_DIR;
+	public static final String MR_JOBTRACKER_ADDRESS;
+	public static final String MR_JOBTRACKER_SYSTEM_DIR;
+	public static final String MR_TASK_IO_SORT_MB;
+	public static final String MR_TASKTRACKER_TASKCONTROLLER;
 
 	// initialize to currently used cluster
 	static {
-
 		// determine hadoop version
-		// e.g., 2.0.4-alpha from 0a11e32419bd4070f28c6d96db66c2abe9fd6d91 by jenkins source checksum
-		// f3c1bf36ae3aa5a6f6d3447fcfadbba
 		String version = VersionInfo.getBuildVersion();
 		boolean hadoopVersion2 = version.startsWith("2");
 		LOG.debug("Hadoop build version: " + version);
 
 		if (hadoopVersion2) {
 			LOG.debug("Using hadoop 2.x configuration properties.");
-			DFS_BLOCK_SIZE = "dfs.blocksize";
+			DFS_BLOCKSIZE = "dfs.blocksize";
 			DFS_METRICS_SESSION_ID = "dfs.metrics.session-id";
-			DFS_PERMISSIONS = "dfs.permissions.enabled";
+			DFS_PERMISSIONS_ENABLED = "dfs.permissions.enabled";
 			MR_CLUSTER_LOCAL_DIR = "mapreduce.cluster.local.dir";
 			MR_JOBTRACKER_ADDRESS = "mapreduce.jobtracker.address";
 			MR_JOBTRACKER_SYSTEM_DIR = "mapreduce.jobtracker.system.dir";
 			MR_TASK_IO_SORT_MB = "mapreduce.task.io.sort.mb";
 			MR_TASKTRACKER_TASKCONTROLLER = "mapreduce.tasktracker.taskcontroller";
-		} else // any older version
-		{
+		} else { // any older version
 			LOG.debug("Using hadoop 1.x configuration properties.");
-			DFS_BLOCK_SIZE = "dfs.block.size";
+			DFS_BLOCKSIZE = "dfs.block.size";
 			DFS_METRICS_SESSION_ID = "session.id";
-			DFS_PERMISSIONS = "dfs.permissions";
+			DFS_PERMISSIONS_ENABLED = "dfs.permissions";
 			MR_CLUSTER_LOCAL_DIR = "mapred.local.dir";
 			MR_JOBTRACKER_ADDRESS = "mapred.job.tracker";
 			MR_JOBTRACKER_SYSTEM_DIR = "mapred.system.dir";

--- a/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
+++ b/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 
 import org.apache.sysml.hops.OptimizerUtils;
-import org.apache.sysml.runtime.matrix.mapred.MRConfigurationNames;
+import org.apache.sysml.runtime.matrix.mapred.MRProp;
 
 /**
  * Central place for analyzing and obtaining static infrastructure properties
@@ -676,7 +676,7 @@ public class YarnClusterAnalyzer
 				throw new YarnException("There are no available nodes in the yarn cluster");
 			
 			// Now get the default cluster settings
-			_remoteMRSortMem = (1024*1024) * conf.getLong(MRConfigurationNames.MR_TASK_IO_SORT_MB,100); //100MB
+			_remoteMRSortMem = (1024*1024) * conf.getLong(MRProp.MR_TASK_IO_SORT_MB,100); //100MB
 
 			//handle jvm max mem (map mem budget is relevant for map-side distcache and parfor)
 			//(for robustness we probe both: child and map configuration parameters)
@@ -693,7 +693,7 @@ public class YarnClusterAnalyzer
 				_remoteJVMMaxMemReduce = extractMaxMemoryOpt(javaOpts1);
 			
 			//HDFS blocksize
-			String blocksize = conf.get(MRConfigurationNames.DFS_BLOCK_SIZE, "134217728");
+			String blocksize = conf.get(MRProp.DFS_BLOCKSIZE, "134217728");
 			_blocksize = Long.parseLong(blocksize);
 			
 			minimalPhyAllocate = (long) 1024 * 1024 * conf.getInt(YarnConfiguration.RM_SCHEDULER_MINIMUM_ALLOCATION_MB, 

--- a/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
+++ b/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
@@ -676,7 +676,7 @@ public class YarnClusterAnalyzer
 				throw new YarnException("There are no available nodes in the yarn cluster");
 			
 			// Now get the default cluster settings
-			_remoteMRSortMem = (1024*1024) * conf.getLong("io.sort.mb",100); //100MB
+			_remoteMRSortMem = (1024*1024) * conf.getLong("mapreduce.task.io.sort.mb",100); //100MB
 
 			//handle jvm max mem (map mem budget is relevant for map-side distcache and parfor)
 			//(for robustness we probe both: child and map configuration parameters)

--- a/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
+++ b/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 
 import org.apache.sysml.hops.OptimizerUtils;
-import org.apache.sysml.runtime.matrix.mapred.MRProp;
+import org.apache.sysml.runtime.matrix.mapred.MRConfigurationNames;
 
 /**
  * Central place for analyzing and obtaining static infrastructure properties
@@ -676,7 +676,7 @@ public class YarnClusterAnalyzer
 				throw new YarnException("There are no available nodes in the yarn cluster");
 			
 			// Now get the default cluster settings
-			_remoteMRSortMem = (1024*1024) * conf.getLong(MRProp.MR_TASK_IO_SORT_MB,100); //100MB
+			_remoteMRSortMem = (1024*1024) * conf.getLong(MRConfigurationNames.MR_TASK_IO_SORT_MB,100); //100MB
 
 			//handle jvm max mem (map mem budget is relevant for map-side distcache and parfor)
 			//(for robustness we probe both: child and map configuration parameters)
@@ -693,7 +693,7 @@ public class YarnClusterAnalyzer
 				_remoteJVMMaxMemReduce = extractMaxMemoryOpt(javaOpts1);
 			
 			//HDFS blocksize
-			String blocksize = conf.get(MRProp.DFS_BLOCKSIZE, "134217728");
+			String blocksize = conf.get(MRConfigurationNames.DFS_BLOCKSIZE, "134217728");
 			_blocksize = Long.parseLong(blocksize);
 			
 			minimalPhyAllocate = (long) 1024 * 1024 * conf.getInt(YarnConfiguration.RM_SCHEDULER_MINIMUM_ALLOCATION_MB, 

--- a/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
+++ b/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
@@ -676,7 +676,7 @@ public class YarnClusterAnalyzer
 				throw new YarnException("There are no available nodes in the yarn cluster");
 			
 			// Now get the default cluster settings
-			_remoteMRSortMem = (1024*1024) * conf.getLong("mapreduce.task.io.sort.mb",100); //100MB
+			_remoteMRSortMem = (1024*1024) * conf.getLong(MRConfigurationNames.MAPREDUCE_TASK_IO_SORT_MB,100); //100MB
 
 			//handle jvm max mem (map mem budget is relevant for map-side distcache and parfor)
 			//(for robustness we probe both: child and map configuration parameters)

--- a/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
+++ b/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
@@ -676,7 +676,7 @@ public class YarnClusterAnalyzer
 				throw new YarnException("There are no available nodes in the yarn cluster");
 			
 			// Now get the default cluster settings
-			_remoteMRSortMem = (1024*1024) * conf.getLong(MRConfigurationNames.MAPREDUCE_TASK_IO_SORT_MB,100); //100MB
+			_remoteMRSortMem = (1024*1024) * conf.getLong(MRConfigurationNames.MR_TASK_IO_SORT_MB,100); //100MB
 
 			//handle jvm max mem (map mem budget is relevant for map-side distcache and parfor)
 			//(for robustness we probe both: child and map configuration parameters)


### PR DESCRIPTION
Removes the console warnings from deprecated Hadoop properties.
MRConfigurationNames includes "constants" for both v1 and v2 of these properties.