### PR TITLE
[SYSTEMML-495] Simplify SystemML Configuration Loading

### DIFF
--- a/src/main/java/org/apache/sysml/api/DMLScript.java
+++ b/src/main/java/org/apache/sysml/api/DMLScript.java
@@ -295,8 +295,10 @@ public class DMLScript
 					if( rtplatform==null ) 
 						return ret;
 				}
-				else if (args[i].startsWith("-config="))
-					fnameOptConfig = args[i].substring(8).replaceAll("\"", ""); 
+				else if (args[i].startsWith("-config=")) // legacy
+					fnameOptConfig = args[i].substring(8).replaceAll("\"", "");
+				else if (args[i].equalsIgnoreCase("-config"))
+					fnameOptConfig = args[++i];
 				else if( args[i].equalsIgnoreCase("-debug") ) {					
 					ENABLE_DEBUG_MODE = true;
 				}
@@ -570,12 +572,12 @@ public class DMLScript
 		printStartExecInfo( dmlScriptStr );
 		
 		//Step 1: parse configuration files
-		DMLConfig dmlconf = DMLConfig.readAndMergeConfigurationFiles(fnameOptConfig);
+		DMLConfig dmlconf = DMLConfig.readConfigurationFile(fnameOptConfig);
 		ConfigurationManager.setGlobalConfig(dmlconf);		
 		CompilerConfig cconf = OptimizerUtils.constructCompilerConfig(dmlconf);
 		ConfigurationManager.setGlobalConfig(cconf);
 		LOG.debug("\nDML config: \n" + dmlconf.getConfigInfo());
-		
+
 		//Step 2: set local/remote memory if requested (for compile in AM context) 
 		if( dmlconf.getBooleanValue(DMLConfig.YARN_APPMASTER) ){
 			DMLAppMasterUtils.setupConfigRemoteMaxMemory(dmlconf); 
@@ -715,9 +717,9 @@ public class DMLScript
 		DMLDebuggerProgramInfo dbprog = new DMLDebuggerProgramInfo();
 		
 		//Step 1: parse configuration files
-		DMLConfig conf = DMLConfig.readAndMergeConfigurationFiles(fnameOptConfig);
+		DMLConfig conf = DMLConfig.readConfigurationFile(fnameOptConfig);
 		ConfigurationManager.setGlobalConfig(conf);
-	
+
 		//Step 2: parse dml script
 		AParserWrapper parser = AParserWrapper.createParser(parsePyDML);
 		DMLProgram prog = parser.parse(DML_FILE_PATH_ANTLR_PARSER, dmlScriptStr, argVals);
@@ -947,7 +949,7 @@ public class DMLScript
 		try
 		{
 			//read the default config
-			DMLConfig conf = DMLConfig.readAndMergeConfigurationFiles(null);
+			DMLConfig conf = DMLConfig.readConfigurationFile(null);
 			
 			//run cleanup job to clean remote local tmp dirs
 			CleanupMR.runJob(conf);

--- a/src/main/java/org/apache/sysml/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysml/conf/DMLConfig.java
@@ -180,7 +180,7 @@ public class DMLConfig
 			} // end if (otherConfigNodeList != null && otherConfigNodeList.getLength() > 0){
 		} catch (Exception e){
 			LOG.error("Failed in merge default config file with optional config file",e);
-			throw new ParseException("ERROR: error merging config file" + otherConfig._fileName + " with " + _fileName);
+			throw new ParseException("ERROR: error merging config file " + otherConfig._fileName + " with " + _fileName);
 		}
 	}
 	
@@ -388,10 +388,10 @@ public class DMLConfig
 	}
 	
 	/**
-	 * Read the specified configuration file.  If it is not explicitly
-	 * given, then fallback to the default configuration file location.
-	 * If that is also not present, then fallback to the internal
-	 * defaults.
+	 * Start with the internal default settings, then merge in the
+	 * settings from any specified configuration file, if available.
+	 * If it is not explicitly given, then merge in settings from
+	 * the default configuration file location, if available.
 	 *
 	 * @param configPath User-defined path of the configuration file.
 	 * @return DMLConfig object containing configuration settings.
@@ -401,27 +401,26 @@ public class DMLConfig
 	public static DMLConfig readConfigurationFile(String configPath)
 		throws ParseException, FileNotFoundException
 	{
-		DMLConfig config = null;
+		// Always start with the internal defaults
+		DMLConfig config = new DMLConfig();
 
-		// try to read the explicitly specified config
+		// Merge in any specified or default configs if available
 		if (configPath != null) {
+			// specified
 			try {
 				config = new DMLConfig(configPath, false);
 			} catch (FileNotFoundException fnfe) {
-				LOG.error("Config file " + configPath + " not found.");
+				LOG.error("Custom config file " + configPath + " not found.");
 				throw fnfe;
 			} catch (ParseException e) {
 				throw e;
 			}
-		} else { // otherwise, look in the default location
+		} else {
+			// default
 			try {
 				config = new DMLConfig(DEFAULT_SYSTEMML_CONFIG_FILEPATH, false);
 			} catch (FileNotFoundException fnfe) {
-				// if no default file was found either, fallback to
-				// the internal defaults.
-				LOG.warn("No SystemML config file supplied, and no default config file " +
-				         "(" + DEFAULT_SYSTEMML_CONFIG_FILEPATH + ") found. " +
-				         "Using internal default settings in DMLConfig.  If you wish to " +
+				LOG.info("Using internal default configuration settings.  If you wish to " +
 						 "customize any settings, please supply a `SystemML-config.xml` file.");
 				config = new DMLConfig();
 			} catch (ParseException e) {

--- a/src/main/java/org/apache/sysml/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysml/conf/DMLConfig.java
@@ -388,64 +388,47 @@ public class DMLConfig
 	}
 	
 	/**
-	 * 
-	 * @return
+	 * Read the specified configuration file.  If it is not explicitly
+	 * given, then fallback to the default configuration file location.
+	 * If that is also not present, then fallback to the internal
+	 * defaults.
+	 *
+	 * @param configPath User-defined path of the configuration file.
+	 * @return DMLConfig object containing configuration settings.
 	 * @throws ParseException 
 	 * @throws FileNotFoundException 
 	 */
-	public static DMLConfig readAndMergeConfigurationFiles( String optConfig ) 
+	public static DMLConfig readConfigurationFile(String configPath)
 		throws ParseException, FileNotFoundException
 	{
-		// optional config specified overwrites/merge into the default config
-		DMLConfig defaultConfig = null;
-		DMLConfig optionalConfig = null;
-		
-		if( optConfig != null ) { // the optional config is specified
-			try { // try to get the default config first 
-				defaultConfig = new DMLConfig(DEFAULT_SYSTEMML_CONFIG_FILEPATH, true);
-			} catch (FileNotFoundException fnfe) { // it is OK to not have the default, but give a warning
-				LOG.warn("No default SystemML config file (" + DEFAULT_SYSTEMML_CONFIG_FILEPATH + ") found");
-			} catch (ParseException e) {
-				defaultConfig = null;
-				throw e;
-			}
-			try { // try to get the optional config next
-				optionalConfig = new DMLConfig(optConfig, false);
+		DMLConfig config = null;
+
+		// try to read the explicitly specified config
+		if (configPath != null) {
+			try {
+				config = new DMLConfig(configPath, false);
 			} catch (FileNotFoundException fnfe) {
-				LOG.error("Config file " + optConfig + " not found");
+				LOG.error("Config file " + configPath + " not found.");
 				throw fnfe;
 			} catch (ParseException e) {
-				optionalConfig = null;
 				throw e;
 			}
-			if (defaultConfig != null) {
-				try {
-					defaultConfig.merge(optionalConfig);
-				}
-				catch(ParseException e){
-					defaultConfig = null;
-					throw e;
-				}
-			}
-			else {
-				defaultConfig = optionalConfig;
-			}
-		}
-		else { // the optional config is not specified
-			try { // try to get the default config 
-				defaultConfig = new DMLConfig(DEFAULT_SYSTEMML_CONFIG_FILEPATH, false);
-			} catch (FileNotFoundException fnfe) { // it is OK to not have the default, but give a warning
-				LOG.warn("No default SystemML config file (" + DEFAULT_SYSTEMML_CONFIG_FILEPATH + ") found");
-				LOG.warn("Using default settings in DMLConfig");
-				DMLConfig dmlConfig = new DMLConfig();
-				return dmlConfig;
-			} catch (ParseException e) { 
-				defaultConfig = null;
+		} else { // otherwise, look in the default location
+			try {
+				config = new DMLConfig(DEFAULT_SYSTEMML_CONFIG_FILEPATH, false);
+			} catch (FileNotFoundException fnfe) {
+				// if no default file was found either, fallback to
+				// the internal defaults.
+				LOG.warn("No SystemML config file supplied, and no default config file " +
+				         "(" + DEFAULT_SYSTEMML_CONFIG_FILEPATH + ") found. " +
+				         "Using internal default settings in DMLConfig.  If you wish to " +
+						 "customize any settings, please supply a `SystemML-config.xml` file.");
+				config = new DMLConfig();
+			} catch (ParseException e) {
 				throw e;
 			}
 		}
-		
-		return defaultConfig;
+		return config;
 	}
 
 	/**


### PR DESCRIPTION
Currently, SystemML always looks for a configuration file in a default location (in the current directory), and will always emit a warning if it is not found.  Additionally, SystemML allows a user to supply a configuration file location.  In this latter case, SystemML will still attempt to read the default configuration file, emitting a warning if it is not present (which causes confusion), as well as the user-supplied file.  If both are loaded, the user-supplied file will be merged into the default configuration with an overwrite strategy.

Always looking for a default file, even when a file is explicitly supplied, causes confusion, and may create unintended side effects.  If a user explicitly supplies a configuration file, we should simply use that file, rather than attempting to also read an additional default file at the same time.  In order to provide backwards compatibility, if the user does not supply a file, then we should fall back to the default file location.  If that file is also not found, we should then fall back to the internal defaults.  Note that this means that the configuration settings of a user-supplied file will *not* be merged with those of a default file, assuming both are found.

Additionally, in order to supply an additional configuration file, the `-config=path/to/file` flag has to be used, and it only works with the equals sign `=` present, which is unlike all other flags that use spaces.  Instead, we should support `-config path/to/file`.