### PR TITLE
[SYSTEMML-480] [SYSTEMML-463] Fix Release Packaging

### DIFF
--- a/docs/Language Reference/README_HADOOP_CONFIG.txt
+++ b/docs/Language Reference/README_HADOOP_CONFIG.txt
@@ -1,7 +1,6 @@
 Usage
 -----
-The machine learning algorithms described in 
-$BIGINSIGHTS_HOME/machine-learning/docs/SystemML_Algorithms_Reference.pdf can be invoked
+The machine learning algorithms described in SystemML_Algorithms_Reference.pdf can be invoked
 from the hadoop command line using the described, algorithm-specific parameters. 
 
 Generic command line arguments arguments are provided by the help command below.
@@ -13,17 +12,14 @@ Recommended configurations
 --------------------------
 1) JVM Heap Sizes: 
 We recommend an equal-sized JVM configuration for clients, mappers, and reducers. For the client
-process this can be done via 
+process this can be done via
 
    export HADOOP_CLIENT_OPTS="-Xmx2048m -Xms2048m -Xmn256m" 
    
 where Xmx specifies the maximum heap size, Xms the initial heap size, and Xmn is size of the young 
 generation. For Xmn values of equal or less than 15% of the max heap size, we guarantee the memory budget.
 
-The above option may also be set through BigR setting the "ml.jvm" option, e.g.
-   bigr.set.server.option("jaql.fence.jvm.parameters", "-Xmx2g -Xms2g -Xmn256m")
-
-For mapper or reducer JVM configurations, the following properties can be specified in mapred-site.xml, 
+For mapper or reducer JVM configurations, the following properties can be specified in mapred-site.xml,
 where 'child' refers to both mapper and reducer. If map and reduce are specified individually, they take 
 precedence over the generic property.
 
@@ -58,8 +54,8 @@ behavior, we recommend to disable THP with
 Performance benefits from JVM reuse because data sets that fit into the mapper memory budget are 
 reused across tasks per slot. However, Hadoop 1.0.3 JVM Reuse is incompatible with security (when 
 using the LinuxTaskController). The workaround is to use the DefaultTaskController. SystemML provides 
-a configuration property in $BIGINSIGHTS_HOME/machine-learning/SystemML-config.xml to enable JVM reuse 
-on a per job level without changing the global cluster configuration. 
+a configuration property in SystemML-config.xml to enable JVM reuse on a per job level without
+changing the global cluster configuration.
    
    <jvmreuse>false</jvmreuse> 
    
@@ -67,8 +63,8 @@ on a per job level without changing the global cluster configuration.
 The number of reducers can have significant impact on performance. SystemML provides a configuration
 property to set the default number of reducers per job without changing the global cluster configuration.
 In general, we recommend a setting of twice the number of nodes. Smaller numbers create less intermediate
-files, larger numbers increase the degree of parallelism for compute and parallel write. In 
-$BIGINSIGHTS_HOME/machine-learning/SystemML-config.xml, set:
+files, larger numbers increase the degree of parallelism for compute and parallel write. In
+SystemML-config.xml, set:
    
    <!-- default number of reduce tasks per MR job, default: 2 x number of nodes -->
    <numreducers>12</numreducers> 
@@ -76,8 +72,8 @@ $BIGINSIGHTS_HOME/machine-learning/SystemML-config.xml, set:
 6) SystemML temporary directories:
 SystemML uses temporary directories in two different locations: (1) on local file system for temping from 
 the client process, and (2) on HDFS for intermediate results between different MR jobs and between MR jobs 
-and in-memory operations. Locations of these directories can be configured in 
-$BIGINSIGHTS_HOME/machine-learning/SystemML-config.xml with the following properties
+and in-memory operations. Locations of these directories can be configured in SystemML-config.xml with the
+following properties:
 
    <!-- local fs tmp working directory-->
    <localtmpdir>/tmp/systemml</localtmpdir>

--- a/pom.xml
+++ b/pom.xml
@@ -531,7 +531,7 @@
 							</execution>
 
 							<execution>
-								<id>create-binary-distribution-assembly</id>
+								<id>create-binary-cluster-distribution-assembly</id>
 								<phase>package</phase>
 								<goals>
 									<goal>single</goal>
@@ -540,7 +540,7 @@
 									<descriptors>
 										<descriptor>src/assembly/distrib.xml</descriptor>
 									</descriptors>
-									<appendAssemblyId>false</appendAssemblyId>
+									<!--<appendAssemblyId>false</appendAssemblyId>-->
 								</configuration>
 							</execution>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,10 @@
 	</parent>
 	<groupId>org.apache.systemml</groupId>
 	<version>0.10.0-incubating-SNAPSHOT</version>
-	<artifactId>system-ml</artifactId>
+	<artifactId>systemml</artifactId>
 	<packaging>jar</packaging>
 	<name>SystemML</name>
-	<description>Declarative machine learning</description>
+	<description>Declarative Machine Learning</description>
 	<url>http://systemml.apache.org/</url>
 	<licenses>
 		<license>
@@ -540,7 +540,7 @@
 									<descriptors>
 										<descriptor>src/assembly/distrib.xml</descriptor>
 									</descriptors>
-									<!--<appendAssemblyId>false</appendAssemblyId>-->
+									<appendAssemblyId>false</appendAssemblyId>
 								</configuration>
 							</execution>
 

--- a/pom.xml
+++ b/pom.xml
@@ -545,6 +545,25 @@
 							</execution>
 
 							<execution>
+								<id>create-standalone-jar</id>
+								<phase>package</phase>
+								<goals>
+									<goal>single</goal>
+								</goals>
+								<configuration>
+									<descriptors>
+										<descriptor>src/assembly/standalone-jar.xml</descriptor>
+									</descriptors>
+									<archive>
+										<index>true</index>
+										<manifest>
+											<mainClass>org.apache.sysml.api.DMLScript</mainClass>
+										</manifest>
+									</archive>
+								</configuration>
+							</execution>
+
+							<execution>
 								<id>create-binary-standalone-distribution-assembly</id>
 								<phase>package</phase>
 								<goals>

--- a/src/assembly/distrib.xml
+++ b/src/assembly/distrib.xml
@@ -22,7 +22,7 @@
 		xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 	<!-- Assembly file for the "distributed" SystemML release for running on a
 		cluster with Spark or Hadoop. -->
-	<id>cluster</id>
+	<id>distrib</id>
 
 	<formats>
 		<format>tar.gz</format>
@@ -30,7 +30,7 @@
 	</formats>
 
 	<includeBaseDirectory>true</includeBaseDirectory>
-	<baseDirectory>system-ml-${version}-cluster</baseDirectory>
+	<baseDirectory>${artifactId}-${version}</baseDirectory>
 
 	<fileSets>
 		<fileSet>

--- a/src/assembly/distrib.xml
+++ b/src/assembly/distrib.xml
@@ -22,7 +22,7 @@
 		xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 	<!-- Assembly file for the "distributed" SystemML release for running on a
 		cluster with Spark or Hadoop. -->
-	<id>distrib</id>
+	<id>cluster</id>
 
 	<formats>
 		<format>tar.gz</format>
@@ -30,7 +30,7 @@
 	</formats>
 
 	<includeBaseDirectory>true</includeBaseDirectory>
-	<baseDirectory>system-ml-${version}</baseDirectory>
+	<baseDirectory>system-ml-${version}-cluster</baseDirectory>
 
 	<fileSets>
 		<fileSet>

--- a/src/assembly/distrib.xml
+++ b/src/assembly/distrib.xml
@@ -17,15 +17,18 @@
  * under the License.
 -->
 <assembly
-	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+		xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	<!-- Assembly file for the "distributed" SystemML release for running on a
+		cluster with Spark or Hadoop. -->
 	<id>distrib</id>
+
 	<formats>
 		<format>tar.gz</format>
 		<format>zip</format>
 	</formats>
-	
+
 	<includeBaseDirectory>true</includeBaseDirectory>
 	<baseDirectory>system-ml-${version}</baseDirectory>
 
@@ -37,7 +40,7 @@
 			</includes>
 			<outputDirectory>.</outputDirectory>
 		</fileSet>
-		
+
 		<fileSet>
 			<directory>${basedir}/scripts</directory>
 			<includes>
@@ -84,8 +87,8 @@
 			</includes>
 			<outputDirectory>./algorithms</outputDirectory>
 		</fileSet>
-    
-    <fileSet>
+
+		<fileSet>
 			<directory>${basedir}/scripts/utils</directory>
 			<includes>
 				<include>cbind.dml</include>
@@ -101,40 +104,23 @@
 			</includes>
 			<outputDirectory>./algorithms/utils</outputDirectory>
 		</fileSet>
-		
+
 		<fileSet>
-			<directory>${basedir}/docs/Language Reference</directory>
+			<directory>${basedir}</directory>
 			<includes>
-				<include>SystemML_Language_Reference.html</include>
-				<include>README.txt</include>
+				<include>DISCLAIMER</include>
+				<include>LICENSE</include>
+				<include>NOTICE</include>
 			</includes>
-			<outputDirectory>./docs</outputDirectory>
-		</fileSet>
-		
-		<fileSet>
-			<directory>${basedir}/docs/Algorithms Reference</directory>
-			<includes>
-				<include>SystemML_Algorithms_Reference.pdf</include>
-			</includes>
-			<outputDirectory>./docs</outputDirectory>
+			<outputDirectory>.</outputDirectory>
 		</fileSet>
 	</fileSets>
-	
+
 	<files>
 		<file>
 			<source>target/${artifactId}-${project.version}.jar</source>
 			<outputDirectory>.</outputDirectory>
 			<destName>SystemML.jar</destName>
-		</file>
-		<file>
-			<source>LICENSE</source>
-			<outputDirectory>.</outputDirectory>
-			<destName>LICENSE</destName>
-		</file>
-		<file>
-			<source>NOTICE</source>
-			<outputDirectory>.</outputDirectory>
-			<destName>NOTICE</destName>
 		</file>
 	</files>
 </assembly>

--- a/src/assembly/source.xml
+++ b/src/assembly/source.xml
@@ -20,6 +20,7 @@
         xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <!-- Assembly file for the "source" SystemML release containing all source files. -->
     <id>src</id>
     <formats>
         <format>tar.gz</format>
@@ -28,7 +29,6 @@
 
     <includeBaseDirectory>true</includeBaseDirectory>
     <baseDirectory>system-ml-${version}-src</baseDirectory>
-
 
     <fileSets>
         <fileSet>
@@ -54,5 +54,4 @@
             </excludes>
         </fileSet>
     </fileSets>
-
 </assembly>

--- a/src/assembly/source.xml
+++ b/src/assembly/source.xml
@@ -28,7 +28,7 @@
     </formats>
 
     <includeBaseDirectory>true</includeBaseDirectory>
-    <baseDirectory>system-ml-${version}-src</baseDirectory>
+    <baseDirectory>${artifactId}-${version}-src</baseDirectory>
 
     <fileSets>
         <fileSet>

--- a/src/assembly/standalone-jar.xml
+++ b/src/assembly/standalone-jar.xml
@@ -1,0 +1,89 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+<assembly
+		xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	<!-- Assembly file for the "in-memory" SystemML release. -->
+	<id>standalone</id>
+
+	<formats>
+		<format>jar</format>
+	</formats>
+
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.directory}/hadoop-test</directory>
+			<includes>
+				<include>**/*</include>
+			</includes>
+			<outputDirectory>.</outputDirectory>
+		</fileSet>
+
+		<fileSet>
+			<directory>${basedir}/src/main/standalone</directory>
+			<includes>
+				<include>log4j.properties</include>
+			</includes>
+			<outputDirectory>.</outputDirectory>
+		</fileSet>
+	</fileSets>
+
+	<!-- Include all the libraries needed to run in standalone mode. -->
+	<dependencySets>
+		<dependencySet>
+			<includes>
+				<include>*:JSON4J*</include>
+				<include>*:antlr*</include>
+			</includes>
+			<scope>compile</scope>
+			<unpack>true</unpack>
+		</dependencySet>
+
+		<dependencySet>
+			<includes>
+				<include>*:avro*</include>
+				<include>*:commons-math3*</include>
+				<include>*:log4j*</include>
+				<include>*:opencsv*</include>
+				<include>*:hadoop-auth*</include>
+				<include>*:hadoop-client*</include>
+				<include>*:hadoop-common*</include>
+				<include>*:hadoop-hdfs*</include>
+				<include>*:hadoop-mapreduce-client*</include>
+				<include>*:hadoop-yarn*</include>
+				<include>*:commons-configuration*</include>
+				<include>*:commons-lang</include>
+				<include>*:commons-logging*</include>
+				<include>*:commons-httpclient*</include>
+				<include>*:commons-cli*</include>
+				<include>*:commons-collections*</include>
+				<include>*:jackson-core-asl*</include>
+				<include>*:jackson-mapper-asl*</include>
+				<include>*:slf4j-api*</include>
+				<include>*:slf4j-log4j*</include>
+				<include>*:system-ml*</include>
+			</includes>
+			<scope>provided</scope>
+			<unpack>true</unpack>
+		</dependencySet>
+	</dependencySets>
+</assembly>

--- a/src/assembly/standalone-jar.xml
+++ b/src/assembly/standalone-jar.xml
@@ -51,7 +51,7 @@
 	<dependencySets>
 		<dependencySet>
 			<includes>
-				<include>*:JSON4J*</include>
+				<include>*:wink-json4j*</include>
 				<include>*:antlr*</include>
 			</includes>
 			<scope>compile</scope>
@@ -80,7 +80,7 @@
 				<include>*:jackson-mapper-asl*</include>
 				<include>*:slf4j-api*</include>
 				<include>*:slf4j-log4j*</include>
-				<include>*:system-ml*</include>
+				<include>*:${artifactId}*</include>
 			</includes>
 			<scope>provided</scope>
 			<unpack>true</unpack>

--- a/src/assembly/standalone.xml
+++ b/src/assembly/standalone.xml
@@ -17,13 +17,11 @@
  * under the License.
 -->
 <assembly
-	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-
+		xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 	<!-- Assembly file for the "standalone" SystemML release for running on a
 		standalone machine. -->
-
 	<id>standalone</id>
 
 	<formats>
@@ -35,23 +33,6 @@
 	<baseDirectory>system-ml-${version}-standalone</baseDirectory>
 
 	<fileSets>
-		<fileSet>
-			<directory>${basedir}/src/assembly/standalone</directory>
-			<includes>
-				<include>LICENSE</include>
-				<include>NOTICE</include>
-			</includes>
-			<outputDirectory>.</outputDirectory>
-		</fileSet>
-
-		<fileSet>
-			<directory>${basedir}</directory>
-			<includes>
-				<include>SystemML-config.xml</include>
-			</includes>
-			<outputDirectory>.</outputDirectory>
-		</fileSet>
-
 		<fileSet>
 			<directory>${basedir}/scripts/algorithms</directory>
 			<includes>
@@ -90,16 +71,16 @@
 			</includes>
 			<outputDirectory>./scripts/algorithms</outputDirectory>
 		</fileSet>
-		
+
 		<fileSet>
 			<directory>${basedir}/scripts/datagen</directory>
 			<includes>
 				<include>genLinearRegressionData.dml</include>
 			</includes>
 			<outputDirectory>./scripts/datagen</outputDirectory>
-		</fileSet>	
-    
-    <fileSet>
+		</fileSet>
+
+		<fileSet>
 			<directory>${basedir}/scripts/utils</directory>
 			<includes>
 				<include>cbind.dml</include>
@@ -115,23 +96,6 @@
 		</fileSet>
 
 		<fileSet>
-			<directory>${basedir}/docs/Language Reference</directory>
-			<includes>
-				<include>SystemML_Language_Reference.html</include>
-				<include>README.txt</include>
-			</includes>
-			<outputDirectory>./docs</outputDirectory>
-		</fileSet>
-
-		<fileSet>
-			<directory>${basedir}/docs/Algorithms Reference</directory>
-			<includes>
-				<include>SystemML_Algorithms_Reference.pdf</include>
-			</includes>
-			<outputDirectory>./docs</outputDirectory>
-		</fileSet>
-
-		<fileSet>
 			<directory>${basedir}/src/main/standalone</directory>
 			<includes>
 				<include>log4j.properties</include>
@@ -140,7 +104,7 @@
 			</includes>
 			<outputDirectory>.</outputDirectory>
 		</fileSet>
-		
+
 		<fileSet>
 			<directory>${basedir}/src/test/config/hadoop_bin_windows/bin</directory>
 			<includes>
@@ -148,7 +112,7 @@
 			</includes>
 			<outputDirectory>./lib/hadoop/bin</outputDirectory>
 		</fileSet>
-		
+
 		<!--  Make scripts executable. -->
 		<fileSet>
 			<directory>${basedir}/src/main/standalone</directory>
@@ -159,22 +123,35 @@
 			<outputDirectory>.</outputDirectory>
 			<fileMode>0755</fileMode>
 		</fileSet>
+
+		<fileSet>
+			<directory>${basedir}/src/assembly/standalone</directory>
+			<includes>
+				<include>LICENSE</include>
+				<include>NOTICE</include>
+			</includes>
+			<outputDirectory>.</outputDirectory>
+		</fileSet>
+
+		<fileSet>
+			<directory>${basedir}</directory>
+			<includes>
+				<include>DISCLAIMER</include>
+			</includes>
+			<outputDirectory>.</outputDirectory>
+		</fileSet>
 	</fileSets>
 
-	<!-- 
-	<files>
+	<!--files>
 		<file>
-			<source>target/${artifactId}-${project.version}.jar</source>
+			<source>target/${artifactId}-${project.version}-standalone.jar</source>
 			<outputDirectory>.</outputDirectory>
-			<destName>SystemML.jar</destName> 
+			<destName>SystemML-standalone.jar</destName>
 		</file>
-	</files>
-	-->
-	
-	<!--  Include all the libraries needed to run in standalone mode. -->
-	
+	</files-->
+
+	<!-- Include all the libraries needed to run in standalone mode. -->
 	<dependencySets>
-	
 		<dependencySet>
 			<includes>
 				<include>*:JSON4J*</include>
@@ -183,7 +160,7 @@
 			<outputDirectory>./lib</outputDirectory>
 			<scope>compile</scope>
 		</dependencySet>
-	
+
 		<dependencySet>
 			<includes>
 				<include>*:avro*</include>
@@ -212,5 +189,4 @@
 			<scope>provided</scope>
 		</dependencySet>
 	</dependencySets>
-
 </assembly>

--- a/src/assembly/standalone.xml
+++ b/src/assembly/standalone.xml
@@ -30,7 +30,7 @@
 	</formats>
 
 	<includeBaseDirectory>true</includeBaseDirectory>
-	<baseDirectory>system-ml-${version}-standalone</baseDirectory>
+	<baseDirectory>${artifactId}-${version}-standalone</baseDirectory>
 
 	<fileSets>
 		<fileSet>
@@ -154,7 +154,7 @@
 	<dependencySets>
 		<dependencySet>
 			<includes>
-				<include>*:JSON4J*</include>
+				<include>*:wink-json4j*</include>
 				<include>*:antlr*</include>
 			</includes>
 			<outputDirectory>./lib</outputDirectory>
@@ -183,7 +183,7 @@
 				<include>*:jackson-mapper-asl*</include>
 				<include>*:slf4j-api*</include>
 				<include>*:slf4j-log4j*</include>
-				<include>*:system-ml*</include>
+				<include>*:${artifactId}*</include>
 			</includes>
 			<outputDirectory>./lib</outputDirectory>
 			<scope>provided</scope>

--- a/src/main/standalone/log4j.properties
+++ b/src/main/standalone/log4j.properties
@@ -280,5 +280,5 @@ log4j.logger.org.apache.hadoop.mapred.JobInProgress$JobSummary=${hadoop.mapreduc
 log4j.additivity.org.apache.hadoop.mapred.JobInProgress$JobSummary=false
 
 // setup of the logging level for various components
-log4j.logger.org.apache.hadoop=WARN
-log4j.logger.org.apache.hadoop.conf.Configuration.deprecation=WARN
+log4j.logger.org.apache.hadoop=ERROR
+log4j.logger.org.apache.hadoop.conf.Configuration.deprecation=ERROR


### PR DESCRIPTION
This cleans up and adds missing files to the release packaging, removes outdated documentation from the releases, cleans up an old readme file, and adds the ability to create a standalone JAR.  With regards to the latter item, we can also explore replacing the `lib` folder of dependency JARs with this new, single standalone JAR file at some point in the near future.