### PR TITLE
[SYSTEMML-632] Handle source statements in imported scripts

### DIFF
--- a/src/main/java/org/apache/sysml/parser/DMLProgram.java
+++ b/src/main/java/org/apache/sysml/parser/DMLProgram.java
@@ -48,7 +48,6 @@ import org.apache.sysml.runtime.instructions.CPInstructionParser;
 import org.apache.sysml.runtime.instructions.Instruction;
 
 
-
 public class DMLProgram 
 {
 	
@@ -63,7 +62,6 @@ public class DMLProgram
 		_blocks = new ArrayList<StatementBlock>();
 		_functionBlocks = new HashMap<String,FunctionStatementBlock>();
 		_namespaces = new HashMap<String,DMLProgram>();
-		_namespaces.put(DMLProgram.DEFAULT_NAMESPACE,this);
 	}
 	
 	public HashMap<String,DMLProgram> getNamespaces(){

--- a/src/main/java/org/apache/sysml/parser/dml/DMLParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DMLParserWrapper.java
@@ -184,22 +184,22 @@ public class DMLParserWrapper extends AParserWrapper
 			List<ParseIssue> parseIssues = errorListener.getParseIssues();
 			throw new ParseException(parseIssues, dmlScript);
 		}
-		dmlPgm = createDMLProgram(ast);
+		dmlPgm = createDMLProgram(ast, sourceNamespace);
 		
 		return dmlPgm;
 	}
 	
-	private DMLProgram createDMLProgram(ProgramrootContext ast) {
+	private DMLProgram createDMLProgram(ProgramrootContext ast, String sourceNamespace) {
 
 		DMLProgram dmlPgm = new DMLProgram();
+		String namespace = (sourceNamespace != null && sourceNamespace.length() > 0) ? sourceNamespace : DMLProgram.DEFAULT_NAMESPACE;
+		dmlPgm.getNamespaces().put(namespace, dmlPgm);
 
 		// First add all the functions
 		for(FunctionStatementContext fn : ast.functionBlocks) {
 			FunctionStatementBlock functionStmtBlk = new FunctionStatementBlock();
 			functionStmtBlk.addStatement(fn.info.stmt);
 			try {
-				// TODO: currently the logic of nested namespace is not clear.
-				String namespace = DMLProgram.DEFAULT_NAMESPACE;
 				dmlPgm.addFunctionStatementBlock(namespace, fn.info.functionName, functionStmtBlk);
 			} catch (LanguageException e) {
 				LOG.error("line: " + fn.start.getLine() + ":" + fn.start.getCharPositionInLine() + " cannot process the function " + fn.info.functionName);
@@ -220,32 +220,17 @@ public class DMLParserWrapper extends AParserWrapper
 				if(stmtCtx.info.namespaces != null) {
 					// Add the DMLProgram entries into current program
 					for(Map.Entry<String, DMLProgram> entry : stmtCtx.info.namespaces.entrySet()) {
+						// TODO handle namespace key already exists for different program value instead of overwriting
 						dmlPgm.getNamespaces().put(entry.getKey(), entry.getValue());
 						
-//						// Don't add DMLProgram into the current program, just add function statements
-						// dmlPgm.getNamespaces().put(entry.getKey(), entry.getValue());
-						// Add function statements to current dml program
-//						DMLProgram importedPgm = entry.getValue();
-//						try {
-//							for(FunctionStatementBlock importedFnBlk : importedPgm.getFunctionStatementBlocks()) {
-//								if(importedFnBlk.getStatements() != null && importedFnBlk.getStatements().size() == 1) {
-//									String functionName = ((FunctionStatement)importedFnBlk.getStatement(0)).getName();
-//									System.out.println("Adding function => " + entry.getKey() + "::" + functionName);
-//									TODO:33
-//									dmlPgm.addFunctionStatementBlock(entry.getKey(), functionName, importedFnBlk);
-//								}
-//								else {
-//									LOG.error("line: " + stmtCtx.start.getLine() + ":" + stmtCtx.start.getCharPositionInLine() + " incorrect number of functions in the imported function block .... strange");
-//									return null;
-//								}
-//							}
-//							if(importedPgm.getStatementBlocks() != null && importedPgm.getStatementBlocks().size() > 0) {
-//								LOG.warn("Only the functions can be imported from the namespace " + entry.getKey());
-//							}
-//						} catch (LanguageException e) {
-//							LOG.error("line: " + stmtCtx.start.getLine() + ":" + stmtCtx.start.getCharPositionInLine() + " cannot import functions from the file in the import statement: " + e.getMessage());
-//							return null;
-//						}
+						// Add dependent programs (handle imported script that also imports scripts)
+						for(Map.Entry<String, DMLProgram> dependency : entry.getValue().getNamespaces().entrySet()) {
+							String depNamespace = dependency.getKey();
+							DMLProgram depProgram = dependency.getValue();
+							if (dmlPgm.getNamespaces().get(depNamespace) == null) {
+								dmlPgm.getNamespaces().put(depNamespace, depProgram);
+							}
+						}
 					}
 				}
 				else {

--- a/src/main/java/org/apache/sysml/parser/pydml/PyDMLParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PyDMLParserWrapper.java
@@ -171,23 +171,23 @@ public class PyDMLParserWrapper extends AParserWrapper
 			List<ParseIssue> parseIssues = errorListener.getParseIssues();
 			throw new ParseException(parseIssues, dmlScript);
 		}
-		dmlPgm = createDMLProgram(ast);
+		dmlPgm = createDMLProgram(ast, sourceNamespace);
 		
 		return dmlPgm;
 	}
 
 
-	private DMLProgram createDMLProgram(ProgramrootContext ast) {
+	private DMLProgram createDMLProgram(ProgramrootContext ast, String sourceNamespace) {
 
 		DMLProgram dmlPgm = new DMLProgram();
+		String namespace = (sourceNamespace != null && sourceNamespace.length() > 0) ? sourceNamespace : DMLProgram.DEFAULT_NAMESPACE;
+		dmlPgm.getNamespaces().put(namespace, dmlPgm);
 
 		// First add all the functions
 		for(FunctionStatementContext fn : ast.functionBlocks) {
 			FunctionStatementBlock functionStmtBlk = new FunctionStatementBlock();
 			functionStmtBlk.addStatement(fn.info.stmt);
 			try {
-				// TODO: currently the logic of nested namespace is not clear.
-				String namespace = DMLProgram.DEFAULT_NAMESPACE;
 				dmlPgm.addFunctionStatementBlock(namespace, fn.info.functionName, functionStmtBlk);
 			} catch (LanguageException e) {
 				LOG.error("line: " + fn.start.getLine() + ":" + fn.start.getCharPositionInLine() + " cannot process the function " + fn.info.functionName);
@@ -213,7 +213,17 @@ public class PyDMLParserWrapper extends AParserWrapper
 				if(stmtCtx.info.namespaces != null) {
 					// Add the DMLProgram entries into current program
 					for(Map.Entry<String, DMLProgram> entry : stmtCtx.info.namespaces.entrySet()) {
+						// TODO handle namespace key already exists for different program value instead of overwriting
 						dmlPgm.getNamespaces().put(entry.getKey(), entry.getValue());
+						
+						// Add dependent programs (handle imported script that also imports scripts)
+						for(Map.Entry<String, DMLProgram> dependency : entry.getValue().getNamespaces().entrySet()) {
+							String depNamespace = dependency.getKey();
+							DMLProgram depProgram = dependency.getValue();
+							if (dmlPgm.getNamespaces().get(depNamespace) == null) {
+								dmlPgm.getNamespaces().put(depNamespace, depProgram);
+							}
+						}
 					}
 				}
 				else {

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionNamespaceTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionNamespaceTest.java
@@ -29,6 +29,8 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	private final static String TEST_NAME0 = "FunctionsA";
 	private final static String TEST_NAME1 = "Functions1";
 	private final static String TEST_NAME2 = "Functions2";
+	private final static String TEST_NAME3 = "Functions3";
+	private final static String TEST_NAME4 = "Functions4";
 	private final static String TEST_DIR = "functions/misc/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FunctionNamespaceTest.class.getSimpleName() + "/";
 	
@@ -38,6 +40,8 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME0, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME0));
 		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1)); 
 		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2)); 
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3)); 
+		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4)); 
 	}
 	
 	@Test
@@ -59,6 +63,18 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	}
 	
 	@Test
+	public void testFunctionImportSource() 
+	{
+		runFunctionNamespaceTest(TEST_NAME3, ScriptType.DML);
+	}
+	
+	@Test
+	public void testFunctionMultiSource() 
+	{
+		runFunctionNamespaceTest(TEST_NAME4, ScriptType.DML);
+	}
+	
+	@Test
 	public void testPyFunctionDefaultNS() 
 	{
 		runFunctionNamespaceTest(TEST_NAME0, ScriptType.PYDML);
@@ -74,6 +90,18 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	public void testPyFunctionWithoutNS() 
 	{
 		runFunctionNamespaceTest(TEST_NAME2, ScriptType.PYDML);
+	}
+	
+	@Test
+	public void testPyFunctionImportSource() 
+	{
+		runFunctionNamespaceTest(TEST_NAME3, ScriptType.PYDML);
+	}
+	
+	@Test
+	public void testPyFunctionMultiSource() 
+	{
+		runFunctionNamespaceTest(TEST_NAME4, ScriptType.PYDML);
 	}
 
 	private void runFunctionNamespaceTest(String TEST_NAME, ScriptType scriptType)

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionNamespaceTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionNamespaceTest.java
@@ -19,10 +19,17 @@
 
 package org.apache.sysml.test.integration.functions.misc;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.apache.sysml.api.DMLException;
+import org.apache.sysml.hops.OptimizerUtils;
+import org.apache.sysml.runtime.util.MapReduceTool;
 import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
+import org.apache.sysml.utils.Statistics;
 
 public class FunctionNamespaceTest extends AutomatedTestBase 
 {
@@ -31,8 +38,13 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	private final static String TEST_NAME2 = "Functions2";
 	private final static String TEST_NAME3 = "Functions3";
 	private final static String TEST_NAME4 = "Functions4";
+	private final static String TEST_NAME5 = "Functions5";
 	private final static String TEST_DIR = "functions/misc/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FunctionNamespaceTest.class.getSimpleName() + "/";
+	
+	private final static long rows = 3400;
+	private final static long cols = 2700;
+	private final static double val = 1.0;
 	
 	@Override
 	public void setUp() 
@@ -42,6 +54,7 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2)); 
 		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3)); 
 		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4)); 
+		addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5)); 
 	}
 	
 	@Test
@@ -75,6 +88,18 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	}
 	
 	@Test
+	public void testFunctionNoInliningIPA() 
+	{
+		runFunctionNoInliningNamespaceTest(TEST_NAME5, ScriptType.DML, true);
+	}
+	
+	@Test
+	public void testFunctionNoInliningNoIPA() 
+	{
+		runFunctionNoInliningNamespaceTest(TEST_NAME5, ScriptType.DML, false);
+	}
+	
+	@Test
 	public void testPyFunctionDefaultNS() 
 	{
 		runFunctionNamespaceTest(TEST_NAME0, ScriptType.PYDML);
@@ -103,6 +128,18 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	{
 		runFunctionNamespaceTest(TEST_NAME4, ScriptType.PYDML);
 	}
+	
+	@Test
+	public void testPyFunctionNoInliningIPA() 
+	{
+		runFunctionNoInliningNamespaceTest(TEST_NAME5, ScriptType.PYDML, true);
+	}
+	
+	@Test
+	public void testPyFunctionNoInliningNoIPA() 
+	{
+		runFunctionNoInliningNamespaceTest(TEST_NAME5, ScriptType.PYDML, false);
+	}
 
 	private void runFunctionNamespaceTest(String TEST_NAME, ScriptType scriptType)
 	{		
@@ -110,15 +147,97 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 		
 		fullDMLScriptName = SCRIPT_DIR + TEST_DIR + TEST_NAME + "." + scriptType.toString().toLowerCase();
 		programArgs = (ScriptType.PYDML == scriptType) ? new String[]{"-python"} : new String[]{};
+		
+		PrintStream origStdErr = System.err;
 
 		try
 		{
-	        boolean exceptionExpected = (TEST_NAME2.equals(TEST_NAME)) ? true : false;
+			ByteArrayOutputStream baos = null;
+			
+			boolean exceptionExpected = (TEST_NAME2.equals(TEST_NAME)) ? true : false;
+			if (!exceptionExpected)
+			{
+				baos = new ByteArrayOutputStream();
+				PrintStream newStdErr = new PrintStream(baos);
+				System.setErr(newStdErr);
+			}
+			
 			runTest(true, exceptionExpected, DMLException.class, -1);
-		} 
+			
+			if (!exceptionExpected)
+			{
+				String stdErrString = baos.toString();
+				if (null != stdErrString && stdErrString.length() > 0)
+				{
+					Assert.fail("Unexpected parse error or DML script error: " + stdErrString);
+				}
+			}
+		}
 		catch (Exception e) 
 		{
-			e.printStackTrace();
+			e.printStackTrace(origStdErr);
+			Assert.fail("Unexpected exception: " + e);
+		}
+		finally
+		{
+			System.setErr(origStdErr);
+		}
+	}
+
+	/*
+	 * Based on testChainNoInliningIPA and testChainNoInliningIPA from
+	 * org.apache.sysml.test.integration.functions.misc.FunctionInliningTest
+	 */
+	private void runFunctionNoInliningNamespaceTest(String TEST_NAME, ScriptType scriptType, boolean IPA)
+	{		
+		boolean origIPA = OptimizerUtils.ALLOW_INTER_PROCEDURAL_ANALYSIS;
+		
+		getAndLoadTestConfiguration(TEST_NAME);
+		
+		fullDMLScriptName = SCRIPT_DIR + TEST_DIR + TEST_NAME + "." + scriptType.toString().toLowerCase();
+		programArgs = (ScriptType.PYDML == scriptType) ? 
+			new String[]{"-python", "-args", String.valueOf(rows), String.valueOf(cols), String.valueOf(val), output("Rout")} : 
+			new String[]{"-args", String.valueOf(rows), String.valueOf(cols), String.valueOf(val), output("Rout")};
+		
+		PrintStream originalStdErr = System.err;
+
+		try
+		{
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			PrintStream newStdErr = new PrintStream(baos);
+			System.setErr(newStdErr);
+	        
+			OptimizerUtils.ALLOW_INTER_PROCEDURAL_ANALYSIS = IPA;
+			runTest(true, false, null, -1); 
+			OptimizerUtils.ALLOW_INTER_PROCEDURAL_ANALYSIS = origIPA;
+			
+			//compare output
+			double ret = MapReduceTool.readDoubleFromHDFSFile(output("Rout"));
+			Assert.assertEquals(Double.valueOf(rows*cols*val*6), Double.valueOf(ret));
+			
+			//compiled MR jobs
+			int expectNumCompiled = IPA ? 0 : 4; 
+			Assert.assertEquals("Unexpected number of compiled MR jobs.", expectNumCompiled, Statistics.getNoOfCompiledMRJobs());
+		
+			//check executed MR jobs (should always be 0 due to dynamic recompilation)
+			int expectNumExecuted = 0;
+			Assert.assertEquals("Unexpected number of executed MR jobs.", expectNumExecuted, Statistics.getNoOfExecutedMRJobs());
+			
+			String stdErrString = baos.toString();
+			if (stdErrString != null && stdErrString.length() > 0)
+			{
+				Assert.fail("Unexpected parse error or DML script error: " + stdErrString);
+			}
+		}
+		catch (Exception e) 
+		{
+			e.printStackTrace(originalStdErr);
+			Assert.fail("Unexpected exception: " + e);
+		}
+		finally
+		{
+			System.setErr(originalStdErr);
+			OptimizerUtils.ALLOW_INTER_PROCEDURAL_ANALYSIS = origIPA;
 		}
 	}
 }

--- a/src/test/scripts/functions/misc/Functions3.dml
+++ b/src/test/scripts/functions/misc/Functions3.dml
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsC.dml") as FunctionsC
+M = matrix("1 2 3 4", rows=2, cols=2)
+nothing = FunctionsC::matrixPrintInfo(M)

--- a/src/test/scripts/functions/misc/Functions3.pydml
+++ b/src/test/scripts/functions/misc/Functions3.pydml
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsC.pydml") as FunctionsC
+M = full("1 2 3 4", rows=2, cols=2)
+nothing = FunctionsC.matrixPrintInfo(M)

--- a/src/test/scripts/functions/misc/Functions4.dml
+++ b/src/test/scripts/functions/misc/Functions4.dml
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsD.dml") as FunctionsD
+M = matrix("1 2 3 4", rows=2, cols=2)
+nothing = FunctionsD::matrixPrintMoreInfo(M)

--- a/src/test/scripts/functions/misc/Functions4.pydml
+++ b/src/test/scripts/functions/misc/Functions4.pydml
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsD.pydml") as FunctionsD
+M = full("1 2 3 4", rows=2, cols=2)
+nothing = FunctionsD.matrixPrintMoreInfo(M)

--- a/src/test/scripts/functions/misc/Functions5.dml
+++ b/src/test/scripts/functions/misc/Functions5.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsE.dml") as FunctionsE
+
+X = matrix($3, rows=$1, cols=$2)
+Y = FunctionsE::foo1(X)
+z = sum(Y)
+
+write(z, $4)

--- a/src/test/scripts/functions/misc/Functions5.pydml
+++ b/src/test/scripts/functions/misc/Functions5.pydml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsE.pydml") as FunctionsE
+
+X = full($3, rows=$1, cols=$2)
+Y = FunctionsE.foo1(X)
+z = sum(Y)
+
+save(z, $4)

--- a/src/test/scripts/functions/misc/FunctionsC.dml
+++ b/src/test/scripts/functions/misc/FunctionsC.dml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsB.dml") as FunctionsB
+matrixPrintInfo = function(matrix[double] X) return ()
+{
+    result = FunctionsB::matrixPrint(X)
+    result = FunctionsB::matrixPrintMinMax(X)
+}

--- a/src/test/scripts/functions/misc/FunctionsC.pydml
+++ b/src/test/scripts/functions/misc/FunctionsC.pydml
@@ -1,0 +1,24 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsB.pydml") as FunctionsB
+def matrixPrintInfo(X: matrix[float]) -> ():
+    result = FunctionsB.matrixPrint(X)
+    result = FunctionsB.matrixPrintMinMax(X)

--- a/src/test/scripts/functions/misc/FunctionsD.dml
+++ b/src/test/scripts/functions/misc/FunctionsD.dml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsC.dml") as FunctionsC
+source("./src/test/scripts/functions/misc/FunctionsA.dml") as FunctionsA
+matrixPrintMoreInfo = function(matrix[double] X) return ()
+{
+    result = FunctionsC::matrixPrintInfo(X)
+    result = FunctionsA::matrixMean(X)
+    print("Mean is " + result)
+}

--- a/src/test/scripts/functions/misc/FunctionsD.pydml
+++ b/src/test/scripts/functions/misc/FunctionsD.pydml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsC.pydml") as FunctionsC
+source("./src/test/scripts/functions/misc/FunctionsA.pydml") as FunctionsA
+def matrixPrintMoreInfo(X:matrix[float]) -> ():
+    result = FunctionsC.matrixPrintInfo(X)
+    result = FunctionsA.matrixMean(X)
+    print("Mean is " + result)

--- a/src/test/scripts/functions/misc/FunctionsE.dml
+++ b/src/test/scripts/functions/misc/FunctionsE.dml
@@ -1,0 +1,25 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsF.dml") as FunctionsF
+foo1 = function(matrix[double] B) return (matrix[double] V)
+{
+   V = FunctionsF::foo2(B+2)
+}

--- a/src/test/scripts/functions/misc/FunctionsE.pydml
+++ b/src/test/scripts/functions/misc/FunctionsE.pydml
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsF.pydml") as FunctionsF
+def foo1(B: matrix[float]) -> (V: matrix[float]):
+   V = FunctionsF.foo2(B+2)

--- a/src/test/scripts/functions/misc/FunctionsF.dml
+++ b/src/test/scripts/functions/misc/FunctionsF.dml
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+foo2 = function(matrix[double] B) return (matrix[double] V)
+{
+   if (sum(B) > 0)
+   {
+      V = B + B
+   }
+   else
+   {
+      V = B
+   }
+}

--- a/src/test/scripts/functions/misc/FunctionsF.pydml
+++ b/src/test/scripts/functions/misc/FunctionsF.pydml
@@ -1,0 +1,25 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+def foo2(B: matrix[float]) -> (V: matrix[float]):
+    if sum(B) > 0:
+        V = B + B
+    else:
+        V = B


### PR DESCRIPTION
This patch expands parser wrapper import statement processing to handle cases where an imported script1 also imports and calls functions in another script2.  Previously, the custom function calls in script1 to script2 would fail due to namespace undefined in main script.  Test cases were added for both dml and pydml where an imported script sources additional script(s) that also source scripts.
