### PR TITLE
Update parse method parameters from HashMap to Map

### DIFF
--- a/src/main/java/org/apache/sysml/api/DMLScript.java
+++ b/src/main/java/org/apache/sysml/api/DMLScript.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Scanner;
 
 import org.apache.commons.logging.Log;
@@ -322,7 +323,7 @@ public class DMLScript
 		
 			//Step 2: prepare script invocation
 			String dmlScriptStr = readDMLScript(args[0], args[1]);
-			HashMap<String, String> argVals = createArgumentsMap(namedScriptArgs, scriptArgs);		
+			Map<String, String> argVals = createArgumentsMap(namedScriptArgs, scriptArgs);
 			
 			DML_FILE_PATH_ANTLR_PARSER = args[1];
 			
@@ -369,10 +370,10 @@ public class DMLScript
 	 * @param args
 	 * @throws LanguageException
 	 */
-	protected static HashMap<String,String> createArgumentsMap(boolean hasNamedArgs, String[] args) 
+	protected static Map<String,String> createArgumentsMap(boolean hasNamedArgs, String[] args)
 		throws LanguageException
 	{			
-		HashMap<String, String> argMap = new HashMap<String,String>();
+		Map<String, String> argMap = new HashMap<String,String>();
 		
 		if (args == null)
 			return argMap;
@@ -562,7 +563,7 @@ public class DMLScript
 	 * @throws LanguageException 
 	 * @throws LopsException 
 	 */
-	private static void execute(String dmlScriptStr, String fnameOptConfig, HashMap<String,String> argVals, String[] allArgs, boolean parsePyDML)
+	private static void execute(String dmlScriptStr, String fnameOptConfig, Map<String,String> argVals, String[] allArgs, boolean parsePyDML)
 		throws ParseException, IOException, DMLRuntimeException, LanguageException, HopsException, LopsException 
 	{	
 		//print basic time and environment info
@@ -707,7 +708,7 @@ public class DMLScript
 	 * @throws LanguageException 
 	 * @throws LopsException
 	 */
-	private static void launchDebugger(String dmlScriptStr, String fnameOptConfig, HashMap<String,String> argVals, boolean parsePyDML)
+	private static void launchDebugger(String dmlScriptStr, String fnameOptConfig, Map<String,String> argVals, boolean parsePyDML)
 		throws ParseException, IOException, DMLRuntimeException, DMLDebuggerException, LanguageException, HopsException, LopsException 
 	{		
 		DMLDebuggerProgramInfo dbprog = new DMLDebuggerProgramInfo();
@@ -899,7 +900,7 @@ public class DMLScript
 	 * @param fnameOptConfig
 	 * @param argVals
 	 */
-	private static void printInvocationInfo(String fnameScript, String fnameOptConfig, HashMap<String,String> argVals)
+	private static void printInvocationInfo(String fnameScript, String fnameOptConfig, Map<String,String> argVals)
 	{		
 		LOG.debug("****** args to DML Script ******\n" + "UUID: " + getUUID() + "\n" + "SCRIPT PATH: " + fnameScript + "\n" 
 	                + "RUNTIME: " + rtplatform + "\n" + "BUILTIN CONFIG: " + DMLConfig.DEFAULT_SYSTEMML_CONFIG_FILEPATH + "\n"

--- a/src/main/java/org/apache/sysml/api/MLOutput.java
+++ b/src/main/java/org/apache/sysml/api/MLOutput.java
@@ -22,6 +22,7 @@ package org.apache.sysml.api;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.spark.api.java.JavaPairRDD;
@@ -37,9 +38,6 @@ import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-
-import scala.Tuple2;
-
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.instructions.spark.functions.GetMLBlock;
 import org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt;
@@ -47,6 +45,8 @@ import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.util.UtilFunctions;
+
+import scala.Tuple2;
 
 /**
  * This is a simple container object that returns the output of execute from MLContext 
@@ -56,10 +56,10 @@ public class MLOutput {
 	
 	
 	
-	HashMap<String, JavaPairRDD<MatrixIndexes,MatrixBlock>> _outputs;
-	private HashMap<String, MatrixCharacteristics> _outMetadata = null;
+	Map<String, JavaPairRDD<MatrixIndexes,MatrixBlock>> _outputs;
+	private Map<String, MatrixCharacteristics> _outMetadata = null;
 	
-	public MLOutput(HashMap<String, JavaPairRDD<MatrixIndexes,MatrixBlock>> outputs, HashMap<String, MatrixCharacteristics> outMetadata) {
+	public MLOutput(Map<String, JavaPairRDD<MatrixIndexes,MatrixBlock>> outputs, Map<String, MatrixCharacteristics> outMetadata) {
 		this._outputs = outputs;
 		this._outMetadata = outMetadata;
 	}
@@ -132,7 +132,7 @@ public class MLOutput {
 	 * @return
 	 * @throws DMLRuntimeException
 	 */
-	public DataFrame getDF(SQLContext sqlContext, String varName, HashMap<String, Tuple2<Long, Long>> range) throws DMLRuntimeException {
+	public DataFrame getDF(SQLContext sqlContext, String varName, Map<String, Tuple2<Long, Long>> range) throws DMLRuntimeException {
 		if(sqlContext == null) {
 			throw new DMLRuntimeException("SQLContext is not created.");
 		}

--- a/src/main/java/org/apache/sysml/api/jmlc/Connection.java
+++ b/src/main/java/org/apache/sysml/api/jmlc/Connection.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -75,7 +76,7 @@ import org.apache.wink.json4j.JSONObject;
  * a {@link Connection} object. The JMLC API is patterned
  * after JDBC. A DML script is precompiled by calling
  * the {@link #prepareScript(String, String[], String[], boolean)}
- * method or the {@link #prepareScript(String, HashMap, String[], String[], boolean)}
+ * method or the {@link #prepareScript(String, Map, String[], String[], boolean)}
  * method on the {@link Connection} object, which returns a
  * {@link PreparedScript} object. Note that this is similar to calling
  * a {@code prepareStatement} method on a JDBC {@code Connection} object.
@@ -164,7 +165,7 @@ public class Connection
 	 * @return PreparedScript object representing the precompiled script
 	 * @throws DMLException
 	 */
-	public PreparedScript prepareScript( String script, HashMap<String, String> args, String[] inputs, String[] outputs, boolean parsePyDML) 
+	public PreparedScript prepareScript( String script, Map<String, String> args, String[] inputs, String[] outputs, boolean parsePyDML) 
 		throws DMLException 
 	{
 		//prepare arguments
@@ -466,7 +467,7 @@ public class Connection
 		}
 		
 		//read meta data (currently only recode supported, without parsing spec)
-		HashMap<String,String> meta = new HashMap<String,String>();
+		Map<String,String> meta = new HashMap<String,String>();
 		int rows = 0;
 		for( int j=0; j<colnames.size(); j++ ) {
 			String colName = colnames.get(j);
@@ -543,7 +544,7 @@ public class Connection
 		}
 		
 		//read meta data (currently only recode supported, without parsing spec)
-		HashMap<String,String> meta = new HashMap<String,String>();
+		Map<String,String> meta = new HashMap<String,String>();
 		int rows = 0;
 		for( int j=0; j<colnames.size(); j++ ) {
 			String colName = colnames.get(j);
@@ -576,7 +577,7 @@ public class Connection
 	 * @return
 	 * @throws IOException
 	 */
-	private FrameBlock convertToTransformMetaDataFrame(int rows, List<Integer> recodeIDs, List<String> colnames, HashMap<String,String> meta) 
+	private FrameBlock convertToTransformMetaDataFrame(int rows, List<Integer> recodeIDs, List<String> colnames, Map<String,String> meta) 
 		throws IOException 
 	{
 		//create frame block w/ pure string schema

--- a/src/main/java/org/apache/sysml/parser/AParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/AParserWrapper.java
@@ -23,7 +23,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.hadoop.fs.FileSystem;
@@ -47,7 +47,7 @@ public abstract class AParserWrapper
 	 * @return
 	 * @throws ParseException
 	 */
-	public abstract DMLProgram parse(String fileName, String dmlScript, HashMap<String, String> argVals) 
+	public abstract DMLProgram parse(String fileName, String dmlScript, Map<String, String> argVals)
 		throws ParseException;
 
 	

--- a/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
@@ -51,7 +51,6 @@ import org.apache.sysml.parser.PrintStatement;
 import org.apache.sysml.parser.RelationalExpression;
 import org.apache.sysml.parser.Statement;
 import org.apache.sysml.parser.StringIdentifier;
-import org.apache.sysml.parser.common.CustomErrorListener;
 import org.apache.sysml.parser.dml.DmlParser.BuiltinFunctionExpressionContext;
 import org.apache.sysml.parser.dml.DmlSyntacticValidator;
 import org.apache.sysml.parser.pydml.PydmlSyntacticValidator;
@@ -64,10 +63,10 @@ public abstract class CommonSyntacticValidator {
 	protected final CustomErrorListener errorListener;
 	protected final String currentFile;
 	protected String _workingDir = ".";   //current working directory
-	protected HashMap<String,String> argVals = null;
+	protected Map<String,String> argVals = null;
 	protected String sourceNamespace = null;
 
-	public CommonSyntacticValidator(CustomErrorListener errorListener, HashMap<String,String> argVals, String sourceNamespace) {
+	public CommonSyntacticValidator(CustomErrorListener errorListener, Map<String,String> argVals, String sourceNamespace) {
 		this.errorListener = errorListener;
 		currentFile = errorListener.getCurrentFileName();
 		this.argVals = argVals;

--- a/src/main/java/org/apache/sysml/parser/dml/DMLParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DMLParserWrapper.java
@@ -23,7 +23,6 @@ import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -87,7 +86,7 @@ public class DMLParserWrapper extends AParserWrapper
 	 * @throws ParseException
 	 */
 	@Override
-	public DMLProgram parse(String fileName, String dmlScript, HashMap<String,String> argVals) throws ParseException {
+	public DMLProgram parse(String fileName, String dmlScript, Map<String,String> argVals) throws ParseException {
 		DMLProgram prog = doParse(fileName, dmlScript, null, argVals);
 		
 		return prog;
@@ -102,7 +101,7 @@ public class DMLParserWrapper extends AParserWrapper
 	 * @return null if at least one error
 	 * @throws ParseException
 	 */
-	public DMLProgram doParse(String fileName, String dmlScript, String sourceNamespace, HashMap<String,String> argVals) throws ParseException {
+	public DMLProgram doParse(String fileName, String dmlScript, String sourceNamespace, Map<String,String> argVals) throws ParseException {
 		DMLProgram dmlPgm = null;
 		
 		ANTLRInputStream in;

--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -111,7 +112,7 @@ import org.apache.sysml.parser.dml.DmlParser.WhileStatementContext;
 
 public class DmlSyntacticValidator extends CommonSyntacticValidator implements DmlListener {
 
-	public DmlSyntacticValidator(CustomErrorListener errorListener, HashMap<String,String> argVals, String sourceNamespace) {
+	public DmlSyntacticValidator(CustomErrorListener errorListener, Map<String,String> argVals, String sourceNamespace) {
 		super(errorListener, argVals, sourceNamespace);
 	}
 

--- a/src/main/java/org/apache/sysml/parser/pydml/PyDMLParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PyDMLParserWrapper.java
@@ -23,7 +23,6 @@ import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -71,7 +70,7 @@ public class PyDMLParserWrapper extends AParserWrapper
 	 * @throws ParseException
 	 */
 	@Override
-	public DMLProgram parse(String fileName, String dmlScript, HashMap<String,String> argVals) throws ParseException {
+	public DMLProgram parse(String fileName, String dmlScript, Map<String,String> argVals) throws ParseException {
 		DMLProgram prog = doParse(fileName, dmlScript, null, argVals);
 		
 		return prog;
@@ -86,7 +85,7 @@ public class PyDMLParserWrapper extends AParserWrapper
 	 * @return null if at least one error
 	 * @throws ParseException
 	 */
-	public DMLProgram doParse(String fileName, String dmlScript, String sourceNamespace, HashMap<String,String> argVals) throws ParseException {
+	public DMLProgram doParse(String fileName, String dmlScript, String sourceNamespace, Map<String,String> argVals) throws ParseException {
 		DMLProgram dmlPgm = null;
 		
 		ANTLRInputStream in;

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -119,7 +120,7 @@ import org.apache.sysml.parser.pydml.PydmlParser.WhileStatementContext;
  */
 public class PydmlSyntacticValidator extends CommonSyntacticValidator implements PydmlListener {
 
-	public PydmlSyntacticValidator(CustomErrorListener errorListener, HashMap<String,String> argVals, String sourceNamespace) {
+	public PydmlSyntacticValidator(CustomErrorListener errorListener, Map<String,String> argVals, String sourceNamespace) {
 		super(errorListener, argVals, sourceNamespace);
 	}
 


### PR DESCRIPTION
Referencing Map interface rather than HashMap concrete class allows
the methods to not be tied to a specific implementation of Map.

Updated for AParserWrapper, CommonSyntacticValidator, DMLParserWrapper, DmlSyntacticValidator, PyDMLParserWrapper, and PydmlSyntacticValidator, relating to the parse calls, so that a client calling the parser code can pass a Map reference rather than a HashMap reference. Also updated DMLScript, MLContext, MLOutput, and jmlc Connection to use Map references rather than HashMaps.
