### PR TITLE
[SYSTEMML-510] Generalization wcemm

### DIFF
--- a/docs/devdocs/MatrixMultiplicationOperators.txt
+++ b/docs/devdocs/MatrixMultiplicationOperators.txt
@@ -120,7 +120,7 @@ C) CORE MATRIX MULT PRIMITIVES LibMatrixMult (incl related script patterns)
   - sequential / multi-threaded (same block ops, par over rows in X)                 
   - all dense, sparse-dense factors, sparse/dense-* x 9 patterns
 
-* 8) wcemm    (sum(X*log(U%*%t(V))))  
+* 8) wcemm    ((a) sum(X*log(U%*%t(V))), (b) sum(X*log(U%*%t(V) + epsilon)))
   - sequential / multi-threaded (same block ops, par over rows in X)                 
   - all dense, sparse-dense factors, sparse/dense-*, 1 pattern
 

--- a/docs/devdocs/MatrixMultiplicationOperators.txt
+++ b/docs/devdocs/MatrixMultiplicationOperators.txt
@@ -1,6 +1,6 @@
 #####################################################################
 # TITLE: An Overview of Matrix Multiplication Operators in SystemML #
-# DATE MODIFIED: 02/20/2016                                         #
+# DATE MODIFIED: 03/18/2016                                         #
 #####################################################################
 
 In the following, we give an overview of backend-specific physical matrix multiplication operators in SystemML as well as their internally used matrix multiplication block operations.

--- a/src/main/java/org/apache/sysml/hops/QuaternaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/QuaternaryOp.java
@@ -260,7 +260,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 				}
 				
 				case WCEMM:{
-					WCeMMType wtype = WCeMMType.BASIC;
+					WCeMMType wtype = checkWCeMMType();
 					
 					if( et == ExecType.CP )
 						constructCPLopsWeightedCeMM(wtype);
@@ -601,7 +601,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 	{
 		//NOTE: the common case for wsigmoid are factors U/V with a rank of 10s to 100s; the current runtime only
 		//supports single block outer products (U/V rank <= blocksize, i.e., 1000 by default); we enforce this
-		//by applying the hop rewrite for Weighted Squared Loss only if this constraint holds. 
+		//by applying the hop rewrite for Weighted Sigmoid only if this constraint holds. 
 		
 		Hop X = getInput().get(0);
 		Hop U = getInput().get(1);
@@ -610,9 +610,9 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 		//MR operator selection, part1
 		double m1Size = OptimizerUtils.estimateSize(U.getDim1(), U.getDim2()); //size U
 		double m2Size = OptimizerUtils.estimateSize(V.getDim1(), V.getDim2()); //size V
-		boolean isMapWsloss = (m1Size+m2Size < OptimizerUtils.getRemoteMemBudgetMap(true)); 
+		boolean isMapWsig = (m1Size+m2Size < OptimizerUtils.getRemoteMemBudgetMap(true)); 
 		
-		if( !FORCE_REPLICATION && isMapWsloss ) //broadcast
+		if( !FORCE_REPLICATION && isMapWsig ) //broadcast
 		{
 			//partitioning of U
 			boolean needPartU = !U.dimsKnown() || U.getDim1() * U.getDim2() > DistributedCacheInput.PARTITION_SIZE;
@@ -632,7 +632,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 				setLineNumbers(lV);	
 			}
 			
-			//map-side wsloss always with broadcast
+			//map-side wsig always with broadcast
 			Lop wsigmoid = new WeightedSigmoid( X.constructLops(), lU, lV,  
 					DataType.MATRIX, ValueType.DOUBLE, wtype, ExecType.MR);
 			setOutputDimensions(wsigmoid);
@@ -707,7 +707,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 				lV = grpV;
 			}
 			
-			//reduce-side wsloss w/ or without broadcast
+			//reduce-side wsig w/ or without broadcast
 			Lop wsigmoid = new WeightedSigmoidR( 
 					grpX, lU, lV, DataType.MATRIX, ValueType.DOUBLE, wtype, cacheU, cacheV, ExecType.MR);
 			setOutputDimensions(wsigmoid);
@@ -729,7 +729,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 	{
 		//NOTE: the common case for wsigmoid are factors U/V with a rank of 10s to 100s; the current runtime only
 		//supports single block outer products (U/V rank <= blocksize, i.e., 1000 by default); we enforce this
-		//by applying the hop rewrite for Weighted Squared Loss only if this constraint holds. 
+		//by applying the hop rewrite for Weighted Sigmoid only if this constraint holds. 
 
 		//Notes: Any broadcast needs to fit twice in local memory because we partition the input in cp,
 		//and needs to fit once in executor broadcast memory. The 2GB broadcast constraint is no longer
@@ -744,12 +744,12 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 		//MR operator selection, part1
 		double m1Size = OptimizerUtils.estimateSize(U.getDim1(), U.getDim2()); //size U
 		double m2Size = OptimizerUtils.estimateSize(V.getDim1(), V.getDim2()); //size V
-		boolean isMapWsloss = (m1Size+m2Size < memBudgetExec
+		boolean isMapWsig = (m1Size+m2Size < memBudgetExec
 				&& 2*m1Size<memBudgetLocal && 2*m2Size<memBudgetLocal); 
 		
-		if( !FORCE_REPLICATION && isMapWsloss ) //broadcast
+		if( !FORCE_REPLICATION && isMapWsig ) //broadcast
 		{
-			//map-side wsloss always with broadcast
+			//map-side wsig always with broadcast
 			Lop wsigmoid = new WeightedSigmoid( X.constructLops(), U.constructLops(), V.constructLops(),  
 					DataType.MATRIX, ValueType.DOUBLE, wtype, ExecType.SPARK);
 			setOutputDimensions(wsigmoid);
@@ -763,7 +763,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 			boolean cacheV = !FORCE_REPLICATION && ((!cacheU && m2Size < memBudgetExec ) 
 					        || (cacheU && m1Size+m2Size < memBudgetExec)) && 2*m2Size < memBudgetLocal;
 			
-			//reduce-side wsloss w/ or without broadcast
+			//reduce-side wsig w/ or without broadcast
 			Lop wsigmoid = new WeightedSigmoidR( 
 					X.constructLops(), U.constructLops(), V.constructLops(), 
 					DataType.MATRIX, ValueType.DOUBLE, wtype, cacheU, cacheV, ExecType.SPARK);
@@ -809,7 +809,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 	{
 		//NOTE: the common case for wdivmm are factors U/V with a rank of 10s to 100s; the current runtime only
 		//supports single block outer products (U/V rank <= blocksize, i.e., 1000 by default); we enforce this
-		//by applying the hop rewrite for Weighted Squared Loss only if this constraint holds. 
+		//by applying the hop rewrite for Weighted DivMM only if this constraint holds. 
 		
 		Hop W = getInput().get(0);
 		Hop U = getInput().get(1);
@@ -1012,6 +1012,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 				getInput().get(0).constructLops(),
 				getInput().get(1).constructLops(),
 				getInput().get(2).constructLops(),
+				getInput().get(3).constructLops(),
 				getDataType(), getValueType(), wtype, ExecType.CP);
 		
 		//set degree of parallelism
@@ -1032,20 +1033,21 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 	private void constructMRLopsWeightedCeMM(WCeMMType wtype) 
 		throws HopsException, LopsException
 	{
-		//NOTE: the common case for wsloss are factors U/V with a rank of 10s to 100s; the current runtime only
+		//NOTE: the common case for wcemm are factors U/V with a rank of 10s to 100s; the current runtime only
 		//supports single block outer products (U/V rank <= blocksize, i.e., 1000 by default); we enforce this
-		//by applying the hop rewrite for Weighted Squared Loss only if this constraint holds. 
+		//by applying the hop rewrite for Weighted Cross Entropy only if this constraint holds. 
 		
 		Hop X = getInput().get(0);
 		Hop U = getInput().get(1);
 		Hop V = getInput().get(2);
+		Hop eps = getInput().get(3);
 		
 		//MR operator selection, part1
 		double m1Size = OptimizerUtils.estimateSize(U.getDim1(), U.getDim2()); //size U
 		double m2Size = OptimizerUtils.estimateSize(V.getDim1(), V.getDim2()); //size V
-		boolean isMapWsloss = (m1Size+m2Size < OptimizerUtils.getRemoteMemBudgetMap(true)); 
+		boolean isMapWcemm = (m1Size+m2Size < OptimizerUtils.getRemoteMemBudgetMap(true)); 
 		
-		if( !FORCE_REPLICATION && isMapWsloss ) //broadcast
+		if( !FORCE_REPLICATION && isMapWcemm ) //broadcast
 		{
 			//partitioning of U
 			boolean needPartU = !U.dimsKnown() || U.getDim1() * U.getDim2() > DistributedCacheInput.PARTITION_SIZE;
@@ -1065,8 +1067,8 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 				setLineNumbers(lV);	
 			}
 			
-			//map-side wsloss always with broadcast
-			Lop wcemm = new WeightedCrossEntropy( X.constructLops(), lU, lV, 
+			//map-side wcemm always with broadcast
+			Lop wcemm = new WeightedCrossEntropy( X.constructLops(), lU, lV, eps.constructLops(),
 					DataType.MATRIX, ValueType.DOUBLE, wtype, ExecType.MR);
 			wcemm.getOutputParameters().setDimensions(1, 1, X.getRowsInBlock(), X.getColsInBlock(), -1);
 			setLineNumbers(wcemm);
@@ -1151,9 +1153,9 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 				lV = grpV;
 			}
 			
-			//reduce-side wsloss w/ or without broadcast
-			Lop wcemm = new WeightedCrossEntropyR( 
-					grpX, lU, lV, DataType.MATRIX, ValueType.DOUBLE, wtype, cacheU, cacheV, ExecType.MR);
+			//reduce-side wcemm w/ or without broadcast
+			Lop wcemm = new WeightedCrossEntropyR( grpX, lU, lV, eps.constructLops(),
+					DataType.MATRIX, ValueType.DOUBLE, wtype, cacheU, cacheV, ExecType.MR);
 			wcemm.getOutputParameters().setDimensions(1, 1, X.getRowsInBlock(), X.getColsInBlock(), -1);
 			setLineNumbers(wcemm);
 			
@@ -1182,9 +1184,9 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 	private void constructSparkLopsWeightedCeMM(WCeMMType wtype) 
 		throws HopsException, LopsException
 	{
-		//NOTE: the common case for wsloss are factors U/V with a rank of 10s to 100s; the current runtime only
+		//NOTE: the common case for wcemm are factors U/V with a rank of 10s to 100s; the current runtime only
 		//supports single block outer products (U/V rank <= blocksize, i.e., 1000 by default); we enforce this
-		//by applying the hop rewrite for Weighted Squared Loss only if this constraint holds. 
+		//by applying the hop rewrite for Weighted Cross Entropy only if this constraint holds. 
 		
 		//Notes: Any broadcast needs to fit twice in local memory because we partition the input in cp,
 		//and needs to fit once in executor broadcast memory. The 2GB broadcast constraint is no longer
@@ -1195,21 +1197,22 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 		Hop X = getInput().get(0);
 		Hop U = getInput().get(1);
 		Hop V = getInput().get(2);
+		Hop eps = getInput().get(3);
 		
 		//MR operator selection, part1
 		double m1Size = OptimizerUtils.estimateSize(U.getDim1(), U.getDim2()); //size U
 		double m2Size = OptimizerUtils.estimateSize(V.getDim1(), V.getDim2()); //size V
-		boolean isMapWsloss = (m1Size+m2Size < memBudgetExec
+		boolean isMapWcemm = (m1Size+m2Size < memBudgetExec
 				&& 2*m1Size < memBudgetLocal && 2*m2Size < memBudgetLocal); 
 		
-		if( !FORCE_REPLICATION && isMapWsloss ) //broadcast
+		if( !FORCE_REPLICATION && isMapWcemm ) //broadcast
 		{
-			//map-side wsloss always with broadcast
-			Lop wsloss = new WeightedCrossEntropy( X.constructLops(), U.constructLops(), V.constructLops(),  
+			//map-side wcemm always with broadcast
+			Lop wcemm = new WeightedCrossEntropy( X.constructLops(), U.constructLops(), V.constructLops(), eps.constructLops(),
 					DataType.SCALAR, ValueType.DOUBLE, wtype, ExecType.SPARK);
-			setOutputDimensions(wsloss);
-			setLineNumbers(wsloss);
-			setLops(wsloss);
+			setOutputDimensions(wcemm);
+			setLineNumbers(wcemm);
+			setLops(wcemm);
 		}
 		else //general case
 		{
@@ -1218,9 +1221,9 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 			boolean cacheV = !FORCE_REPLICATION && ((!cacheU && m2Size < memBudgetExec ) 
 					        || (cacheU && m1Size+m2Size < memBudgetExec)) && 2*m2Size < memBudgetLocal;
 			
-			//reduce-side wsloss w/ or without broadcast
+			//reduce-side wcemm w/ or without broadcast
 			Lop wcemm = new WeightedCrossEntropyR( 
-					X.constructLops(), U.constructLops(), V.constructLops(), 
+					X.constructLops(), U.constructLops(), V.constructLops(), eps.constructLops(),
 					DataType.SCALAR, ValueType.DOUBLE, wtype, cacheU, cacheV, ExecType.SPARK);
 			setOutputDimensions(wcemm);
 			setLineNumbers(wcemm);
@@ -1241,7 +1244,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 				HopsOpOp1LopsU.get(_uop) : _sop==OpOp2.POW ? 
 				Unary.OperationTypes.POW2 : Unary.OperationTypes.MULTIPLY2;	
 		
-		WeightedUnaryMM wsig = new WeightedUnaryMM(
+		WeightedUnaryMM wumm = new WeightedUnaryMM(
 				getInput().get(0).constructLops(),
 				getInput().get(1).constructLops(),
 				getInput().get(2).constructLops(),
@@ -1249,11 +1252,11 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 		
 		//set degree of parallelism
 		int k = OptimizerUtils.getConstrainedNumThreads(_maxNumThreads);
-		wsig.setNumThreads(k);
+		wumm.setNumThreads(k);
 		
-		setOutputDimensions( wsig );
-		setLineNumbers( wsig );
-		setLops( wsig );
+		setOutputDimensions( wumm );
+		setLineNumbers( wumm );
+		setLops( wumm );
 	}
 	
 	/**
@@ -1265,9 +1268,9 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 	private void constructMRLopsWeightedUMM( WUMMType wtype ) 
 		throws HopsException, LopsException
 	{
-		//NOTE: the common case for wsigmoid are factors U/V with a rank of 10s to 100s; the current runtime only
+		//NOTE: the common case for wumm are factors U/V with a rank of 10s to 100s; the current runtime only
 		//supports single block outer products (U/V rank <= blocksize, i.e., 1000 by default); we enforce this
-		//by applying the hop rewrite for Weighted Squared Loss only if this constraint holds. 
+		//by applying the hop rewrite for Weighted UnaryMM  only if this constraint holds. 
 		
 		Unary.OperationTypes uop = _uop!=null ? 
 				HopsOpOp1LopsU.get(_uop) : _sop==OpOp2.POW ? 
@@ -1280,9 +1283,9 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 		//MR operator selection, part1
 		double m1Size = OptimizerUtils.estimateSize(U.getDim1(), U.getDim2()); //size U
 		double m2Size = OptimizerUtils.estimateSize(V.getDim1(), V.getDim2()); //size V
-		boolean isMapWsloss = (m1Size+m2Size < OptimizerUtils.getRemoteMemBudgetMap(true)); 
+		boolean isMapWumm = (m1Size+m2Size < OptimizerUtils.getRemoteMemBudgetMap(true)); 
 		
-		if( !FORCE_REPLICATION && isMapWsloss ) //broadcast
+		if( !FORCE_REPLICATION && isMapWumm ) //broadcast
 		{
 			//partitioning of U
 			boolean needPartU = !U.dimsKnown() || U.getDim1() * U.getDim2() > DistributedCacheInput.PARTITION_SIZE;
@@ -1302,7 +1305,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 				setLineNumbers(lV);	
 			}
 			
-			//map-side wsloss always with broadcast
+			//map-side wumm always with broadcast
 			Lop wumm = new WeightedUnaryMM( X.constructLops(), lU, lV,  
 					DataType.MATRIX, ValueType.DOUBLE, wtype, uop, ExecType.MR);
 			setOutputDimensions(wumm);
@@ -1377,7 +1380,7 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 				lV = grpV;
 			}
 			
-			//reduce-side wsloss w/ or without broadcast
+			//reduce-side wumm w/ or without broadcast
 			Lop wumm = new WeightedUnaryMMR( 
 					grpX, lU, lV, DataType.MATRIX, ValueType.DOUBLE, wtype, uop, cacheU, cacheV, ExecType.MR);
 			setOutputDimensions(wumm);
@@ -1397,9 +1400,9 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 	private void constructSparkLopsWeightedUMM( WUMMType wtype ) 
 		throws HopsException, LopsException
 	{
-		//NOTE: the common case for wsigmoid are factors U/V with a rank of 10s to 100s; the current runtime only
+		//NOTE: the common case for wumm are factors U/V with a rank of 10s to 100s; the current runtime only
 		//supports single block outer products (U/V rank <= blocksize, i.e., 1000 by default); we enforce this
-		//by applying the hop rewrite for Weighted Squared Loss only if this constraint holds. 
+		//by applying the hop rewrite for Weighted UnaryMM only if this constraint holds. 
 
 		Unary.OperationTypes uop = _uop!=null ? 
 				HopsOpOp1LopsU.get(_uop) : _sop==OpOp2.POW ? 
@@ -1423,12 +1426,12 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 		
 		if( !FORCE_REPLICATION && isMapWsloss ) //broadcast
 		{
-			//map-side wsloss always with broadcast
-			Lop wsigmoid = new WeightedUnaryMM( X.constructLops(), U.constructLops(), V.constructLops(),  
+			//map-side wumm always with broadcast
+			Lop wumm = new WeightedUnaryMM( X.constructLops(), U.constructLops(), V.constructLops(),  
 					DataType.MATRIX, ValueType.DOUBLE, wtype, uop, ExecType.SPARK);
-			setOutputDimensions(wsigmoid);
-			setLineNumbers(wsigmoid);
-			setLops( wsigmoid );
+			setOutputDimensions(wumm);
+			setLineNumbers(wumm);
+			setLops( wumm );
 		}
 		else //general case
 		{
@@ -1437,13 +1440,13 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 			boolean cacheV = !FORCE_REPLICATION && ((!cacheU && m2Size < memBudgetExec ) 
 					        || (cacheU && m1Size+m2Size < memBudgetExec)) && 2*m2Size < memBudgetLocal;
 			
-			//reduce-side wsloss w/ or without broadcast
-			Lop wsigmoid = new WeightedUnaryMMR( 
+			//reduce-side wumm w/ or without broadcast
+			Lop wumm = new WeightedUnaryMMR( 
 					X.constructLops(), U.constructLops(), V.constructLops(), 
 					DataType.MATRIX, ValueType.DOUBLE, wtype, uop, cacheU, cacheV, ExecType.SPARK);
-			setOutputDimensions(wsigmoid);
-			setLineNumbers(wsigmoid);
-			setLops(wsigmoid);
+			setOutputDimensions(wumm);
+			setLineNumbers(wumm);
+			setLops(wumm);
 		}
 	}
 	
@@ -1515,6 +1518,15 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 		}
 		
 		return null;
+	}
+	
+	/**
+	 * 
+	 * @return
+	 */
+	private WCeMMType checkWCeMMType()
+	{
+		return _baseType == 1 ? WCeMMType.BASIC_EPS : WCeMMType.BASIC;
 	}
 	
 	@Override

--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteAlgebraicSimplificationDynamic.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteAlgebraicSimplificationDynamic.java
@@ -2140,8 +2140,8 @@ public class RewriteAlgebraicSimplificationDynamic extends HopRewriteRule
 		throws HopsException
 	{
 		Hop hnew = null;
+		boolean appliedPattern = false;
 		
-		//Pattern 1) sum( X * log(U %*% t(V)))
 		if( hi instanceof AggUnaryOp && ((AggUnaryOp)hi).getDirection()==Direction.RowCol
 			&& ((AggUnaryOp)hi).getOp() == AggOp.SUM     //pattern rooted by sum()
 			&& hi.getInput().get(0) instanceof BinaryOp  //pattern subrooted by binary op
@@ -2151,6 +2151,7 @@ public class RewriteAlgebraicSimplificationDynamic extends HopRewriteRule
 			Hop left = bop.getInput().get(0);
 			Hop right = bop.getInput().get(1);
 			
+			//Pattern 1) sum( X * log(U %*% t(V)))
 			if( bop.getOp()==OpOp2.MULT && left.getDataType()==DataType.MATRIX		
 				&& HopRewriteUtils.isEqualSize(left, right)  //prevent mb
 				&& right instanceof UnaryOp	&& ((UnaryOp)right).getOp()==OpOp1.LOG
@@ -2166,10 +2167,41 @@ public class RewriteAlgebraicSimplificationDynamic extends HopRewriteRule
 				else 
 					V = V.getInput().get(0);
 					
-				hnew = new QuaternaryOp(hi.getName(), DataType.SCALAR, ValueType.DOUBLE, OpOp4.WCEMM, X, U, V);
+				hnew = new QuaternaryOp(hi.getName(), DataType.SCALAR, ValueType.DOUBLE, OpOp4.WCEMM, X, U, V,
+						new LiteralOp(-1), 0, false, false);
+				HopRewriteUtils.setOutputBlocksizes(hnew, X.getRowsInBlock(), X.getColsInBlock());
+				appliedPattern = true;
+				
+				LOG.debug("Applied simplifyWeightedCEMM (line "+hi.getBeginLine()+")");					
+			}
+			
+			//Pattern 2) sum( X * log(U %*% t(V) + eps))
+			if( !appliedPattern
+				&& bop.getOp()==OpOp2.MULT && left.getDataType()==DataType.MATRIX		
+				&& HopRewriteUtils.isEqualSize(left, right)
+				&& right instanceof UnaryOp	&& ((UnaryOp)right).getOp()==OpOp1.LOG
+				&& right.getInput().get(0) instanceof BinaryOp
+				&& ((BinaryOp)right.getInput().get(0)).getOp() == OpOp2.PLUS
+				&& right.getInput().get(0).getInput().get(0) instanceof AggBinaryOp
+				&& right.getInput().get(0).getInput().get(1) instanceof LiteralOp
+				&& right.getInput().get(0).getInput().get(1).getDataType() == DataType.SCALAR
+				&& HopRewriteUtils.isSingleBlock(right.getInput().get(0).getInput().get(0).getInput().get(0),true))
+			{
+				Hop X = left; 
+				Hop U = right.getInput().get(0).getInput().get(0).getInput().get(0);
+				Hop V = right.getInput().get(0).getInput().get(0).getInput().get(1);
+				Hop eps = right.getInput().get(0).getInput().get(1);
+				
+				if( !HopRewriteUtils.isTransposeOperation(V) )
+					V = HopRewriteUtils.createTranspose(V);
+				else 
+					V = V.getInput().get(0);
+					
+				hnew = new QuaternaryOp(hi.getName(), DataType.SCALAR, ValueType.DOUBLE, 
+						OpOp4.WCEMM, X, U, V, eps, 1, false, false); // 1 => BASIC_EPS
 				HopRewriteUtils.setOutputBlocksizes(hnew, X.getRowsInBlock(), X.getColsInBlock());
 					
-				LOG.debug("Applied simplifyWeightedCEMM (line "+hi.getBeginLine()+")");					
+				LOG.debug("Applied simplifyWeightedCEMMEps (line "+hi.getBeginLine()+")");					
 			}
 		}
 		

--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteAlgebraicSimplificationDynamic.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteAlgebraicSimplificationDynamic.java
@@ -2168,7 +2168,7 @@ public class RewriteAlgebraicSimplificationDynamic extends HopRewriteRule
 					V = V.getInput().get(0);
 					
 				hnew = new QuaternaryOp(hi.getName(), DataType.SCALAR, ValueType.DOUBLE, OpOp4.WCEMM, X, U, V,
-						new LiteralOp(-1), 0, false, false);
+						new LiteralOp(0.0), 0, false, false);
 				HopRewriteUtils.setOutputBlocksizes(hnew, X.getRowsInBlock(), X.getColsInBlock());
 				appliedPattern = true;
 				

--- a/src/main/java/org/apache/sysml/lops/WeightedCrossEntropyR.java
+++ b/src/main/java/org/apache/sysml/lops/WeightedCrossEntropyR.java
@@ -39,16 +39,18 @@ public class WeightedCrossEntropyR extends Lop
 	private boolean _cacheU = false;
 	private boolean _cacheV = false;
 	
-	public WeightedCrossEntropyR(Lop input1, Lop input2, Lop input3, DataType dt, ValueType vt, WCeMMType wt, boolean cacheU, boolean cacheV, ExecType et) 
+	public WeightedCrossEntropyR(Lop input1, Lop input2, Lop input3, Lop input4, DataType dt, ValueType vt, WCeMMType wt, boolean cacheU, boolean cacheV, ExecType et) 
 		throws LopsException 
 	{
 		super(Lop.Type.WeightedCeMM, dt, vt);		
 		addInput(input1); //X
 		addInput(input2); //U
 		addInput(input3); //V
+		addInput(input4); //optional
 		input1.addOutput(this); 
 		input2.addOutput(this);
 		input3.addOutput(this);
+		input4.addOutput(this);
 		
 		//setup mapmult parameters
 		_wcemmType = wt;
@@ -91,21 +93,24 @@ public class WeightedCrossEntropyR extends Lop
 	}
 	
 	@Override
-	public String getInstructions(int input1, int input2, int input3, int output)
+	public String getInstructions(int input1, int input2, int input3, int input4, int output)
 	{
 		return getInstructions(
 				String.valueOf(input1),
 				String.valueOf(input2),
 				String.valueOf(input3),
+				String.valueOf(input4),
 				String.valueOf(output));
 	}
 
 	@Override
-	public String getInstructions(String input1, String input2, String input3, String output)
+	public String getInstructions(String input1, String input2, String input3, String input4, String output)
 	{
 		StringBuilder sb = new StringBuilder();
 		
-		sb.append(getExecType());
+		final ExecType et = getExecType();
+		
+		sb.append(et);
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
 		sb.append(OPCODE);
@@ -118,7 +123,15 @@ public class WeightedCrossEntropyR extends Lop
 		
 		sb.append(Lop.OPERAND_DELIMITOR);
 		sb.append( getInputs().get(2).prepInputOperand(input3));
-	
+		
+		sb.append(Lop.OPERAND_DELIMITOR);
+		if ( (et == ExecType.MR) && (getInputs().get(3).getDataType() == DataType.SCALAR) ) {
+			sb.append( getInputs().get(3).prepScalarInputOperand(et));
+		}
+		else {
+			sb.append( getInputs().get(3).prepInputOperand(input4));
+		}
+		
 		sb.append(Lop.OPERAND_DELIMITOR);
 		sb.append( prepOutputOperand(output));
 		

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/QuaternaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/QuaternaryCPInstruction.java
@@ -65,7 +65,7 @@ public class QuaternaryCPInstruction extends ComputationCPInstruction
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(inst);
 		String opcode = parts[0];
 		
-		if( opcode.equalsIgnoreCase("wsloss") || opcode.equalsIgnoreCase("wdivmm") ) 
+		if( opcode.equalsIgnoreCase("wsloss") || opcode.equalsIgnoreCase("wdivmm") || opcode.equalsIgnoreCase("wcemm") ) 
 		{
 			InstructionUtils.checkNumFields ( parts, 7 );
 			
@@ -80,8 +80,10 @@ public class QuaternaryCPInstruction extends ComputationCPInstruction
 				return new QuaternaryCPInstruction(new QuaternaryOperator(WeightsType.valueOf(parts[6])), in1, in2, in3, in4, out, k, opcode, inst);	
 			else if( opcode.equalsIgnoreCase("wdivmm") )
 				return new QuaternaryCPInstruction(new QuaternaryOperator(WDivMMType.valueOf(parts[6])), in1, in2, in3, in4, out, k, opcode, inst);				
+			else if( opcode.equalsIgnoreCase("wcemm") ) 		
+				return new QuaternaryCPInstruction(new QuaternaryOperator(WCeMMType.valueOf(parts[6])), in1, in2, in3, in4, out, k, opcode, inst);
 		}
-		else if( opcode.equalsIgnoreCase("wsigmoid") || opcode.equalsIgnoreCase("wcemm") )
+		else if( opcode.equalsIgnoreCase("wsigmoid") )
 		{
 			InstructionUtils.checkNumFields ( parts, 6 );
 			
@@ -93,8 +95,6 @@ public class QuaternaryCPInstruction extends ComputationCPInstruction
 			
 			if( opcode.equalsIgnoreCase("wsigmoid") )
 				return new QuaternaryCPInstruction(new QuaternaryOperator(WSigmoidType.valueOf(parts[5])), in1, in2, in3, null, out, k, opcode, inst);
-			else if( opcode.equalsIgnoreCase("wcemm") ) 		
-				return new QuaternaryCPInstruction(new QuaternaryOperator(WCeMMType.valueOf(parts[5])), in1, in2, in3, null, out, k, opcode, inst);
 		}
 		else if( opcode.equalsIgnoreCase("wumm") )
 		{
@@ -143,7 +143,8 @@ public class QuaternaryCPInstruction extends ComputationCPInstruction
 		ec.releaseMatrixInput(input2.getName());
 		ec.releaseMatrixInput(input3.getName());
 		if( qop.wtype1 != null || qop.wtype4 != null ) { //wsloss/wcemm
-			if( qop.wtype1 != null && qop.wtype1.hasFourInputs() )
+			if( (qop.wtype1 != null && qop.wtype1.hasFourInputs()) ||
+				(qop.wtype4 != null && qop.wtype4.hasFourInputs()) )
 				if (input4.getDataType() == DataType.MATRIX) {
 					ec.releaseMatrixInput(input4.getName());
 				}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/QuaternaryInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/QuaternaryInstruction.java
@@ -206,7 +206,7 @@ public class QuaternaryInstruction extends MRInstruction implements IDistributed
 		{
 			boolean isRed = opcode.startsWith("red");
 			
-			//check number of fields (3 inputs, output, type)
+			//check number of fields (4 inputs, output, type)
 			if( isRed )
 				InstructionUtils.checkNumFields ( str, 8 );
 			else
@@ -232,12 +232,13 @@ public class QuaternaryInstruction extends MRInstruction implements IDistributed
 		else //wsigmoid / wcemm
 		{
 			boolean isRed = opcode.startsWith("red");
+			int addInput4 = (opcode.endsWith("wcemm")) ? 1 : 0;
 			
-			//check number of fields (3 inputs, output, type)
+			//check number of fields (3 or 4 inputs, output, type)
 			if( isRed )
-				InstructionUtils.checkNumFields ( str, 7 );
+				InstructionUtils.checkNumFields ( str, 7 + addInput4 );
 			else
-				InstructionUtils.checkNumFields ( str, 5 );
+				InstructionUtils.checkNumFields ( str, 5 + addInput4 );
 				
 			//parse instruction parts (without exec type)
 			String[] parts = InstructionUtils.getInstructionParts(str);
@@ -245,16 +246,16 @@ public class QuaternaryInstruction extends MRInstruction implements IDistributed
 			byte in1 = Byte.parseByte(parts[1]);
 			byte in2 = Byte.parseByte(parts[2]);
 			byte in3 = Byte.parseByte(parts[3]);
-			byte out = Byte.parseByte(parts[4]);
+			byte out = Byte.parseByte(parts[4 + addInput4]);
 			
 			//in mappers always through distcache, in reducers through distcache/shuffle
-			boolean cacheU = isRed ? Boolean.parseBoolean(parts[6]) : true;
-			boolean cacheV = isRed ? Boolean.parseBoolean(parts[7]) : true;
+			boolean cacheU = isRed ? Boolean.parseBoolean(parts[6 + addInput4]) : true;
+			boolean cacheV = isRed ? Boolean.parseBoolean(parts[7 + addInput4]) : true;
 			
 			if( opcode.endsWith("wsigmoid") )
 				return new QuaternaryInstruction(new QuaternaryOperator(WSigmoidType.valueOf(parts[5])), in1, in2, in3, (byte)-1, out, cacheU, cacheV, str);
 			else if( opcode.endsWith("wcemm") )
-				return new QuaternaryInstruction(new QuaternaryOperator(WCeMMType.valueOf(parts[5])), in1, in2, in3, (byte)-1, out, cacheU, cacheV, str);
+				return new QuaternaryInstruction(new QuaternaryOperator(WCeMMType.valueOf(parts[6])), in1, in2, in3, (byte)-1, out, cacheU, cacheV, str);
 		}
 		
 		return null;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/QuaternarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/QuaternarySPInstruction.java
@@ -152,7 +152,7 @@ public class QuaternarySPInstruction extends ComputationSPInstruction
 		{
 			boolean isRed = opcode.startsWith("red");
 			
-			//check number of fields (3 inputs, output, type)
+			//check number of fields (4 inputs, output, type)
 			if( isRed )
 				InstructionUtils.checkNumFields( parts, 8 );
 			else
@@ -175,26 +175,31 @@ public class QuaternarySPInstruction extends ComputationSPInstruction
 		else //map/redwsigmoid, map/redwcemm
 		{
 			boolean isRed = opcode.startsWith("red");
+			int addInput4 = (opcode.endsWith("wcemm")) ? 1 : 0;
 			
-			//check number of fields (3 inputs, output, type)
+			//check number of fields (3 or 4 inputs, output, type)
 			if( isRed )
-				InstructionUtils.checkNumFields( parts, 7 );
+				InstructionUtils.checkNumFields( parts, 7 + addInput4 );
 			else
-				InstructionUtils.checkNumFields( parts, 5 );
+				InstructionUtils.checkNumFields( parts, 5 + addInput4 );
 			
 			CPOperand in1 = new CPOperand(parts[1]);
 			CPOperand in2 = new CPOperand(parts[2]);
 			CPOperand in3 = new CPOperand(parts[3]);
-			CPOperand out = new CPOperand(parts[4]);
+			CPOperand out = new CPOperand(parts[4 + addInput4]);
 			
 			//in mappers always through distcache, in reducers through distcache/shuffle
-			boolean cacheU = isRed ? Boolean.parseBoolean(parts[6]) : true;
-			boolean cacheV = isRed ? Boolean.parseBoolean(parts[7]) : true;
+			boolean cacheU = isRed ? Boolean.parseBoolean(parts[6 + addInput4]) : true;
+			boolean cacheV = isRed ? Boolean.parseBoolean(parts[7 + addInput4]) : true;
 		
 			if( opcode.endsWith("wsigmoid") )
 				return new QuaternarySPInstruction(new QuaternaryOperator(WSigmoidType.valueOf(parts[5])), in1, in2, in3, null, out, cacheU, cacheV, opcode, str);
-			else if( opcode.endsWith("wcemm") )
-				return new QuaternarySPInstruction(new QuaternaryOperator(WCeMMType.valueOf(parts[5])), in1, in2, in3, null, out, cacheU, cacheV, opcode, str);
+			else if( opcode.endsWith("wcemm") ) {
+				CPOperand in4 = new CPOperand(parts[4]);
+				final WCeMMType wt = WCeMMType.valueOf(parts[6]);
+				QuaternaryOperator qop = (wt.hasFourInputs() ? new QuaternaryOperator(wt, Double.parseDouble(in4.getName())) : new QuaternaryOperator(wt));
+				return new QuaternarySPInstruction(qop, in1, in2, in3, in4, out, cacheU, cacheV, opcode, str);
+			}
 		}
 		
 		return null;
@@ -237,7 +242,7 @@ public class QuaternarySPInstruction extends ComputationSPInstruction
 			PartitionedBroadcastMatrix bc2 = sec.getBroadcastForVariable( input3.getName() );
 			
 			//partitioning-preserving mappartitions (key access required for broadcast loopkup)
-			boolean noKeyChange = (qop.wtype3 == null || qop.wtype3.isBasic()); //only wsdivmm changes keys
+			boolean noKeyChange = (qop.wtype3 == null || qop.wtype3.isBasic()); //only wdivmm changes keys
 			out = in.mapPartitionsToPair(new RDDQuaternaryFunction1(qop, bc1, bc2), noKeyChange);
 			
 			rddVars.add( input1.getName() );

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/MatrixBlock.java
@@ -5802,10 +5802,15 @@ public class MatrixBlock extends MatrixValue implements Externalizable
 				LibMatrixMult.matrixMultWDivMM(X, U, V, W, R, qop.wtype3);	
 		}
 		else if( qop.wtype4 != null ){ //wcemm
+			MatrixBlock W = qop.wtype4.hasFourInputs() ? checkType(wm) : null;
+			if( qop.getScalar() != 0 ) {
+				W = new MatrixBlock(1, 1, false);
+				W.quickSetValue(0, 0, qop.getScalar());
+			}
 			if( k > 1 )
-				LibMatrixMult.matrixMultWCeMM(X, U, V, R, qop.wtype4, k);
+				LibMatrixMult.matrixMultWCeMM(X, U, V, W, R, qop.wtype4, k);
 			else
-				LibMatrixMult.matrixMultWCeMM(X, U, V, R, qop.wtype4);	
+				LibMatrixMult.matrixMultWCeMM(X, U, V, W, R, qop.wtype4);
 		}
 		else if( qop.wtype5 != null ){ //wumm
 			if( k > 1 )

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/MatrixBlock.java
@@ -5803,14 +5803,12 @@ public class MatrixBlock extends MatrixValue implements Externalizable
 		}
 		else if( qop.wtype4 != null ){ //wcemm
 			MatrixBlock W = qop.wtype4.hasFourInputs() ? checkType(wm) : null;
-			if( qop.getScalar() != 0 ) {
-				W = new MatrixBlock(1, 1, false);
-				W.quickSetValue(0, 0, qop.getScalar());
-			}
+			double eps = (W != null && W.getNumRows() == 1 && W.getNumColumns() == 1) ? W.quickGetValue(0, 0) : qop.getScalar();
+			
 			if( k > 1 )
-				LibMatrixMult.matrixMultWCeMM(X, U, V, W, R, qop.wtype4, k);
+				LibMatrixMult.matrixMultWCeMM(X, U, V, eps, R, qop.wtype4, k);
 			else
-				LibMatrixMult.matrixMultWCeMM(X, U, V, W, R, qop.wtype4);
+				LibMatrixMult.matrixMultWCeMM(X, U, V, eps, R, qop.wtype4);
 		}
 		else if( qop.wtype5 != null ){ //wumm
 			if( k > 1 )

--- a/src/main/java/org/apache/sysml/runtime/matrix/operators/QuaternaryOperator.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/operators/QuaternaryOperator.java
@@ -93,6 +93,16 @@ public class QuaternaryOperator extends Operator
 	}
 	
 	/**
+	 * wcemm w/epsilon
+	 * 
+	 * @param wt
+	 */
+	public QuaternaryOperator( WCeMMType wt, double epsilon) {
+		wtype4 = wt;
+		eps = epsilon;
+	}
+	
+	/**
 	 * wumm
 	 * 
 	 * @param wt
@@ -115,7 +125,8 @@ public class QuaternaryOperator extends Operator
 	 */
 	public boolean hasFourInputs() {
 		return (wtype1 != null && wtype1.hasFourInputs())
-			|| (wtype3 != null && wtype3.hasFourInputs());
+			|| (wtype3 != null && wtype3.hasFourInputs())
+			|| (wtype4 != null && wtype4.hasFourInputs());
 	}
 	
 	/**

--- a/src/test/scripts/functions/quaternary/WeightedCeMMEps.R
+++ b/src/test/scripts/functions/quaternary/WeightedCeMMEps.R
@@ -1,0 +1,38 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+args <- commandArgs(TRUE)
+options(digits=22)
+
+library("Matrix")
+
+X = as.matrix(readMM(paste(args[1], "X.mtx", sep="")))
+U = as.matrix(readMM(paste(args[1], "U.mtx", sep="")))
+V = as.matrix(readMM(paste(args[1], "V.mtx", sep="")))
+
+eps = as.numeric(args[3])
+
+R = as.matrix(sum(X * log(U%*%t(V) + eps)));
+
+writeMM(as(R, "CsparseMatrix"), paste(args[2], "R", sep="")); 
+
+

--- a/src/test/scripts/functions/quaternary/WeightedCeMMEps.dml
+++ b/src/test/scripts/functions/quaternary/WeightedCeMMEps.dml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+
+X = read($1);
+U = read($2);
+V = read($3);
+
+eps = $5;
+
+R = as.matrix(sum(X * log(U%*%t(V) + eps)));
+
+write(R, $4);


### PR DESCRIPTION
This patch adds support to wcemm for handling pattern (sum(X*log(U%*%t(V) + epsilon))).
It leverages functionality from previous PRs under SYSTEMML-510 and SYSTEMML-488 to generalize the wcemm operator with four operands.  Also included are 8 new test cases to cover Dense and Sparse-Dense for CP, MR, and Spark plus reduce-side.
