### PR TITLE
Update syntax highlighter to rouge for GitHub pages Jekyll 3

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,4 +1,3 @@
 source "https://rubygems.org"
 gem "jekyll"
-gem "jekyll-redirect-from"
-gem "pygments.rb"
+gem "rouge"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,5 @@
-highlighter: pygments
+highlighter: rouge
 markdown: kramdown
-gems:
-  - jekyll-redirect-from
 
 # For some reason kramdown seems to behave differently on different
 # OS/packages wrt encoding. So we hard code this config.


### PR DESCRIPTION
See:
1) https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors
2) https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0

