### PR TITLE
[SYSTEMML-510] Generalized wdivmm w/ eps all patterns

### DIFF
--- a/docs/devdocs/MatrixMultiplicationOperators.txt
+++ b/docs/devdocs/MatrixMultiplicationOperators.txt
@@ -1,6 +1,6 @@
 #####################################################################
 # TITLE: An Overview of Matrix Multiplication Operators in SystemML #
-# DATE MODIFIED: 11/21/2015                                         #
+# DATE MODIFIED: 02/20/2016                                         #
 #####################################################################
 
 In the following, we give an overview of backend-specific physical matrix multiplication operators in SystemML as well as their internally used matrix multiplication block operations.
@@ -115,7 +115,8 @@ C) CORE MATRIX MULT PRIMITIVES LibMatrixMult (incl related script patterns)
                (c) t(t(U)%*%(W*(U%*%t(V)))), (d) (W*(U%*%t(V)))%*%V, 
                (e) W*(U%*%t(V)), (f) t(t(U)%*%((X!=0)*(U%*%t(V)-X))),
                (g) (X!=0)*(U%*%t(V)-X)%*%V, (h) t(t(U)%*%(W*(U%*%t(V)-X))),  
-               (i) (W*(U%*%t(V)-X)%*%V
+               (i) (W*(U%*%t(V)-X)%*%V,
+               (j) t(t(U)%*%(W/(U%*%t(V)+x))), (k) (W/(U%*%t(V)+x))%*%V
   - sequential / multi-threaded (same block ops, par over rows in X)                 
   - all dense, sparse-dense factors, sparse/dense-* x 9 patterns
 

--- a/src/main/java/org/apache/sysml/hops/QuaternaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/QuaternaryOp.java
@@ -819,7 +819,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 		//MR operator selection, part1
 		double m1Size = OptimizerUtils.estimateSize(U.getDim1(), U.getDim2()); //size U
 		double m2Size = OptimizerUtils.estimateSize(V.getDim1(), V.getDim2()); //size V
-		boolean isMapWdivmm = (!(wtype.hasFourInputs() && !wtype.hasScalar()) &&
+		boolean isMapWdivmm = ((!wtype.hasFourInputs() || wtype.hasScalar()) &&
 				m1Size+m2Size < OptimizerUtils.getRemoteMemBudgetMap(true)); 
 		
 		if( !FORCE_REPLICATION && isMapWdivmm ) //broadcast
@@ -970,7 +970,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 		//MR operator selection, part1
 		double m1Size = OptimizerUtils.estimateSize(U.getDim1(), U.getDim2()); //size U
 		double m2Size = OptimizerUtils.estimateSize(V.getDim1(), V.getDim2()); //size V
-		boolean isMapWdivmm = (!(wtype.hasFourInputs() && !wtype.hasScalar()) && m1Size+m2Size < memBudgetExec
+		boolean isMapWdivmm = ((!wtype.hasFourInputs() || wtype.hasScalar()) && m1Size+m2Size < memBudgetExec
 				&& 2*m1Size<memBudgetLocal && 2*m2Size<memBudgetLocal); 
 		
 		if( !FORCE_REPLICATION && isMapWdivmm ) //broadcast

--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteAlgebraicSimplificationDynamic.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteAlgebraicSimplificationDynamic.java
@@ -1873,7 +1873,7 @@ public class RewriteAlgebraicSimplificationDynamic extends HopRewriteRule
 			
 			//Pattern 1e) t(U) %*% (W/(U%*%t(V) + x))
 			if( !appliedPattern
-				&& right instanceof BinaryOp && HopRewriteUtils.isValidOp(((BinaryOp)right).getOp(),LOOKUP_VALID_WDIVMM_BINARY)	
+				&& right instanceof BinaryOp && ((BinaryOp)right).getOp() == LOOKUP_VALID_WDIVMM_BINARY[1] //DIV
 				&& HopRewriteUtils.isEqualSize(right.getInput().get(0), right.getInput().get(1)) //prevent mv
 				&& right.getInput().get(1) instanceof BinaryOp
 				&& ((BinaryOp) right.getInput().get(1)).getOp() == Hop.OpOp2.PLUS
@@ -1892,16 +1892,15 @@ public class RewriteAlgebraicSimplificationDynamic extends HopRewriteRule
 					else 
 						V = V.getInput().get(0);
 					
-					boolean mult = ((BinaryOp)right).getOp() == OpOp2.MULT;
 					hnew = new QuaternaryOp(hi.getName(), DataType.MATRIX, ValueType.DOUBLE, 
-							  OpOp4.WDIVMM, W, U, V, X, 3, mult, false); // 3=>DIV_LEFT_EPS
+							  OpOp4.WDIVMM, W, U, V, X, 3, false, false); // 3=>DIV_LEFT_EPS
 					HopRewriteUtils.setOutputBlocksizes(hnew, W.getRowsInBlock(), W.getColsInBlock());
 					
 					//add output transpose for efficient target indexing (redundant t() removed by other rewrites)
 					hnew = HopRewriteUtils.createTranspose(hnew);
 					
 					appliedPattern = true;
-					LOG.debug("Applied simplifyWeightedDivMM1 (line "+hi.getBeginLine()+")");					
+					LOG.debug("Applied simplifyWeightedDivMM1e (line "+hi.getBeginLine()+")");					
 				}
 			}	
 			
@@ -1936,7 +1935,7 @@ public class RewriteAlgebraicSimplificationDynamic extends HopRewriteRule
 			
 			//Pattern 2e) (W/(U%*%t(V) + x)) %*% V
 			if( !appliedPattern
-				&& left instanceof BinaryOp && HopRewriteUtils.isValidOp(((BinaryOp)left).getOp(), LOOKUP_VALID_WDIVMM_BINARY)	
+				&& left instanceof BinaryOp && ((BinaryOp)left).getOp() == LOOKUP_VALID_WDIVMM_BINARY[1] //DIV
 				&& HopRewriteUtils.isEqualSize(left.getInput().get(0), left.getInput().get(1)) //prevent mv
 				&& left.getInput().get(1) instanceof BinaryOp
 				&& ((BinaryOp) left.getInput().get(1)).getOp() == Hop.OpOp2.PLUS
@@ -1955,13 +1954,12 @@ public class RewriteAlgebraicSimplificationDynamic extends HopRewriteRule
 					else 
 						V = V.getInput().get(0);
 					
-					boolean mult = ((BinaryOp)left).getOp() == OpOp2.MULT;
 					hnew = new QuaternaryOp(hi.getName(), DataType.MATRIX, ValueType.DOUBLE, 
-							  OpOp4.WDIVMM, W, U, V, X, 4, mult, false); // 4=>DIV_RIGHT_EPS
+							  OpOp4.WDIVMM, W, U, V, X, 4, false, false); // 4=>DIV_RIGHT_EPS
 					HopRewriteUtils.setOutputBlocksizes(hnew, W.getRowsInBlock(), W.getColsInBlock());
 
 					appliedPattern = true;
-					LOG.debug("Applied simplifyWeightedDivMM2 (line "+hi.getBeginLine()+")");	
+					LOG.debug("Applied simplifyWeightedDivMM2e (line "+hi.getBeginLine()+")");	
 				}
 			}
 			

--- a/src/main/java/org/apache/sysml/lops/WeightedDivMM.java
+++ b/src/main/java/org/apache/sysml/lops/WeightedDivMM.java
@@ -169,12 +169,7 @@ public class WeightedDivMM extends Lop
 		sb.append( getInputs().get(2).prepInputOperand(input3));
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
-		if ( (getExecType() != ExecType.CP) && (getInputs().get(3).getDataType() == DataType.SCALAR) ) {
-			sb.append(getInputs().get(3).prepScalarInputOperand(getExecType()));
-		}
-		else {
-			sb.append( getInputs().get(3).prepInputOperand(input4));
-		}
+		sb.append( getInputs().get(3).prepInputOperand(input4));
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
 		sb.append( prepOutputOperand(output));

--- a/src/main/java/org/apache/sysml/lops/WeightedDivMM.java
+++ b/src/main/java/org/apache/sysml/lops/WeightedDivMM.java
@@ -38,6 +38,8 @@ public class WeightedDivMM extends Lop
 	public enum WDivMMType {
 		DIV_LEFT,			//t(t(U) %*% (W / U%*%t(V)))
 		DIV_RIGHT,			//(W / U%*%t(V)) %*% V
+		DIV_LEFT_EPS,		//t(t(U) %*% (W / (U%*%t(V) + x)))
+		DIV_RIGHT_EPS,		//(W / (U%*%t(V) + x)) %*% V
 		MULT_BASIC,			//(W * U%*%t(V))
 		MULT_LEFT,			//t(t(U) %*% (W * U%*%t(V)))
 		MULT_RIGHT,			//(W * U%*%t(V)) %*% V
@@ -51,7 +53,7 @@ public class WeightedDivMM extends Lop
 			return (this == MULT_BASIC);
 		}
 		public boolean isLeft() {
-			return (this == DIV_LEFT || this == MULT_LEFT 
+			return (this == DIV_LEFT || this == DIV_LEFT_EPS || this == MULT_LEFT 
 					|| this == MULT_MINUS_LEFT || this == MULT_MINUS_4_LEFT);
 		}
 		public boolean isRight() {
@@ -66,7 +68,11 @@ public class WeightedDivMM extends Lop
 					|| this == MULT_MINUS_4_LEFT || this == MULT_MINUS_4_RIGHT);
 		}
 		public boolean hasFourInputs() {
-			return (this == MULT_MINUS_4_LEFT || this == MULT_MINUS_4_RIGHT);
+			return (this == MULT_MINUS_4_LEFT || this == MULT_MINUS_4_RIGHT 
+					|| this == DIV_LEFT_EPS || this == DIV_RIGHT_EPS);
+		}
+		public boolean hasScalar() {
+			return (this == DIV_LEFT_EPS || this == DIV_RIGHT_EPS);
 		}
 		
 		public MatrixCharacteristics computeOutputCharacteristics(long Xrlen, long Xclen, long rank) {
@@ -163,7 +169,12 @@ public class WeightedDivMM extends Lop
 		sb.append( getInputs().get(2).prepInputOperand(input3));
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
-		sb.append( getInputs().get(3).prepInputOperand(input4));
+		if ( (getExecType() != ExecType.CP) && (getInputs().get(3).getDataType() == DataType.SCALAR) ) {
+			sb.append(getInputs().get(3).prepScalarInputOperand(getExecType()));
+		}
+		else {
+			sb.append( getInputs().get(3).prepInputOperand(input4));
+		}
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
 		sb.append( prepOutputOperand(output));

--- a/src/main/java/org/apache/sysml/lops/WeightedDivMM.java
+++ b/src/main/java/org/apache/sysml/lops/WeightedDivMM.java
@@ -151,10 +151,12 @@ public class WeightedDivMM extends Lop
 	{
 		StringBuilder sb = new StringBuilder();
 		
-		sb.append(getExecType());
+		final ExecType et = getExecType();
+		
+		sb.append(et);
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
-		if( getExecType() == ExecType.CP )
+		if( et == ExecType.CP )
 			sb.append(OPCODE_CP);
 		else
 			sb.append(OPCODE);
@@ -169,7 +171,12 @@ public class WeightedDivMM extends Lop
 		sb.append( getInputs().get(2).prepInputOperand(input3));
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
-		sb.append( getInputs().get(3).prepInputOperand(input4));
+		if ( (et == ExecType.MR) && (getInputs().get(3).getDataType() == DataType.SCALAR) ) {
+			sb.append( getInputs().get(3).prepScalarInputOperand(et));
+		}
+		else {
+			sb.append( getInputs().get(3).prepInputOperand(input4));
+		}
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
 		sb.append( prepOutputOperand(output));
@@ -178,7 +185,7 @@ public class WeightedDivMM extends Lop
 		sb.append(_weightsType);
 		
 		//append degree of parallelism
-		if( getExecType()==ExecType.CP ) {
+		if( et == ExecType.CP ) {
 			sb.append( OPERAND_DELIMITOR );
 			sb.append( _numThreads );
 		}

--- a/src/main/java/org/apache/sysml/lops/WeightedDivMMR.java
+++ b/src/main/java/org/apache/sysml/lops/WeightedDivMMR.java
@@ -107,7 +107,9 @@ public class WeightedDivMMR extends Lop
 	{
 		StringBuilder sb = new StringBuilder();
 		
-		sb.append(getExecType());
+		final ExecType et = getExecType();
+		
+		sb.append(et);
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
 		sb.append(OPCODE);
@@ -122,7 +124,13 @@ public class WeightedDivMMR extends Lop
 		sb.append( getInputs().get(2).prepInputOperand(input3));
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
-		sb.append( getInputs().get(3).prepInputOperand(input4));
+		if ( (et != ExecType.CP) && (getInputs().get(3).getDataType() == DataType.SCALAR) ) {
+			sb.append( getInputs().get(3).prepScalarInputOperand(et));
+		}
+		else {
+			sb.append( getInputs().get(3).prepInputOperand(input4));
+		}
+		
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
 		sb.append( prepOutputOperand(output));

--- a/src/main/java/org/apache/sysml/lops/WeightedDivMMR.java
+++ b/src/main/java/org/apache/sysml/lops/WeightedDivMMR.java
@@ -124,13 +124,12 @@ public class WeightedDivMMR extends Lop
 		sb.append( getInputs().get(2).prepInputOperand(input3));
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
-		if ( (et != ExecType.CP) && (getInputs().get(3).getDataType() == DataType.SCALAR) ) {
+		if ( (et == ExecType.MR) && (getInputs().get(3).getDataType() == DataType.SCALAR) ) {
 			sb.append( getInputs().get(3).prepScalarInputOperand(et));
 		}
 		else {
 			sb.append( getInputs().get(3).prepInputOperand(input4));
 		}
-		
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
 		sb.append( prepOutputOperand(output));

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/QuaternarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/QuaternarySPInstruction.java
@@ -168,7 +168,9 @@ public class QuaternarySPInstruction extends ComputationSPInstruction
 			boolean cacheU = isRed ? Boolean.parseBoolean(parts[7]) : true;
 			boolean cacheV = isRed ? Boolean.parseBoolean(parts[8]) : true;
 		
-			return new QuaternarySPInstruction(new QuaternaryOperator(WDivMMType.valueOf(parts[6])), in1, in2, in3, in4, out, cacheU, cacheV, opcode, str);
+			final WDivMMType wt = WDivMMType.valueOf(parts[6]);
+			QuaternaryOperator qop = (wt.hasScalar() ? new QuaternaryOperator(wt, Double.parseDouble(in4.getName())) : new QuaternaryOperator(wt));
+			return new QuaternarySPInstruction(qop, in1, in2, in3, in4, out, cacheU, cacheV, opcode, str);
 		} 
 		else //map/redwsigmoid, map/redwcemm
 		{

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/QuaternarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/QuaternarySPInstruction.java
@@ -251,7 +251,7 @@ public class QuaternarySPInstruction extends ComputationSPInstruction
 			PartitionedBroadcastMatrix bc2 = _cacheV ? sec.getBroadcastForVariable( input3.getName() ) : null;
 			JavaPairRDD<MatrixIndexes,MatrixBlock> inU = (!_cacheU) ? sec.getBinaryBlockRDDHandleForVariable( input2.getName() ) : null;
 			JavaPairRDD<MatrixIndexes,MatrixBlock> inV = (!_cacheV) ? sec.getBinaryBlockRDDHandleForVariable( input3.getName() ) : null;
-			JavaPairRDD<MatrixIndexes,MatrixBlock> inW = qop.hasFourInputs() ? 
+			JavaPairRDD<MatrixIndexes,MatrixBlock> inW = (qop.hasFourInputs() && !_input4.isLiteral()) ? 
 					sec.getBinaryBlockRDDHandleForVariable( _input4.getName() ) : null;
 
 			//preparation of transposed and replicated U
@@ -283,6 +283,9 @@ public class QuaternarySPInstruction extends ComputationSPInstruction
 			else if( inU == null && inV != null && inW != null )
 				out = in.join(inV).join(inW)
 				        .mapToPair(new RDDQuaternaryFunction3(qop, bc1, bc2));
+			else if( inU == null && inV == null && inW == null ) {
+				out = in.mapPartitionsToPair(new RDDQuaternaryFunction1(qop, bc1, bc2), false);
+			}
 			//function call w/ four rdd inputs
 			else //need keys in case of wdivmm 
 				out = in.join(inU).join(inV).join(inW)

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixMult.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixMult.java
@@ -2606,10 +2606,7 @@ public class LibMatrixMult
 								c[ix+j] = w[ix+j] * dotProduct(u, v, uix, vix, cd);	
 							else if( four ) //left/right 
 								if (scalar)
-									if (null != x)
-										wdivmm(w[ix+j], x[0], u, v, c, uix, vix, left, scalar, cd);
-									else
-										wdivmm(w[ix+j],    0, u, v, c, uix, vix, left, scalar, cd);
+									wdivmm(w[ix+j], x[0], u, v, c, uix, vix, left, scalar, cd);
 								else
 									wdivmm(w[ix+j], x[ix+j], u, v, c, uix, vix, left, scalar, cd);
 							else //left/right minus/default
@@ -2639,6 +2636,7 @@ public class LibMatrixMult
 		final boolean minus = wt.isMinus();
 		final boolean four = wt.hasFourInputs();
 		final boolean scalar = wt.hasScalar();
+		final double eps = scalar ? mX.quickGetValue(0, 0) : 0;
 		final int cd = mU.clen;
 		
 		SparseBlock w = mW.sparseBlock;
@@ -2668,12 +2666,18 @@ public class LibMatrixMult
 						//O(n) where n is nnz in w/x 
 						double[] xvals = x.values(i);
 						for( ; k<wpos+wlen && wix[k]<cu; k++ )
-							wdivmm(wval[k], xvals[k], u, v, c, uix, wix[k]*cd, left, scalar, cd);
+							if (scalar)
+								wdivmm(wval[k], eps, u, v, c, uix, wix[k]*cd, left, scalar, cd);
+							else
+								wdivmm(wval[k], xvals[k], u, v, c, uix, wix[k]*cd, left, scalar, cd);
 					}
 					else {
 						//O(n log m) where n/m are nnz in w/x
 						for( ; k<wpos+wlen && wix[k]<cu; k++ )
-							wdivmm(wval[k], x.get(i, wix[k]), u, v, c, uix, wix[k]*cd, left, scalar, cd);
+							if (scalar)
+								wdivmm(wval[k], eps, u, v, c, uix, wix[k]*cd, left, scalar, cd);
+							else
+								wdivmm(wval[k], x.get(i, wix[k]), u, v, c, uix, wix[k]*cd, left, scalar, cd);
 					}
 				}
 				else { //left/right minus default
@@ -2707,6 +2711,7 @@ public class LibMatrixMult
 		final boolean minus = wt.isMinus();
 		final boolean four = wt.hasFourInputs();
 		final boolean scalar = wt.hasScalar();
+		final double eps = scalar ? mX.quickGetValue(0, 0) : 0;
 		final int n = mW.clen; 
 		final int cd = mU.clen;
 
@@ -2732,7 +2737,7 @@ public class LibMatrixMult
 							ret.appendValue(i, wix[k], uvij);
 						}
 						else if( four ) { //left/right
-							double xij = scalar ? mX.quickGetValue(0, 0): mX.quickGetValue(i, wix[k]);
+							double xij = scalar ? eps : mX.quickGetValue(i, wix[k]);
 							wdivmm(wval[k], xij, mU, mV, c, i, wix[k], left, scalar, cd);
 						}
 						else { //left/right minus/default
@@ -2753,7 +2758,7 @@ public class LibMatrixMult
 							c[ix+j] = dotProductGeneric(mU,mV, i, j, cd);
 						}
 						else if( four ) { //left/right
-							double xij = scalar ? mX.quickGetValue(0, 0): mX.quickGetValue(i, j);
+							double xij = scalar ? eps : mX.quickGetValue(i, j);
 							wdivmm(w[ix+j], xij, mU, mV, c, i, j, left, scalar, cd);
 						}
 						else { //left/right minus/default

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixMult.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixMult.java
@@ -2577,6 +2577,7 @@ public class LibMatrixMult
 		final boolean minus = wt.isMinus();
 		final boolean four = wt.hasFourInputs();
 		final boolean scalar = wt.hasScalar();
+		final double eps = scalar ? mX.quickGetValue(0, 0) : 0;
 		final int n = mW.clen;
 		final int cd = mU.clen;
 		
@@ -2606,7 +2607,7 @@ public class LibMatrixMult
 								c[ix+j] = w[ix+j] * dotProduct(u, v, uix, vix, cd);	
 							else if( four ) //left/right 
 								if (scalar)
-									wdivmm(w[ix+j], x[0], u, v, c, uix, vix, left, scalar, cd);
+									wdivmm(w[ix+j], eps, u, v, c, uix, vix, left, scalar, cd);
 								else
 									wdivmm(w[ix+j], x[ix+j], u, v, c, uix, vix, left, scalar, cd);
 							else //left/right minus/default

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/MatrixBlock.java
@@ -5792,7 +5792,7 @@ public class MatrixBlock extends MatrixValue implements Externalizable
 		else if( qop.wtype3 != null ){ //wdivmm
 			//note: for wdivmm-minus X and W interchanged because W always present 
 			MatrixBlock W = qop.wtype3.hasFourInputs() ? checkType(wm) : null;
-			if (null == W && (qop.wtype3.hasScalar() && qop.hasScalar() > 0)) {
+			if( qop.hasScalar() != 0 ) {
 				W = new MatrixBlock(1, 1, false);
 				W.quickSetValue(0, 0, qop.hasScalar());
 			}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/MatrixBlock.java
@@ -5792,9 +5792,9 @@ public class MatrixBlock extends MatrixValue implements Externalizable
 		else if( qop.wtype3 != null ){ //wdivmm
 			//note: for wdivmm-minus X and W interchanged because W always present 
 			MatrixBlock W = qop.wtype3.hasFourInputs() ? checkType(wm) : null;
-			if( qop.hasScalar() != 0 ) {
+			if( qop.getScalar() != 0 ) {
 				W = new MatrixBlock(1, 1, false);
-				W.quickSetValue(0, 0, qop.hasScalar());
+				W.quickSetValue(0, 0, qop.getScalar());
 			}
 			if( k > 1 )
 				LibMatrixMult.matrixMultWDivMM(X, U, V, W, R, qop.wtype3, k);

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/MatrixBlock.java
@@ -5792,6 +5792,10 @@ public class MatrixBlock extends MatrixValue implements Externalizable
 		else if( qop.wtype3 != null ){ //wdivmm
 			//note: for wdivmm-minus X and W interchanged because W always present 
 			MatrixBlock W = qop.wtype3.hasFourInputs() ? checkType(wm) : null;
+			if (null == W && (qop.wtype3.hasScalar() && qop.hasScalar() > 0)) {
+				W = new MatrixBlock(1, 1, false);
+				W.quickSetValue(0, 0, qop.hasScalar());
+			}
 			if( k > 1 )
 				LibMatrixMult.matrixMultWDivMM(X, U, V, W, R, qop.wtype3, k);
 			else

--- a/src/main/java/org/apache/sysml/runtime/matrix/operators/QuaternaryOperator.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/operators/QuaternaryOperator.java
@@ -43,6 +43,8 @@ public class QuaternaryOperator extends Operator
 	
 	public ValueFunction fn;
 	
+	private double eps = 0;
+
 	/**
 	 * wsloss
 	 * 
@@ -69,6 +71,16 @@ public class QuaternaryOperator extends Operator
 	 */
 	public QuaternaryOperator( WDivMMType wt ) {
 		wtype3 = wt;
+	}
+	
+	/**
+	 * wdivmm w/epsilon
+	 * 
+	 * @param wt
+	 */
+	public QuaternaryOperator( WDivMMType wt, double epsilon) {
+		wtype3 = wt;
+		eps = epsilon;
 	}
 	
 	/**
@@ -105,4 +117,13 @@ public class QuaternaryOperator extends Operator
 		return (wtype1 != null && wtype1.hasFourInputs())
 			|| (wtype3 != null && wtype3.hasFourInputs());
 	}
+	
+	/**
+	 * 
+	 * @return
+	 */
+	public double hasScalar() {
+		return eps;
+	}
+
 }

--- a/src/main/java/org/apache/sysml/runtime/matrix/operators/QuaternaryOperator.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/operators/QuaternaryOperator.java
@@ -120,9 +120,9 @@ public class QuaternaryOperator extends Operator
 	
 	/**
 	 * 
-	 * @return
+	 * @return epsilon
 	 */
-	public double hasScalar() {
+	public double getScalar() {
 		return eps;
 	}
 

--- a/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedDivMatrixMultTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedDivMatrixMultTest.java
@@ -503,6 +503,11 @@ public class WeightedDivMatrixMultTest extends AutomatedTestBase
 	}
 	
 	@Test
+	public void testWeightedDivMMLeftEpsDenseMRRep() {
+		runWeightedDivMMTest(TEST_NAME10, false, true, true, ExecType.MR);
+	}
+	
+	@Test
 	public void testWeightedDivMMRightEpsDenseMR() {
 		runWeightedDivMMTest(TEST_NAME11, false, true, false, ExecType.MR);
 	}
@@ -510,6 +515,11 @@ public class WeightedDivMatrixMultTest extends AutomatedTestBase
 	@Test
 	public void testWeightedDivMMRightEpsSparseMR() {
 		runWeightedDivMMTest(TEST_NAME11, true, true, false, ExecType.MR);
+	}
+	
+	@Test
+	public void testWeightedDivMMRightEpsDenseMRRep() {
+		runWeightedDivMMTest(TEST_NAME11, false, true, true, ExecType.MR);
 	}
 	
 	@Test
@@ -523,6 +533,11 @@ public class WeightedDivMatrixMultTest extends AutomatedTestBase
 	}
 	
 	@Test
+	public void testWeightedDivMMLeftEpsDenseSPRep() {
+		runWeightedDivMMTest(TEST_NAME10, false, true, true, ExecType.SPARK);
+	}
+	
+	@Test
 	public void testWeightedDivMMRightEpsDenseSP() {
 		runWeightedDivMMTest(TEST_NAME11, false, true, false, ExecType.SPARK);
 	}
@@ -530,6 +545,11 @@ public class WeightedDivMatrixMultTest extends AutomatedTestBase
 	@Test
 	public void testWeightedDivMMRightEpsSparseSP() {
 		runWeightedDivMMTest(TEST_NAME11, true, true, false, ExecType.SPARK);
+	}
+	
+	@Test
+	public void testWeightedDivMMRightEpsDenseSPRep() {
+		runWeightedDivMMTest(TEST_NAME11, false, true, true, ExecType.SPARK);
 	}
 
 	/**

--- a/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedDivMatrixMultTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedDivMatrixMultTest.java
@@ -56,10 +56,13 @@ public class WeightedDivMatrixMultTest extends AutomatedTestBase
 	private final static String TEST_NAME7 = "WeightedDivMMMultMinusRight";
 	private final static String TEST_NAME8 = "WeightedDivMM4MultMinusLeft";
 	private final static String TEST_NAME9 = "WeightedDivMM4MultMinusRight";
+	private final static String TEST_NAME10 = "WeightedDivMMLeftEps";
+	private final static String TEST_NAME11 = "WeightedDivMMRightEps";
 	private final static String TEST_DIR = "functions/quaternary/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + WeightedDivMatrixMultTest.class.getSimpleName() + "/";
 	
 	private final static double eps = 1e-6;
+	private final static double div_eps = 1e-17;
 	
 	private final static int rows = 1201;
 	private final static int cols = 1103;
@@ -80,6 +83,8 @@ public class WeightedDivMatrixMultTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME7,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME7,new String[]{"R"}));
 		addTestConfiguration(TEST_NAME8,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME8,new String[]{"R"}));
 		addTestConfiguration(TEST_NAME9,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME9,new String[]{"R"}));
+		addTestConfiguration(TEST_NAME10,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME10,new String[]{"R"}));
+		addTestConfiguration(TEST_NAME11,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME11,new String[]{"R"}));
 	
 		if (TEST_CACHE_ENABLED) {
 			setOutAndExpectedDeletionDisabled(true);
@@ -465,6 +470,68 @@ public class WeightedDivMatrixMultTest extends AutomatedTestBase
 		runWeightedDivMMTest(TEST_NAME9, false, true, true, ExecType.SPARK);
 	}
 	
+	//c) testcases for wdivmm w/ DIVIDE LEFT/RIGHT with Epsilon
+	
+	@Test
+	public void testWeightedDivMMLeftEpsDenseCP() {
+		runWeightedDivMMTest(TEST_NAME10, false, true, false, ExecType.CP);
+	}
+	
+	@Test
+	public void testWeightedDivMMLeftEpsSparseCP() {
+		runWeightedDivMMTest(TEST_NAME10, true, true, false, ExecType.CP);
+	}
+	
+	@Test
+	public void testWeightedDivMMRightEpsDenseCP() {
+		runWeightedDivMMTest(TEST_NAME11, false, true, false, ExecType.CP);
+	}
+	
+	@Test
+	public void testWeightedDivMMRightEpsSparseCP() {
+		runWeightedDivMMTest(TEST_NAME11, true, true, false, ExecType.CP);
+	}
+	
+	@Test
+	public void testWeightedDivMMLeftEpsDenseMR() {
+		runWeightedDivMMTest(TEST_NAME10, false, true, false, ExecType.MR);
+	}
+	
+	@Test
+	public void testWeightedDivMMLeftEpsSparseMR() {
+		runWeightedDivMMTest(TEST_NAME10, true, true, false, ExecType.MR);
+	}
+	
+	@Test
+	public void testWeightedDivMMRightEpsDenseMR() {
+		runWeightedDivMMTest(TEST_NAME11, false, true, false, ExecType.MR);
+	}
+	
+	@Test
+	public void testWeightedDivMMRightEpsSparseMR() {
+		runWeightedDivMMTest(TEST_NAME11, true, true, false, ExecType.MR);
+	}
+	
+	@Test
+	public void testWeightedDivMMLeftEpsDenseSP() {
+		runWeightedDivMMTest(TEST_NAME10, false, true, false, ExecType.SPARK);
+	}
+	
+	@Test
+	public void testWeightedDivMMLeftEpsSparseSP() {
+		runWeightedDivMMTest(TEST_NAME10, true, true, false, ExecType.SPARK);
+	}
+	
+	@Test
+	public void testWeightedDivMMRightEpsDenseSP() {
+		runWeightedDivMMTest(TEST_NAME11, false, true, false, ExecType.SPARK);
+	}
+	
+	@Test
+	public void testWeightedDivMMRightEpsSparseSP() {
+		runWeightedDivMMTest(TEST_NAME11, true, true, false, ExecType.SPARK);
+	}
+
 	/**
 	 * 
 	 * @param sparseM1
@@ -494,7 +561,8 @@ public class WeightedDivMatrixMultTest extends AutomatedTestBase
 		{
 			boolean basic = testname.equals(TEST_NAME3);
 			boolean left = testname.equals(TEST_NAME1) || testname.equals(TEST_NAME4) 
-					|| testname.equals(TEST_NAME6) || testname.equals(TEST_NAME8);
+					|| testname.equals(TEST_NAME6) || testname.equals(TEST_NAME8)
+					|| testname.equals(TEST_NAME10);
 			double sparsity = (sparse) ? spSparse : spDense;
 			String TEST_NAME = testname;
 			String TEST_CACHE_DIR = TEST_CACHE_ENABLED ? 
@@ -507,10 +575,10 @@ public class WeightedDivMatrixMultTest extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{"-stats", "-explain", "runtime", "-args",
-				input("W"), input("U"), input("V"), output("R") };
+				input("W"), input("U"), input("V"), output("R"), Double.toString(div_eps) };
 			
 			fullRScriptName = HOME + TEST_NAME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir() + " " + div_eps;
 	
 			//generate actual dataset 
 			double[][] W = getRandomMatrix(rows, cols, 0, 1, sparsity, 7); 

--- a/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedDivMatrixMultTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/quaternary/WeightedDivMatrixMultTest.java
@@ -62,7 +62,7 @@ public class WeightedDivMatrixMultTest extends AutomatedTestBase
 	private final static String TEST_CLASS_DIR = TEST_DIR + WeightedDivMatrixMultTest.class.getSimpleName() + "/";
 	
 	private final static double eps = 1e-6;
-	private final static double div_eps = 1e-17;
+	private final static double div_eps = 0.1;
 	
 	private final static int rows = 1201;
 	private final static int cols = 1103;

--- a/src/test/scripts/functions/quaternary/WeightedDivMMLeftEps.R
+++ b/src/test/scripts/functions/quaternary/WeightedDivMMLeftEps.R
@@ -1,0 +1,38 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+args <- commandArgs(TRUE)
+options(digits=22)
+
+library("Matrix")
+
+W = as.matrix(readMM(paste(args[1], "W.mtx", sep="")))
+U = as.matrix(readMM(paste(args[1], "U.mtx", sep="")))
+V = as.matrix(readMM(paste(args[1], "V.mtx", sep="")))
+
+x = as.numeric(args[3])
+
+R = t(t(U) %*% (W/(U%*%t(V) + x)));
+
+writeMM(as(R, "CsparseMatrix"), paste(args[2], "R", sep="")); 
+
+

--- a/src/test/scripts/functions/quaternary/WeightedDivMMLeftEps.dml
+++ b/src/test/scripts/functions/quaternary/WeightedDivMMLeftEps.dml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+
+W = read($1);
+U = read($2);
+V = read($3);
+
+x = $5;
+
+R = t(t(U) %*% (W/(U%*%t(V) + x)));
+
+write(R, $4);

--- a/src/test/scripts/functions/quaternary/WeightedDivMMRightEps.R
+++ b/src/test/scripts/functions/quaternary/WeightedDivMMRightEps.R
@@ -1,0 +1,38 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+args <- commandArgs(TRUE)
+options(digits=22)
+
+library("Matrix")
+
+W = as.matrix(readMM(paste(args[1], "W.mtx", sep="")))
+U = as.matrix(readMM(paste(args[1], "U.mtx", sep="")))
+V = as.matrix(readMM(paste(args[1], "V.mtx", sep="")))
+
+x = as.numeric(args[3])
+
+R = (W/(U%*%t(V) + x)) %*% V;
+
+writeMM(as(R, "CsparseMatrix"), paste(args[2], "R", sep="")); 
+
+

--- a/src/test/scripts/functions/quaternary/WeightedDivMMRightEps.dml
+++ b/src/test/scripts/functions/quaternary/WeightedDivMMRightEps.dml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+
+W = read($1);
+U = read($2);
+V = read($3);
+
+x = $5;
+
+R = (W/(U%*%t(V) + x)) %*% V;
+
+write(R, $4);


### PR DESCRIPTION
This patch with related tests extends the existing wdivmm operator by two patterns for four operands:
t(t(U)%*%(W*(U%*%t(V)+x))), and (W*(U%*%t(V)+x)%*%V, where x is a scalar (e.g., epsilon).

Supporting these patterns allows a DML script to contain epsilon similar to an equivalent R script that included epsilon to prevent divide-by-zero.
