### PR TITLE
[SYSTEMML-611] Enhance display of parsing errors for user

### DIFF
--- a/src/main/java/org/apache/sysml/api/DMLScript.java
+++ b/src/main/java/org/apache/sysml/api/DMLScript.java
@@ -83,6 +83,7 @@ import org.apache.sysml.utils.Statistics;
 import org.apache.sysml.yarn.DMLAppMasterUtils;
 // import org.apache.sysml.utils.visualize.DotGraph;
 import org.apache.sysml.yarn.DMLYarnClientProxy;
+import org.xml.sax.SAXException;
 
 
 public class DMLScript 
@@ -188,7 +189,9 @@ public class DMLScript
 		String[] otherArgs = new GenericOptionsParser(conf, args).getRemainingArgs();
 		
 		try {
-		DMLScript.executeScript(conf, otherArgs); 
+			DMLScript.executeScript(conf, otherArgs);
+		} catch (ParseException pe) {
+			System.err.println(pe.getMessage());
 		} catch (DMLScriptException e){
 			// In case of DMLScriptException, simply print the error message.
 			System.err.println(e.getMessage());
@@ -196,7 +199,7 @@ public class DMLScript
 	} 
 
 	public static boolean executeScript( String[] args ) 
-		throws DMLException
+		throws DMLException, ParseException
 	{
 		Configuration conf = new Configuration(ConfigurationManager.getCachedJobConf());
 		return executeScript( conf, args );
@@ -210,9 +213,10 @@ public class DMLScript
 	 * @param suppress
 	 * @return
 	 * @throws DMLException
+	 * @throws ParseException
 	 */
 	public static String executeScript( Configuration conf, String[] args, boolean suppress) 
-		throws DMLException
+		throws DMLException, ParseException
 	{
 		_suppressPrint2Stdout = suppress;
 		try {
@@ -230,10 +234,11 @@ public class DMLScript
 	 * @param conf
 	 * @param args
 	 * @return
-	 * @throws LanguageException 
+	 * @throws DMLException 
+	 * @throws ParseException 
 	 */
 	public static boolean executeScript( Configuration conf, String[] args ) 
-		throws DMLException
+		throws DMLException, ParseException
 	{
 		boolean ret = false;
 		
@@ -333,6 +338,9 @@ public class DMLScript
 			}
 			
 			ret = true;
+		}
+		catch (ParseException pe) {
+			throw pe;
 		}
 		catch (DMLScriptException e) {
 			//rethrow DMLScriptException to propagate stop call

--- a/src/main/java/org/apache/sysml/api/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/MLContext.java
@@ -1309,7 +1309,12 @@ public class MLContext {
 		
 		//parsing
 		AParserWrapper parser = AParserWrapper.createParser(parsePyDML);
-		DMLProgram prog = parser.parse(dmlScriptFilePath, dmlScriptStr, argVals);
+		DMLProgram prog;
+		if (isFile) {
+			prog = parser.parse(dmlScriptFilePath, null, argVals);
+		} else {
+			prog = parser.parse(null, dmlScriptStr, argVals);
+		}
 		
 		//language validate
 		DMLTranslator dmlt = new DMLTranslator(prog);

--- a/src/main/java/org/apache/sysml/parser/ParseException.java
+++ b/src/main/java/org/apache/sysml/parser/ParseException.java
@@ -19,74 +19,231 @@
 
 package org.apache.sysml.parser;
 
+import java.util.List;
+
+import org.apache.sysml.parser.common.CustomErrorListener.ParseIssue;
+
 /**
- * This exception is thrown when parse errors are encountered.
- * You can explicitly create objects of this exception type by
- * calling the method generateParseException in the generated
- * parser.
- *
- * You can modify this class to customize your error reporting
- * mechanisms so long as you retain the public fields.
- * 
+ * This exception is thrown when parse issues are encountered.
  * 
  * NOTE: MB: Originally, this exception was generated with javacc.
- * Unfortunately, many classes directly use this exception. Hence,
- * on removing javacc we kept a condensed version of it.
- * TODO: eventually we should remove the token class and create our
- * own exception or just use LanguageException.
+ * Unfortunately, many classes directly use this exception. Hence, on removing
+ * javacc we kept a condensed version of it. TODO: eventually we should remove
+ * the token class and create our own exception or just use LanguageException.
  */
-public class ParseException extends Exception 
-{
-	
-  /**
-   * The version identifier for this Serializable class.
-   * Increment only if the <i>serialized</i> form of the
-   * class changes.
-   */
-  private static final long serialVersionUID = 1L;
+public class ParseException extends Exception {
 
-  /**
-   * The following constructors are for use by you for whatever
-   * purpose you can think of.  Constructing the exception in this
-   * manner makes the exception behave in the normal way - i.e., as
-   * documented in the class "Throwable".  The fields "errorToken",
-   * "expectedTokenSequences", and "tokenImage" do not contain
-   * relevant information.  The JavaCC generated code does not use
-   * these constructors.
-   */
+	/**
+	 * The version identifier for this Serializable class. Increment only if the
+	 * <i>serialized</i> form of the class changes.
+	 */
+	private static final long serialVersionUID = 1L;
 
-  public ParseException() {
-    super();
-  }
+	/**
+	 * The following constructors are for use by you for whatever purpose you
+	 * can think of. Constructing the exception in this manner makes the
+	 * exception behave in the normal way - i.e., as documented in the class
+	 * "Throwable". The fields "errorToken", "expectedTokenSequences", and
+	 * "tokenImage" do not contain relevant information. The JavaCC generated
+	 * code does not use these constructors.
+	 */
 
-  /** Constructor with message. */
-  public ParseException(String message) {
-    super(message);
-  }
-  
-  public ParseException(String message, Exception e) {
-	  super(message, e);
-  }
-  /**
-   * This is the last token that has been consumed successfully.  If
-   * this object has been created due to a parse error, the token
-   * following this token will (therefore) be the first error token.
-   */
-  public Token currentToken;
+	public ParseException() {
+		super();
+	}
 
-  /**
-   * Each entry in this array is an array of integers.  Each array
-   * of integers represents a sequence of tokens (by their ordinal
-   * values) that is expected at this point of the parse.
-   */
-  public int[][] expectedTokenSequences;
+	/** Constructor with message. */
+	public ParseException(String message) {
+		super(message);
+		this.message = message;
+	}
 
-  /**
-   * This is a reference to the "tokenImage" array of the generated
-   * parser within which the parse error occurred.  This array is
-   * defined in the generated ...Constants interface.
-   */
-  public String[] tokenImage;
+	public ParseException(String message, Exception e) {
+		super(message, e);
+		this.message = message;
+	}
 
+	/**
+	 * This constructor takes a list of parse issues that were generated during
+	 * script parsing and the original DML/PyDML script String.
+	 * 
+	 * @param parseIssues
+	 *            List of parse issues (syntax errors, validation errors, and
+	 *            validation warnings) generated during parsing.
+	 * @param scriptString
+	 *            The DML/PyDML script String.
+	 */
+	public ParseException(List<ParseIssue> parseIssues, String scriptString) {
+		super();
+		this.parseIssues = parseIssues;
+		this.scriptString = scriptString;
+	}
+
+	/**
+	 * This is the last token that has been consumed successfully. If this
+	 * object has been created due to a parse issue, the token following this
+	 * token will (therefore) be the first error token.
+	 */
+	public Token currentToken;
+
+	/**
+	 * Each entry in this array is an array of integers. Each array of integers
+	 * represents a sequence of tokens (by their ordinal values) that is
+	 * expected at this point of the parse.
+	 */
+	public int[][] expectedTokenSequences;
+
+	/**
+	 * This is a reference to the "tokenImage" array of the generated parser
+	 * within which the parse issue occurred. This array is defined in the
+	 * generated ...Constants interface.
+	 */
+	public String[] tokenImage;
+
+	/**
+	 * List of issues that happened during parsing. Typically set by the error
+	 * listener.
+	 */
+	private List<ParseIssue> parseIssues;
+
+	/**
+	 * The DML/PyDML script string. Used to display the original lines where the
+	 * parse issues occurred.
+	 */
+	private String scriptString;
+
+	/**
+	 * Standard exception message. If no list of parse issues exists, this
+	 * message can be used to display a parse exception message that doesn't
+	 * relate to the list of parse issues.
+	 */
+	private String message;
+
+	/**
+	 * Obtain the list of parse issues that occurred.
+	 * 
+	 * @return the list of parse issues
+	 */
+	public List<ParseIssue> getParseIssues() {
+		return parseIssues;
+	}
+
+	/**
+	 * Set the list of parse issues.
+	 * 
+	 * @param parseIssues
+	 *            the list of parse issues
+	 */
+	public void setParseIssues(List<ParseIssue> parseIssues) {
+		this.parseIssues = parseIssues;
+	}
+
+	/**
+	 * Obtain the original DML/PyDML script string.
+	 * 
+	 * @return the original DML/PyDML script string
+	 */
+	public String getScriptString() {
+		return scriptString;
+	}
+
+	/**
+	 * Set the original DML/PyDML script string.
+	 * 
+	 * @param scriptString
+	 *            the original DML/PyDML script string
+	 */
+	public void setScriptString(String scriptString) {
+		this.scriptString = scriptString;
+	}
+
+	/**
+	 * Does this ParseException contain a list of parse issues?
+	 * 
+	 * @return <code>true</code> if the list of parse issues exists and is
+	 *         greater than 0, <code>false</code> otherwise
+	 */
+	public boolean hasParseIssues() {
+		if ((parseIssues != null) && (parseIssues.size() > 0)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Obtain the exception message. If there is a list of parse issues, these
+	 * are used to generate the exception message.
+	 * 
+	 */
+	@Override
+	public String getMessage() {
+		if (!hasParseIssues()) {
+			if (message != null) {
+				return message;
+			} else {
+				return "No parse issue message.";
+			}
+		} else {
+			return generateParseIssuesMessage();
+		}
+	}
+
+	/**
+	 * Generate a message displaying information about the parse issues that
+	 * occurred.
+	 * 
+	 * @return String representing the list of parse issues.
+	 */
+	private String generateParseIssuesMessage() {
+		if (scriptString == null) {
+			return "No script string available.";
+		}
+		String[] scriptLines = scriptString.split("\\n");
+		StringBuilder sb = new StringBuilder();
+		sb.append("\n--------------------------------------------------------------");
+		if (parseIssues.size() == 1) {
+			sb.append("\nThe following parse issue was encountered:\n");
+		} else {
+			sb.append("\nThe following " + parseIssues.size() + " parse issues were encountered:\n");
+		}
+		int count = 1;
+		for (ParseIssue parseIssue : parseIssues) {
+			if (parseIssues.size() > 1) {
+				sb.append("#");
+				sb.append(count++);
+				sb.append(" ");
+			}
+
+			int issueLineNum = parseIssue.getLine();
+			boolean displayScriptLine = false;
+			String scriptLine = null;
+			if ((issueLineNum > 0) && (issueLineNum <= scriptLines.length)) {
+				displayScriptLine = true;
+				scriptLine = scriptLines[issueLineNum - 1];
+			}
+
+			String name = parseIssue.getFileName();
+			if (name != null) {
+				sb.append(name);
+				sb.append(" ");
+			}
+			sb.append("[line ");
+			sb.append(issueLineNum);
+			sb.append(":");
+			sb.append(parseIssue.getCharPositionInLine());
+			sb.append("] [");
+			sb.append(parseIssue.getParseIssueType().getText());
+			sb.append("]");
+			if (displayScriptLine) {
+				sb.append(" -> ");
+				sb.append(scriptLine);
+			}
+			sb.append("\n   ");
+			sb.append(parseIssue.getMessage());
+			sb.append("\n");
+		}
+		sb.append("--------------------------------------------------------------");
+		return sb.toString();
+	}
 }
-/* JavaCC - OriginalChecksum=f4855557e750c030aaf6a53d0d8438bb (do not edit this line) */

--- a/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
@@ -302,10 +302,15 @@ public abstract class CommonSyntacticValidator {
 
 	protected void exitDataIdExpressionHelper(ParserRuleContext ctx, ExpressionInfo me, ExpressionInfo dataInfo) {
 		me.expr = dataInfo.expr;
-		int line = ctx.start.getLine();
-		int col = ctx.start.getCharPositionInLine();
-		me.expr.setAllPositions(currentFile, line, col, line, col);
-		setFileLineColumn(me.expr, ctx);
+		// If "The parameter $X either needs to be passed through commandline or initialized to default value" validation
+		// error occurs, then dataInfo.expr is null which would cause a null pointer exception with the following code.
+		// Therefore, check for null so that parsing can continue so all parsing issues can be determined.
+		if (me.expr != null) {
+			int line = ctx.start.getLine();
+			int col = ctx.start.getCharPositionInLine();
+			me.expr.setAllPositions(currentFile, line, col, line, col);
+			setFileLineColumn(me.expr, ctx);
+		}
 	}
 
 	protected void exitIndexedExpressionHelper(ParserRuleContext ctx, String name, ExpressionInfo dataInfo,
@@ -513,7 +518,7 @@ public abstract class CommonSyntacticValidator {
 	protected void setOutputStatement(ParserRuleContext ctx,
 			ArrayList<ParameterExpression> paramExpression, StatementInfo info) {
 		if(paramExpression.size() < 2){
-			notifyErrorListeners("incorrect usage of write function (atleast 2 arguments required)", ctx.start);
+			notifyErrorListeners("incorrect usage of write function (at least 2 arguments required)", ctx.start);
 			return;
 		}
 		if(paramExpression.get(0).getExpr() instanceof DataIdentifier) {

--- a/src/main/java/org/apache/sysml/parser/common/CustomErrorListener.java
+++ b/src/main/java/org/apache/sysml/parser/common/CustomErrorListener.java
@@ -19,6 +19,10 @@
 
 package org.apache.sysml.parser.common;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
@@ -28,10 +32,15 @@ import org.apache.sysml.api.DMLScript;
 
 public class CustomErrorListener extends BaseErrorListener {
 
-	private static final Log LOG = LogFactory.getLog(DMLScript.class.getName());
+	private static final Log log = LogFactory.getLog(DMLScript.class.getName());
 
 	private boolean atleastOneError = false;
 	private String currentFileName = null;
+
+	/**
+	 * List of parse issues.
+	 */
+	private List<ParseIssue> parseIssues = new ArrayList<ParseIssue>();
 
 	public void setCurrentFileName(String currentFilePath) {
 		currentFileName = currentFilePath;
@@ -45,56 +54,78 @@ public class CustomErrorListener extends BaseErrorListener {
 		currentFileName = null;
 	}
 
+	/**
+	 * Validation error occurred. Add the error to the list of parse issues.
+	 * 
+	 * @param line
+	 *            Line number where error was detected
+	 * @param charPositionInLine
+	 *            Character position where error was detected
+	 * @param msg
+	 *            Message describing the nature of the validation error
+	 */
 	public void validationError(int line, int charPositionInLine, String msg) {
+		parseIssues
+				.add(new ParseIssue(line, charPositionInLine, msg, currentFileName, ParseIssueType.VALIDATION_ERROR));
 		try {
 			setAtleastOneError(true);
 			// Print error messages with file name
-			if(currentFileName == null) {
-				LOG.error("line "+line+":"+charPositionInLine+" "+msg);
-			}
-			else {
+			if (currentFileName == null) {
+				log.error("line " + line + ":" + charPositionInLine + " " + msg);
+			} else {
 				String fileName = currentFileName;
-				LOG.error(fileName + " line "+line+":"+charPositionInLine+" "+msg);
+				log.error(fileName + " line " + line + ":" + charPositionInLine + " " + msg);
 			}
-		}
-		catch(Exception e1) {
-			LOG.error("ERROR: while customizing error message:" + e1);
+		} catch (Exception e1) {
+			log.error("ERROR: while customizing error message:" + e1);
 		}
 	}
 
+	/**
+	 * Validation warning occurred. Add the warning to the list of parse issues.
+	 * 
+	 * @param line
+	 *            Line number where warning was detected
+	 * @param charPositionInLine
+	 *            Character position where warning was detected
+	 * @param msg
+	 *            Message describing the nature of the validation warning
+	 */
 	public void validationWarning(int line, int charPositionInLine, String msg) {
+		parseIssues.add(new ParseIssue(line, charPositionInLine, msg, currentFileName,
+				ParseIssueType.VALIDATION_WARNING));
 		try {
-			//atleastOneError = true; ---> not an error, just warning
+			// atleastOneError = true; ---> not an error, just warning
 			// Print error messages with file name
-			if(currentFileName == null)
-				LOG.warn("line "+line+":"+charPositionInLine+" "+msg);
+			if (currentFileName == null)
+				log.warn("line " + line + ":" + charPositionInLine + " " + msg);
 			else {
 				String fileName = currentFileName;
-				LOG.warn(fileName + " line "+line+":"+charPositionInLine+" "+msg);
+				log.warn(fileName + " line " + line + ":" + charPositionInLine + " " + msg);
 			}
-		}
-		catch(Exception e1) {
-			LOG.warn("ERROR: while customizing error message:" + e1);
+		} catch (Exception e1) {
+			log.warn("ERROR: while customizing error message:" + e1);
 		}
 	}
 
+	/**
+	 * Syntax error occurred. Add the error to the list of parse issues.
+	 */
 	@Override
-	public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
-							int line, int charPositionInLine,
-							String msg, RecognitionException e)
-	{
+	public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine,
+			String msg, RecognitionException e) {
+		parseIssues.add(new ParseIssue(line, charPositionInLine, msg, currentFileName, ParseIssueType.SYNTAX_ERROR));
 		try {
 			setAtleastOneError(true);
 			// Print error messages with file name
-			if(currentFileName == null)
-				LOG.error("line "+line+":"+charPositionInLine+" "+msg);
+			if (currentFileName == null)
+				log.error("line " + line + ":" + charPositionInLine + " " + msg);
 			else {
 				String fileName = currentFileName;
-				LOG.error(fileName + " line "+line+":"+charPositionInLine+" "+msg);
+				log.error(fileName + " line " + line + ":" + charPositionInLine + " " + msg);
 			}
-		}
-		catch(Exception e1) {
-			LOG.error("ERROR: while customizing error message:" + e1);
+		} catch (Exception e1) {
+			log.error("ERROR: while customizing error message:" + e1);
 		}
 	}
 
@@ -105,4 +136,188 @@ public class CustomErrorListener extends BaseErrorListener {
 	public void setAtleastOneError(boolean atleastOneError) {
 		this.atleastOneError = atleastOneError;
 	}
+
+	/**
+	 * A parse issue (such as an parse error or a parse warning).
+	 *
+	 */
+	public class ParseIssue implements Comparable<ParseIssue> {
+		/**
+		 * Line number of the parse issue
+		 */
+		int line;
+		/**
+		 * Character position of the parse issue
+		 */
+		int charPositionInLine;
+		/**
+		 * Message describing the parse issue
+		 */
+		String message;
+		/**
+		 * The filename (if available) of the script containing the parse issue
+		 */
+		String fileName;
+
+		/**
+		 * The type of parse issue.
+		 */
+		ParseIssueType parseIssueType;
+
+		public ParseIssue(int line, int charPositionInLine, String message) {
+			this.line = line;
+			this.charPositionInLine = charPositionInLine;
+			this.message = message;
+		}
+
+		public ParseIssue(int line, int charPositionInLine, String message, String fileName) {
+			this.line = line;
+			this.charPositionInLine = charPositionInLine;
+			this.message = message;
+			this.fileName = fileName;
+		}
+
+		public ParseIssue(int line, int charPositionInLine, String message, String fileName,
+				ParseIssueType parseIssueType) {
+			this.line = line;
+			this.charPositionInLine = charPositionInLine;
+			this.message = message;
+			this.fileName = fileName;
+			this.parseIssueType = parseIssueType;
+		}
+
+		/**
+		 * Obtain line number of the parse issue.
+		 * 
+		 * @return Line number of the parse issue
+		 */
+		public int getLine() {
+			return line;
+		}
+
+		public void setLine(int line) {
+			this.line = line;
+		}
+
+		/**
+		 * Obtain character position of the parse issue.
+		 * 
+		 * @return Character position of the parse issue
+		 */
+		public int getCharPositionInLine() {
+			return charPositionInLine;
+		}
+
+		public void setCharPositionInLine(int charPositionInLine) {
+			this.charPositionInLine = charPositionInLine;
+		}
+
+		/**
+		 * Obtain the message describing the parse issue.
+		 * 
+		 * @return Message describing the parse issue
+		 */
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+
+		/**
+		 * Obtain the filename of the script containing the parse issue, if
+		 * available.
+		 * 
+		 * @return The filename of the script contain the parse issue (if
+		 *         available)
+		 */
+		public String getFileName() {
+			return fileName;
+		}
+
+		public void setFileName(String fileName) {
+			this.fileName = fileName;
+		}
+
+		/**
+		 * Obtain the type of the parse issue.
+		 * 
+		 * @return The type of the parse issue.
+		 */
+		public ParseIssueType getParseIssueType() {
+			return parseIssueType;
+		}
+
+		public void setParseIssueType(ParseIssueType parseIssueType) {
+			this.parseIssueType = parseIssueType;
+		}
+
+		/**
+		 * Order by parse issues primarily by line number, and secondarily by
+		 * character position.
+		 */
+		@Override
+		public int compareTo(ParseIssue that) {
+			if (this.line == that.line) {
+				return this.charPositionInLine - that.charPositionInLine;
+			} else {
+				return this.line - that.line;
+			}
+		}
+	}
+
+	/**
+	 * Parse issues can be syntax errors, validation errors, and validation
+	 * warnings. Include a string representation of each enum value for display
+	 * to the user.
+	 */
+	public enum ParseIssueType {
+		SYNTAX_ERROR("Syntax error"), VALIDATION_ERROR("Validation error"), VALIDATION_WARNING("Validation warning");
+
+		ParseIssueType(String text) {
+			this.text = text;
+		}
+
+		private final String text;
+
+		/**
+		 * Obtain the user-friendly string representation of the enum value.
+		 * 
+		 * @return User-friendly string representation of the enum value.
+		 */
+		public String getText() {
+			return text;
+		}
+
+	}
+
+	/**
+	 * Obtain the list of parse issues.
+	 * 
+	 * @return The list of parse issues.
+	 */
+	public List<ParseIssue> getParseIssues() {
+		Collections.sort(parseIssues);
+		return parseIssues;
+	}
+
+	/**
+	 * Set the list of parse issues.
+	 * 
+	 * @param parseIssues
+	 *            The list of parse issues.
+	 */
+	public void setParseIssues(List<ParseIssue> parseIssues) {
+		this.parseIssues = parseIssues;
+	}
+
+	/**
+	 * Clear the list of parse issues.
+	 * 
+	 */
+	public void clearParseIssues() {
+		parseIssues.clear();
+	}
+
 }

--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -339,7 +339,7 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		try {
 			prog = (new DMLParserWrapper()).doParse(filePath, null, argVals);
 		} catch (ParseException e) {
-			notifyErrorListeners("Exception found during importing a program from file " + filePath, ctx.start);
+			notifyErrorListeners(e.getMessage(), ctx.start);
 			return;
 		}
         // Custom logic whether to proceed ahead or not. Better than the current exception handling mechanism

--- a/src/main/java/org/apache/sysml/parser/pydml/PyDMLParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PyDMLParserWrapper.java
@@ -24,6 +24,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
@@ -45,6 +46,7 @@ import org.apache.sysml.parser.LanguageException;
 import org.apache.sysml.parser.ParseException;
 import org.apache.sysml.parser.Statement;
 import org.apache.sysml.parser.common.CustomErrorListener;
+import org.apache.sysml.parser.common.CustomErrorListener.ParseIssue;
 import org.apache.sysml.parser.dml.DMLParserWrapper;
 import org.apache.sysml.parser.pydml.PydmlParser.FunctionStatementContext;
 import org.apache.sysml.parser.pydml.PydmlParser.ProgramrootContext;
@@ -70,17 +72,8 @@ public class PyDMLParserWrapper extends AParserWrapper
 	 */
 	@Override
 	public DMLProgram parse(String fileName, String dmlScript, HashMap<String,String> argVals) throws ParseException {
-		DMLProgram prog = null;
+		DMLProgram prog = doParse(fileName, dmlScript, argVals);
 		
-		if(dmlScript == null || dmlScript.trim().isEmpty()) {
-			throw new ParseException("Incorrect usage of parse. Please pass dmlScript not just filename");
-		}
-		
-		prog = doParse(fileName, dmlScript, argVals);
-		
-		if(prog == null) {
-			throw new ParseException("One or more errors found during parsing (could not construct AST for file: " + fileName + "). Cannot proceed ahead.");
-		}
 		return prog;
 	}
 	
@@ -102,13 +95,13 @@ public class PyDMLParserWrapper extends AParserWrapper
 			in = new org.antlr.v4.runtime.ANTLRInputStream(stream);
 		} 
 		catch (FileNotFoundException e) {
-			throw new ParseException("ERROR: Cannot find file:" + fileName, e);
+			throw new ParseException("Cannot find file: " + fileName, e);
 		} 
 		catch (IOException e) {
-			throw new ParseException("ERROR: Cannot open file:" + fileName, e);
+			throw new ParseException("Cannot open file: " + fileName, e);
 		} 
 		catch (LanguageException e) {
-			throw new ParseException("ERROR: " + e.getMessage(), e);
+			throw new ParseException(e.getMessage(), e);
 		}
 
 		ProgramrootContext ast = null;
@@ -162,23 +155,19 @@ public class PyDMLParserWrapper extends AParserWrapper
 		}
 		
 
-		try {
-			// Now convert the parse tree into DMLProgram
-			// Do syntactic validation while converting 
-			ParseTree tree = ast;
-			// And also do syntactic validation
-			ParseTreeWalker walker = new ParseTreeWalker();
-			PydmlSyntacticValidator validator = new PydmlSyntacticValidator(errorListener, argVals);
-			walker.walk(validator, tree);
-			errorListener.unsetCurrentFileName();
-			if(errorListener.isAtleastOneError()) {
-				return null;
-			}
-			dmlPgm = createDMLProgram(ast);
+		// Now convert the parse tree into DMLProgram
+		// Do syntactic validation while converting 
+		ParseTree tree = ast;
+		// And also do syntactic validation
+		ParseTreeWalker walker = new ParseTreeWalker();
+		PydmlSyntacticValidator validator = new PydmlSyntacticValidator(errorListener, argVals);
+		walker.walk(validator, tree);
+		errorListener.unsetCurrentFileName();
+		if(errorListener.isAtleastOneError()) {
+			List<ParseIssue> parseIssues = errorListener.getParseIssues();
+			throw new ParseException(parseIssues, dmlScript);
 		}
-		catch(Exception e) {
-			throw new ParseException("ERROR: Cannot translate the parse tree into DMLProgram" + e.getMessage(), e);
-		}
+		dmlPgm = createDMLProgram(ast);
 		
 		return dmlPgm;
 	}

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -386,7 +386,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		try {
 			prog = (new PyDMLParserWrapper()).doParse(filePath, null, argVals);
 		} catch (ParseException e) {
-			notifyErrorListeners("Exception found during importing a program from file " + filePath, ctx.start);
+			notifyErrorListeners(e.getMessage(), ctx.start);
 			return;
 		}
         // Custom logic whether to proceed ahead or not. Better than the current exception handling mechanism

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/SetWorkingDirTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/SetWorkingDirTest.java
@@ -19,116 +19,136 @@
 
 package org.apache.sysml.test.integration.functions.misc;
 
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
-
-import org.apache.sysml.api.DMLException;
 import org.apache.sysml.runtime.util.LocalFileUtils;
 import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
+import org.junit.Test;
 
 /**
  *   
  */
-public class SetWorkingDirTest extends AutomatedTestBase
-{	
+public class SetWorkingDirTest extends AutomatedTestBase {
 	private final static String TEST_DIR = "functions/misc/";
 	private final static String TEST_NAME1 = "PackageFunCall1";
 	private final static String TEST_NAME2 = "PackageFunCall2";
 	private final static String TEST_NAME0 = "PackageFunLib";
 	private static final String TEST_CLASS_DIR = TEST_DIR + SetWorkingDirTest.class.getSimpleName() + "/";
-	
+
 	@Override
 	public void setUp() {
 		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {}));
 		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {}));
 	}
-	
+
 	@Test
-	public void testDefaultWorkingDirDml() { 
-		runTest( TEST_NAME1, false, ScriptType.DML ); 
-	}
-	
-	@Test
-	public void testSetWorkingDirDml() { 
-		runTest( TEST_NAME2, false, ScriptType.DML ); 
-	}
-	
-	@Test
-	public void testDefaultWorkingDirFailDml() { 
-		runTest( TEST_NAME1, true, ScriptType.DML ); 
-	}
-	
-	@Test
-	public void testSetWorkingDirFailDml() { 
-		runTest( TEST_NAME2, true, ScriptType.DML ); 
+	public void testDefaultWorkingDirDml() {
+		runTest(TEST_NAME1, false, ScriptType.DML);
 	}
 
 	@Test
-	public void testDefaultWorkingDirPyDml() { 
-		runTest( TEST_NAME1, false, ScriptType.PYDML ); 
+	public void testSetWorkingDirDml() {
+		runTest(TEST_NAME2, false, ScriptType.DML);
 	}
-	
+
 	@Test
-	public void testSetWorkingDirPyDml() { 
-		runTest( TEST_NAME2, false, ScriptType.PYDML ); 
+	public void testDefaultWorkingDirFailDml() {
+		runTest(TEST_NAME1, true, ScriptType.DML);
 	}
-	
+
 	@Test
-	public void testDefaultWorkingDirFailPyDml() { 
-		runTest( TEST_NAME1, true, ScriptType.PYDML ); 
+	public void testSetWorkingDirFailDml() {
+		runTest(TEST_NAME2, true, ScriptType.DML);
 	}
-	
+
 	@Test
-	public void testSetWorkingDirFailPyDml() { 
-		runTest( TEST_NAME2, true, ScriptType.PYDML ); 
+	public void testDefaultWorkingDirPyDml() {
+		runTest(TEST_NAME1, false, ScriptType.PYDML);
 	}
-	
+
+	@Test
+	public void testSetWorkingDirPyDml() {
+		runTest(TEST_NAME2, false, ScriptType.PYDML);
+	}
+
+	@Test
+	public void testDefaultWorkingDirFailPyDml() {
+		runTest(TEST_NAME1, true, ScriptType.PYDML);
+	}
+
+	@Test
+	public void testSetWorkingDirFailPyDml() {
+		runTest(TEST_NAME2, true, ScriptType.PYDML);
+	}
+
 	/**
 	 * 
 	 * @param testName
-	 * @param exceptionExpected
+	 * @param fileMissingTest
 	 * @param scriptType
 	 */
-	private void runTest( String testName, boolean exceptionExpected, ScriptType scriptType ) 
-	{
-		
-		//construct source filenames of dml scripts 
+	private void runTest(String testName, boolean fileMissingTest, ScriptType scriptType) {
+
+		// construct source filenames of dml scripts
 		String dir = SCRIPT_DIR + TEST_DIR;
 		String nameCall = testName + "." + scriptType.lowerCase();
 		String nameLib = TEST_NAME0 + "." + scriptType.lowerCase();
-		
-		try 
-		{
-			//copy dml/pydml scripts to current dir
-			FileUtils.copyFile(new File(dir+nameCall), new File(nameCall));
-			if( !exceptionExpected )
-				FileUtils.copyFile(new File(dir+nameLib), new File(nameLib));
-			
-			//setup test configuration
+
+		PrintStream originalStdErr = System.err;
+
+		try {
+			ByteArrayOutputStream baos = null;
+			if (fileMissingTest) {
+				baos = new ByteArrayOutputStream();
+				PrintStream newStdErr = new PrintStream(baos);
+				System.setErr(newStdErr);
+			}
+
+			// copy dml/pydml scripts to current dir
+			FileUtils.copyFile(new File(dir + nameCall), new File(nameCall));
+			if (!fileMissingTest)
+				FileUtils.copyFile(new File(dir + nameLib), new File(nameLib));
+
+			// setup test configuration
 			TestConfiguration config = getTestConfiguration(testName);
-		    fullDMLScriptName = nameCall;
-		    if (scriptType == ScriptType.PYDML) {
-		    	programArgs = new String[]{ "-python" };
-		    } else {
-		    	programArgs = new String[]{};
-		    }
-		    loadTestConfiguration(config);
-			
-			//run tests
-	        runTest(true, exceptionExpected, DMLException.class, -1);
-		} 
-		catch (IOException e) {
+			fullDMLScriptName = nameCall;
+			if (scriptType == ScriptType.PYDML) {
+				programArgs = new String[] { "-python" };
+			} else {
+				programArgs = new String[] {};
+			}
+			loadTestConfiguration(config);
+
+			// run tests
+			runTest(true, false, null, -1);
+
+			if (fileMissingTest) {
+				String stdErrString = baos.toString();
+				if (stdErrString == null) {
+					fail("Standard error string is null"); // shouldn't happen
+				} else if (!stdErrString.contains("Cannot find file")) {
+					// the error message should contain "Cannot find file" if file is missing
+					fail("Should not be able to find file: " + nameLib);
+				}
+				if (stdErrString != null) {
+					originalStdErr.println(stdErrString); // send standard err string to console
+				}
+			}
+
+		} catch (IOException e) {
 			throw new RuntimeException(e);
-		}
-		finally 
-		{
-			//delete dml/pydml scripts from current dir (see above)
+		} finally {
+			System.setErr(originalStdErr);
+			// delete dml/pydml scripts from current dir (see above)
 			LocalFileUtils.deleteFileIfExists(nameCall);
-			if( !exceptionExpected )
+			if (!fileMissingTest)
 				LocalFileUtils.deleteFileIfExists(nameLib);
 		}
 	}


### PR DESCRIPTION
Output actual parse issues via DMLScript invocation to standard error.
Separate file and string invocations of parser in MLContext.
Make parse issues available higher in call stack via ParseException.
Fix null pointer exception issue in exitDataIdExpressionHelper.
Some more informative parse error messages.
Update SetWorkingDirTest to read from standard error where needed.