### PR TITLE
Remove entry longer than 100 characters warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -513,6 +513,9 @@
 					<plugin>
 						<artifactId>maven-assembly-plugin</artifactId>
 						<version>2.4</version><!--$NO-MVN-MAN-VER$-->
+						<configuration>
+							<tarLongFileMode>gnu</tarLongFileMode>
+						</configuration>
 						<executions>
 							<execution>
 								<id>create-source-distribution-assembly</id>


### PR DESCRIPTION
During tar creation, the following warnings were generated:
[WARNING] Entry: ... longer than 100 characters.
Remove by setting tarLongFileMode to gnu for maven-assembly-plugin.