### PR TITLE
[SYSTEMML-604] Undefined function error message line, col, filename

### DIFF
--- a/src/main/java/org/apache/sysml/parser/StatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/StatementBlock.java
@@ -195,11 +195,6 @@ public class StatementBlock extends LiveVariableAnalysis
 			//function calls (only mergable if inlined dml-bodied function)
 			if (sourceExpr instanceof FunctionCallIdentifier){
 				
-				sourceExpr.setBeginLine(stmt.getBeginLine());
-				sourceExpr.setBeginColumn(stmt.getBeginColumn());
-				sourceExpr.setEndLine(stmt.getEndLine());
-				sourceExpr.setEndColumn(stmt.getEndColumn());
-				sourceExpr.setFilename(stmt.getFilename());
 				
 				FunctionCallIdentifier fcall = (FunctionCallIdentifier) sourceExpr;
 				FunctionStatementBlock fblock = dmlProg.getFunctionStatementBlock(fcall.getNamespace(), fcall.getName());

--- a/src/main/java/org/apache/sysml/parser/StatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/StatementBlock.java
@@ -194,8 +194,6 @@ public class StatementBlock extends LiveVariableAnalysis
 			
 			//function calls (only mergable if inlined dml-bodied function)
 			if (sourceExpr instanceof FunctionCallIdentifier){
-				
-				
 				FunctionCallIdentifier fcall = (FunctionCallIdentifier) sourceExpr;
 				FunctionStatementBlock fblock = dmlProg.getFunctionStatementBlock(fcall.getNamespace(), fcall.getName());
 				if (fblock == null){

--- a/src/main/java/org/apache/sysml/parser/StatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/StatementBlock.java
@@ -194,6 +194,13 @@ public class StatementBlock extends LiveVariableAnalysis
 			
 			//function calls (only mergable if inlined dml-bodied function)
 			if (sourceExpr instanceof FunctionCallIdentifier){
+				
+				sourceExpr.setBeginLine(stmt.getBeginLine());
+				sourceExpr.setBeginColumn(stmt.getBeginColumn());
+				sourceExpr.setEndLine(stmt.getEndLine());
+				sourceExpr.setEndColumn(stmt.getEndColumn());
+				sourceExpr.setFilename(stmt.getFilename());
+				
 				FunctionCallIdentifier fcall = (FunctionCallIdentifier) sourceExpr;
 				FunctionStatementBlock fblock = dmlProg.getFunctionStatementBlock(fcall.getNamespace(), fcall.getName());
 				if (fblock == null){

--- a/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
@@ -697,6 +697,8 @@ public abstract class CommonSyntacticValidator {
 		functCall.setFunctionName(functionName);
 		functCall.setFunctionNamespace(namespace);
 
+		functCall.setAllPositions(currentFile, ctx.start.getLine(), ctx.start.getCharPositionInLine(), ctx.stop.getLine(), ctx.stop.getCharPositionInLine());
+
 		setAssignmentStatement(ctx, info, target, functCall);
 	}
 


### PR DESCRIPTION
Previously, the following DML:
```
print("howdy");
a=foo();
```
produced error message with null filename and no line number or column number set:
```
Caused by: org.apache.sysml.parser.LanguageException: ERROR: null -- line 0, column 0 -- function foo is undefined in namespace .defaultNS
	at org.apache.sysml.parser.StatementBlock.isMergeableFunctionCallBlock(StatementBlock.java:201)
```

This update populates the filename, line number, and column number:
```
Caused by: org.apache.sysml.parser.LanguageException: ERROR: example.dml -- line 2, column 0 -- function foo is undefined in namespace .defaultNS
	at org.apache.sysml.parser.StatementBlock.isMergeableFunctionCallBlock(StatementBlock.java:208)
```