### PR TITLE
[SYSTEMML-153] Read file with extension 'csv' not require mtd file

### DIFF
--- a/src/assembly/standalone-jar.xml
+++ b/src/assembly/standalone-jar.xml
@@ -66,6 +66,7 @@
 				<include>*:commons-collections*</include>
 				<include>*:commons-configuration*</include>
 				<include>*:commons-httpclient*</include>
+				<include>*:commons-io*</include>
 				<include>*:commons-lang</include>
 				<include>*:commons-logging*</include>
 				<include>*:commons-math3*</include>

--- a/src/assembly/standalone.xml
+++ b/src/assembly/standalone.xml
@@ -168,6 +168,7 @@
 				<include>*:commons-collections*</include>
 				<include>*:commons-configuration*</include>
 				<include>*:commons-httpclient*</include>
+				<include>*:commons-io*</include>
 				<include>*:commons-lang</include>
 				<include>*:commons-logging*</include>
 				<include>*:commons-math3*</include>


### PR DESCRIPTION
If a read statement reads a file with a .csv extension with no format parameter specified, such as `read("m.csv")`, the file is considered to be a csv file so that a metadata file is optional and not required.
