### PR TITLE
[SYSTEMML-577] Add High-Level "executeScript" API to Python MLContext.

### DIFF
--- a/src/main/java/org/apache/sysml/api/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/MLContext.java
@@ -1143,6 +1143,11 @@ public class MLContext {
 		return executeScript(dmlScript, new HashMap<String, String>(scala.collection.JavaConversions.mapAsJavaMap(namedArgs)), configFilePath);
 	}
 
+	public MLOutput executeScript(String dmlScript, HashMap<String, String> namedArgs)
+			throws IOException, DMLException, ParseException {
+		return executeScript(dmlScript, namedArgs, null);
+	}
+
 	public MLOutput executeScript(String dmlScript, HashMap<String, String> namedArgs, String configFilePath)
 			throws IOException, DMLException, ParseException {
 		String [] args = new String[namedArgs.size()];


### PR DESCRIPTION
This adds the `executeScript(...)` function to the Python MLContext API, and in the process hides the need to use `registerInput(...)` and `registerOutput(...)` by allowing the user to pass in a dictionary of key:value inputs of any type, and an array of outputs to keep.

Example:
```
pnmf = """ // script here """
outputs = ml.executeScript(pnmf, {"X": X_train, "maxiter": 100, "rank": 10}, ["W", "H", "negloglik"])
```