### PR TITLE
Remove user mailing list ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 # SystemML
 
 **Documentation:** [SystemML Documentation](http://apache.github.io/incubator-systemml/)<br/>
-**Mailing List:** [User and Dev Mailing List](http://systemml.apache.org/community.html)<br/>
+**Mailing List:** [Dev Mailing List](http://systemml.apache.org/community.html)<br/>
 **Build Status:** [![Build Status](https://sparktc.ibmcloud.com/jenkins/job/SystemML-DailyTest/badge/icon)](https://sparktc.ibmcloud.com/jenkins/job/SystemML-DailyTest)<br/>
 **Issue Tracker:** [JIRA](https://issues.apache.org/jira/browse/SYSTEMML)<br/>
 


### PR DESCRIPTION
Users and developers use dev list for all questions currently. Remove "User" reference to avoid confusion since no user list yet.