### PR TITLE
Cleanup assembly for release packages

### DIFF
--- a/src/assembly/distrib.xml
+++ b/src/assembly/distrib.xml
@@ -17,11 +17,10 @@
  * under the License.
 -->
 <assembly
-		xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-	<!-- Assembly file for the "distributed" SystemML release for running on a
-		cluster with Spark or Hadoop. -->
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	<!-- Assembly file for the "distributed" SystemML release for running on a cluster with Spark or Hadoop. -->
 	<id>distrib</id>
 
 	<formats>
@@ -52,38 +51,37 @@
 		<fileSet>
 			<directory>${basedir}/scripts/algorithms</directory>
 			<includes>
-				<include>GLM-predict.dml</include>
-				<include>GLM.dml</include>
-				<include>Kmeans-predict.dml</include>
-				<include>Kmeans.dml</include>
-				<include>LinearRegCG.dml</include>
-				<include>LinearRegDS.dml</include>
-				<include>MultiLogReg.dml</include>
-				<include>Univar-Stats.dml</include>
-				<include>bivar-stats.dml</include>
-				<include>l2-svm-predict.dml</include>
-				<include>l2-svm.dml</include>
-				<include>m-svm-predict.dml</include>
-				<include>m-svm.dml</include>
-				<include>naive-bayes-predict.dml</include>
-				<include>naive-bayes.dml</include>
-				<include>stratstats.dml</include>
-				<include>transform.dml</include>
-				<include>apply-transform.dml</include>
-				<include>decision-tree.dml</include>
-				<include>decision-tree-predict.dml</include>
-				<!-- -->
-				<include>ALS.dml</include>
 				<include>ALS_predict.dml</include>
 				<include>ALS_topk_predict.dml</include>
-				<include>Cox.dml</include>
+				<include>ALS.dml</include>
+				<include>apply-transform.dml</include>
+				<include>bivar-stats.dml</include>
 				<include>Cox-predict.dml</include>
+				<include>Cox.dml</include>
+				<include>decision-tree-predict.dml</include>
+				<include>decision-tree.dml</include>
+				<include>GLM-predict.dml</include>
+				<include>GLM.dml</include>
 				<include>KM.dml</include>
+				<include>Kmeans-predict.dml</include>
+				<include>Kmeans.dml</include>
+				<include>l2-svm-predict.dml</include>
+				<include>l2-svm.dml</include>
+				<include>LinearRegCG.dml</include>
+				<include>LinearRegDS.dml</include>
+				<include>m-svm-predict.dml</include>
+				<include>m-svm.dml</include>
+				<include>MultiLogReg.dml</include>
+				<include>naive-bayes-predict.dml</include>
+				<include>naive-bayes.dml</include>
 				<include>PCA.dml</include>
-				<include>random-forest.dml</include>
 				<include>random-forest-predict.dml</include>
+				<include>random-forest.dml</include>
 				<include>StepGLM.dml</include>
 				<include>StepLinearRegDS.dml</include>
+				<include>stratstats.dml</include>
+				<include>transform.dml</include>
+				<include>Univar-Stats.dml</include>
 			</includes>
 			<outputDirectory>./algorithms</outputDirectory>
 		</fileSet>
@@ -92,15 +90,14 @@
 			<directory>${basedir}/scripts/utils</directory>
 			<includes>
 				<include>cbind.dml</include>
+				<include>csv2bin.dml</include>
 				<include>head.dml</include>
 				<include>project.dml</include>
+				<include>rowIndexMax.dml</include>
+				<include>sample.dml</include>
+				<include>splitXY-dummy.dml</include>
 				<include>splitXY.dml</include>
 				<include>write.dml</include>
-				<include>csv2bin.dml</include>
-				<include>sample.dml</include>
-				<include>rowIndexMax.dml</include>
-				<!-- -->
-				<include>splitXY-dummy.dml</include>
 			</includes>
 			<outputDirectory>./algorithms/utils</outputDirectory>
 		</fileSet>

--- a/src/assembly/inmemory.xml
+++ b/src/assembly/inmemory.xml
@@ -20,10 +20,9 @@
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-
 	<!-- Assembly file for the "in-memory" SystemML release. -->
-
 	<id>inmemory</id>
+
 	<formats>
 		<format>jar</format>
 	</formats>
@@ -39,7 +38,6 @@
 			<outputDirectory>.</outputDirectory>
 		</fileSet>
 
-		
 		<fileSet>
 			<directory>${basedir}/src/main/config</directory>
 			<includes>
@@ -47,16 +45,6 @@
 			</includes>
 			<outputDirectory>.</outputDirectory>
 		</fileSet>
-		
-		<fileSet>
-			<directory>${basedir}/src/main/config</directory>
-			<includes>
-				<include>log4j.properties</include>
-			</includes>
-			<outputDirectory>.</outputDirectory>
-		</fileSet>
-		
-	
 	</fileSets>
 
 	<!-- 
@@ -68,7 +56,7 @@
 		</file>
 	</files>
 	-->
-	
+
 	<!--  Include all the libraries needed to run in standalone mode. -->
 	<dependencySets>
 		<dependencySet>
@@ -80,6 +68,5 @@
 			<unpack>true</unpack>
 		</dependencySet>
 	</dependencySets>
-	
 
 </assembly>

--- a/src/assembly/source.xml
+++ b/src/assembly/source.xml
@@ -42,6 +42,8 @@
 				<exclude>**/conf/*.properties</exclude>
 				<exclude>**/conf/*.xml</exclude>
 				<exclude>**/dependency-reduced-pom.xml</exclude>
+				<exclude>**/scratch_space</exclude>
+				<exclude>**/scratch_space/**/*</exclude>
 				<exclude>**/target</exclude>
 				<exclude>**/target/**/*</exclude>
 				<exclude>**/temp</exclude>

--- a/src/assembly/source.xml
+++ b/src/assembly/source.xml
@@ -17,41 +17,36 @@
  * under the License.
 -->
 <assembly
-        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-    <!-- Assembly file for the "source" SystemML release containing all source files. -->
-    <id>src</id>
-    <formats>
-        <format>tar.gz</format>
-        <format>zip</format>
-    </formats>
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	<!-- Assembly file for the "source" SystemML release containing all source files. -->
+	<id>src</id>
 
-    <includeBaseDirectory>true</includeBaseDirectory>
-    <baseDirectory>${artifactId}-${version}-src</baseDirectory>
+	<formats>
+		<format>tar.gz</format>
+		<format>zip</format>
+	</formats>
 
-    <fileSets>
-        <fileSet>
-            <directory>${basedir}</directory>
-            <outputDirectory></outputDirectory>
-            <excludes>
-                <exclude>**/.*</exclude>
-                <exclude>**/.*/**</exclude>
-                <exclude>**/*.iml</exclude>
-                <exclude>**/*.log</exclude>
-                <exclude>**/conf/*.properties</exclude>
-                <exclude>**/conf/*.xml</exclude>
-                <exclude>**/target</exclude>
-                <exclude>**/target/**/*</exclude>
-                <exclude>**/temp</exclude>
-                <exclude>**/temp/**/*</exclude>
-                <exclude>**/maven-eclipse.xml</exclude>
-                <exclude>**/dependency-reduced-pom.xml</exclude>
-                <exclude>modules/web-javascript-dojo/src/main/resources/dojo/**</exclude>
-                <exclude>samples/learning-more/binding-jsonrpc/calculator-webapp/src/main/webapp/dojo/**</exclude>
-                <exclude>unreleased</exclude>
-                <exclude>unreleased/**</exclude>
-            </excludes>
-        </fileSet>
-    </fileSets>
+	<includeBaseDirectory>true</includeBaseDirectory>
+	<baseDirectory>${artifactId}-${version}-src</baseDirectory>
+
+	<fileSets>
+		<fileSet>
+			<directory>${basedir}</directory>
+			<outputDirectory></outputDirectory>
+			<excludes>
+				<exclude>**/.*</exclude>
+				<exclude>**/.*/**</exclude>
+				<exclude>**/*.log</exclude>
+				<exclude>**/conf/*.properties</exclude>
+				<exclude>**/conf/*.xml</exclude>
+				<exclude>**/dependency-reduced-pom.xml</exclude>
+				<exclude>**/target</exclude>
+				<exclude>**/target/**/*</exclude>
+				<exclude>**/temp</exclude>
+				<exclude>**/temp/**/*</exclude>
+			</excludes>
+		</fileSet>
+	</fileSets>
 </assembly>

--- a/src/assembly/standalone-jar.xml
+++ b/src/assembly/standalone-jar.xml
@@ -17,10 +17,10 @@
  * under the License.
 -->
 <assembly
-		xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-	<!-- Assembly file for the "in-memory" SystemML release. -->
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	<!-- Assembly file for the "standalone jar" SystemML release. -->
 	<id>standalone</id>
 
 	<formats>
@@ -51,8 +51,8 @@
 	<dependencySets>
 		<dependencySet>
 			<includes>
-				<include>*:wink-json4j*</include>
 				<include>*:antlr*</include>
+				<include>*:wink-json4j*</include>
 			</includes>
 			<scope>compile</scope>
 			<unpack>true</unpack>
@@ -60,27 +60,27 @@
 
 		<dependencySet>
 			<includes>
+				<include>*:${artifactId}*</include>
 				<include>*:avro*</include>
+				<include>*:commons-cli*</include>
+				<include>*:commons-collections*</include>
+				<include>*:commons-configuration*</include>
+				<include>*:commons-httpclient*</include>
+				<include>*:commons-lang</include>
+				<include>*:commons-logging*</include>
 				<include>*:commons-math3*</include>
-				<include>*:log4j*</include>
-				<include>*:opencsv*</include>
 				<include>*:hadoop-auth*</include>
 				<include>*:hadoop-client*</include>
 				<include>*:hadoop-common*</include>
 				<include>*:hadoop-hdfs*</include>
 				<include>*:hadoop-mapreduce-client*</include>
 				<include>*:hadoop-yarn*</include>
-				<include>*:commons-configuration*</include>
-				<include>*:commons-lang</include>
-				<include>*:commons-logging*</include>
-				<include>*:commons-httpclient*</include>
-				<include>*:commons-cli*</include>
-				<include>*:commons-collections*</include>
 				<include>*:jackson-core-asl*</include>
 				<include>*:jackson-mapper-asl*</include>
+				<include>*:log4j*</include>
+				<include>*:opencsv*</include>
 				<include>*:slf4j-api*</include>
 				<include>*:slf4j-log4j*</include>
-				<include>*:${artifactId}*</include>
 			</includes>
 			<scope>provided</scope>
 			<unpack>true</unpack>

--- a/src/assembly/standalone.xml
+++ b/src/assembly/standalone.xml
@@ -17,11 +17,10 @@
  * under the License.
 -->
 <assembly
-		xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-	<!-- Assembly file for the "standalone" SystemML release for running on a
-		standalone machine. -->
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	<!-- Assembly file for the "standalone" SystemML release for running on a standalone machine. -->
 	<id>standalone</id>
 
 	<formats>
@@ -36,38 +35,37 @@
 		<fileSet>
 			<directory>${basedir}/scripts/algorithms</directory>
 			<includes>
-				<include>GLM-predict.dml</include>
-				<include>GLM.dml</include>
-				<include>Kmeans-predict.dml</include>
-				<include>Kmeans.dml</include>
-				<include>LinearRegCG.dml</include>
-				<include>LinearRegDS.dml</include>
-				<include>MultiLogReg.dml</include>
-				<include>Univar-Stats.dml</include>
-				<include>bivar-stats.dml</include>
-				<include>l2-svm-predict.dml</include>
-				<include>l2-svm.dml</include>
-				<include>m-svm-predict.dml</include>
-				<include>m-svm.dml</include>
-				<include>naive-bayes-predict.dml</include>
-				<include>naive-bayes.dml</include>
-				<include>stratstats.dml</include>
-				<include>transform.dml</include>
-				<include>apply-transform.dml</include>
-				<include>decision-tree.dml</include>
-				<include>decision-tree-predict.dml</include>
-				<!-- -->
-				<include>ALS.dml</include>
 				<include>ALS_predict.dml</include>
 				<include>ALS_topk_predict.dml</include>
-				<include>Cox.dml</include>
+				<include>ALS.dml</include>
+				<include>apply-transform.dml</include>
+				<include>bivar-stats.dml</include>
 				<include>Cox-predict.dml</include>
+				<include>Cox.dml</include>
+				<include>decision-tree-predict.dml</include>
+				<include>decision-tree.dml</include>
+				<include>GLM-predict.dml</include>
+				<include>GLM.dml</include>
 				<include>KM.dml</include>
+				<include>Kmeans-predict.dml</include>
+				<include>Kmeans.dml</include>
+				<include>l2-svm-predict.dml</include>
+				<include>l2-svm.dml</include>
+				<include>LinearRegCG.dml</include>
+				<include>LinearRegDS.dml</include>
+				<include>m-svm-predict.dml</include>
+				<include>m-svm.dml</include>
+				<include>MultiLogReg.dml</include>
+				<include>naive-bayes-predict.dml</include>
+				<include>naive-bayes.dml</include>
 				<include>PCA.dml</include>
-				<include>random-forest.dml</include>
 				<include>random-forest-predict.dml</include>
+				<include>random-forest.dml</include>
 				<include>StepGLM.dml</include>
 				<include>StepLinearRegDS.dml</include>
+				<include>stratstats.dml</include>
+				<include>transform.dml</include>
+				<include>Univar-Stats.dml</include>
 			</includes>
 			<outputDirectory>./scripts/algorithms</outputDirectory>
 		</fileSet>
@@ -84,13 +82,14 @@
 			<directory>${basedir}/scripts/utils</directory>
 			<includes>
 				<include>cbind.dml</include>
+				<include>csv2bin.dml</include>
 				<include>head.dml</include>
 				<include>project.dml</include>
+				<include>rowIndexMax.dml</include>
+				<include>sample.dml</include>
+				<include>splitXY-dummy.dml</include>
 				<include>splitXY.dml</include>
 				<include>write.dml</include>
-				<include>csv2bin.dml</include>
-				<include>sample.dml</include>
-				<include>rowIndexMax.dml</include>
 			</includes>
 			<outputDirectory>./scripts/utils</outputDirectory>
 		</fileSet>
@@ -117,8 +116,8 @@
 		<fileSet>
 			<directory>${basedir}/src/main/standalone</directory>
 			<includes>
-				<include>*.sh</include>
 				<include>*.bat</include>
+				<include>*.sh</include>
 			</includes>
 			<outputDirectory>.</outputDirectory>
 			<fileMode>0755</fileMode>
@@ -154,8 +153,8 @@
 	<dependencySets>
 		<dependencySet>
 			<includes>
-				<include>*:wink-json4j*</include>
 				<include>*:antlr*</include>
+				<include>*:wink-json4j*</include>
 			</includes>
 			<outputDirectory>./lib</outputDirectory>
 			<scope>compile</scope>
@@ -163,27 +162,27 @@
 
 		<dependencySet>
 			<includes>
+				<include>*:${artifactId}*</include>
 				<include>*:avro*</include>
+				<include>*:commons-cli*</include>
+				<include>*:commons-collections*</include>
+				<include>*:commons-configuration*</include>
+				<include>*:commons-httpclient*</include>
+				<include>*:commons-lang</include>
+				<include>*:commons-logging*</include>
 				<include>*:commons-math3*</include>
-				<include>*:log4j*</include>
-				<include>*:opencsv*</include>
 				<include>*:hadoop-auth*</include>
 				<include>*:hadoop-client*</include>
 				<include>*:hadoop-common*</include>
 				<include>*:hadoop-hdfs*</include>
 				<include>*:hadoop-mapreduce-client*</include>
 				<include>*:hadoop-yarn*</include>
-				<include>*:commons-configuration*</include>
-				<include>*:commons-lang</include>
-				<include>*:commons-logging*</include>
-				<include>*:commons-httpclient*</include>
-				<include>*:commons-cli*</include>
-				<include>*:commons-collections*</include>
 				<include>*:jackson-core-asl*</include>
 				<include>*:jackson-mapper-asl*</include>
+				<include>*:log4j*</include>
+				<include>*:opencsv*</include>
 				<include>*:slf4j-api*</include>
 				<include>*:slf4j-log4j*</include>
-				<include>*:${artifactId}*</include>
 			</includes>
 			<outputDirectory>./lib</outputDirectory>
 			<scope>provided</scope>


### PR DESCRIPTION
Alphabetize includes (scripts, jars, etc).
Apply same formatting to all assembly files.
Fix typos.
Remove redundancies.
Add missing util script in one assembly.