### PR TITLE
[SYSTEMML-625] Handle circular import references

### DIFF
--- a/src/main/java/org/apache/sysml/parser/AParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/AParserWrapper.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.sysml.conf.ConfigurationManager;
+import org.apache.sysml.parser.common.CommonSyntacticValidator;
 import org.apache.sysml.parser.dml.DMLParserWrapper;
 import org.apache.sysml.parser.pydml.PyDMLParserWrapper;
 import org.apache.sysml.runtime.util.LocalFileUtils;
@@ -67,6 +68,8 @@ public abstract class AParserWrapper
 			ret = new PyDMLParserWrapper();
 		else
 			ret = new DMLParserWrapper();
+		
+		CommonSyntacticValidator.init();
 		
 		return ret;
 	}

--- a/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
@@ -65,6 +65,12 @@ public abstract class CommonSyntacticValidator {
 	protected String _workingDir = ".";   //current working directory
 	protected Map<String,String> argVals = null;
 	protected String sourceNamespace = null;
+	// track imported scripts to prevent infinite recursion
+	protected static Map<String, String> scripts = new HashMap<String, String>();
+	
+	public static void init() {
+		scripts.clear();
+	}
 
 	public CommonSyntacticValidator(CustomErrorListener errorListener, Map<String,String> argVals, String sourceNamespace) {
 		this.errorListener = errorListener;

--- a/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
@@ -66,10 +66,12 @@ public abstract class CommonSyntacticValidator {
 	protected Map<String,String> argVals = null;
 	protected String sourceNamespace = null;
 	// track imported scripts to prevent infinite recursion
-	protected static Map<String, String> scripts = new HashMap<String, String>();
+	protected static ThreadLocal<HashMap<String, String>> _scripts = new ThreadLocal<HashMap<String, String>>() {
+		@Override protected HashMap<String, String> initialValue() { return new HashMap<String, String>(); }
+	};
 	
 	public static void init() {
-		scripts.clear();
+		_scripts.get().clear();
 	}
 
 	public CommonSyntacticValidator(CustomErrorListener errorListener, Map<String,String> argVals, String sourceNamespace) {

--- a/src/main/java/org/apache/sysml/parser/dml/DMLParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DMLParserWrapper.java
@@ -220,7 +220,10 @@ public class DMLParserWrapper extends AParserWrapper
 					// Add the DMLProgram entries into current program
 					for(Map.Entry<String, DMLProgram> entry : stmtCtx.info.namespaces.entrySet()) {
 						// TODO handle namespace key already exists for different program value instead of overwriting
-						dmlPgm.getNamespaces().put(entry.getKey(), entry.getValue());
+						DMLProgram prog = entry.getValue();
+						if (prog != null && prog.getNamespaces().size() > 0) {
+							dmlPgm.getNamespaces().put(entry.getKey(), prog);
+						}
 						
 						// Add dependent programs (handle imported script that also imports scripts)
 						for(Map.Entry<String, DMLProgram> dependency : entry.getValue().getNamespaces().entrySet()) {

--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -115,7 +115,7 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 	public DmlSyntacticValidator(CustomErrorListener errorListener, Map<String,String> argVals, String sourceNamespace) {
 		super(errorListener, argVals, sourceNamespace);
 	}
-
+	
 	@Override public String namespaceResolutionOp() { return "::"; }
 	@Override public String trueStringLiteral() { return "TRUE"; }
 	@Override public String falseStringLiteral() { return "FALSE"; }
@@ -335,20 +335,37 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 
 		//concatenate working directory to filepath
 		filePath = _workingDir + File.separator + filePath;
+		String scriptID = filePath + namespaceResolutionOp() + namespace;
 
 		DMLProgram prog = null;
-		try {
-			prog = (new DMLParserWrapper()).doParse(filePath, null, namespace, argVals);
-		} catch (ParseException e) {
-			notifyErrorListeners(e.getMessage(), ctx.start);
-			return;
+		if (!scripts.containsKey(scriptID))
+		{
+			scripts.put(scriptID, this.currentFile);
+			try {
+				prog = (new DMLParserWrapper()).doParse(filePath, null, namespace, argVals);
+			} catch (ParseException e) {
+				notifyErrorListeners(e.getMessage(), ctx.start);
+				return;
+			}
+	        // Custom logic whether to proceed ahead or not. Better than the current exception handling mechanism
+			if(prog == null) {
+				notifyErrorListeners("One or more errors found during importing a program from file " + filePath, ctx.start);
+				return;
+			}
+			else {
+				ctx.info.namespaces = new HashMap<String, DMLProgram>();
+				ctx.info.namespaces.put(namespace, prog);
+				ctx.info.stmt = new ImportStatement();
+				((ImportStatement) ctx.info.stmt).setCompletePath(filePath);
+				((ImportStatement) ctx.info.stmt).setFilePath(ctx.filePath.getText());
+				((ImportStatement) ctx.info.stmt).setNamespace(namespace);
+			}
 		}
-        // Custom logic whether to proceed ahead or not. Better than the current exception handling mechanism
-		if(prog == null) {
-			notifyErrorListeners("One or more errors found during importing a program from file " + filePath, ctx.start);
-			return;
-		}
-		else {
+		else
+		{
+			// Skip redundant parsing (to prevent potential infinite recursion) and
+			// create empty program for this context to allow processing to continue.
+			prog = new DMLProgram();
 			ctx.info.namespaces = new HashMap<String, DMLProgram>();
 			ctx.info.namespaces.put(namespace, prog);
 			ctx.info.stmt = new ImportStatement();

--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -335,12 +335,12 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 
 		//concatenate working directory to filepath
 		filePath = _workingDir + File.separator + filePath;
-		String scriptID = filePath + namespaceResolutionOp() + namespace;
+		String scriptID = DMLProgram.constructFunctionKey(namespace, filePath);
 
 		DMLProgram prog = null;
-		if (!scripts.containsKey(scriptID))
+		if (!_scripts.get().containsKey(scriptID))
 		{
-			scripts.put(scriptID, this.currentFile);
+			_scripts.get().put(scriptID, this.currentFile);
 			try {
 				prog = (new DMLParserWrapper()).doParse(filePath, null, namespace, argVals);
 			} catch (ParseException e) {

--- a/src/main/java/org/apache/sysml/parser/pydml/PyDMLParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PyDMLParserWrapper.java
@@ -213,7 +213,10 @@ public class PyDMLParserWrapper extends AParserWrapper
 					// Add the DMLProgram entries into current program
 					for(Map.Entry<String, DMLProgram> entry : stmtCtx.info.namespaces.entrySet()) {
 						// TODO handle namespace key already exists for different program value instead of overwriting
-						dmlPgm.getNamespaces().put(entry.getKey(), entry.getValue());
+						DMLProgram prog = entry.getValue();
+						if (prog != null && prog.getNamespaces().size() > 0) {
+							dmlPgm.getNamespaces().put(entry.getKey(), prog);
+						}
 						
 						// Add dependent programs (handle imported script that also imports scripts)
 						for(Map.Entry<String, DMLProgram> dependency : entry.getValue().getNamespaces().entrySet()) {

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -382,12 +382,12 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 
 		//concatenate working directory to filepath
 		filePath = _workingDir + File.separator + filePath;
-		String scriptID = filePath + namespaceResolutionOp() + namespace;
+		String scriptID = DMLProgram.constructFunctionKey(namespace, filePath);
 
 		DMLProgram prog = null;
-		if (!scripts.containsKey(scriptID))
+		if (!_scripts.get().containsKey(scriptID))
 		{
-			scripts.put(scriptID, namespace);
+			_scripts.get().put(scriptID, namespace);
 			try {
 				prog = (new PyDMLParserWrapper()).doParse(filePath, null, namespace, argVals);
 			} catch (ParseException e) {

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionNamespaceTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionNamespaceTest.java
@@ -39,6 +39,8 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	private final static String TEST_NAME3 = "Functions3";
 	private final static String TEST_NAME4 = "Functions4";
 	private final static String TEST_NAME5 = "Functions5";
+	private final static String TEST_NAME6 = "Functions6";
+	private final static String TEST_NAME7 = "Functions7";
 	private final static String TEST_DIR = "functions/misc/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FunctionNamespaceTest.class.getSimpleName() + "/";
 	
@@ -55,6 +57,8 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3)); 
 		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4)); 
 		addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5)); 
+		addTestConfiguration(TEST_NAME6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6)); 
+		addTestConfiguration(TEST_NAME7, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME7)); 
 	}
 	
 	@Test
@@ -100,6 +104,24 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	}
 	
 	@Test
+	public void testFunctionCircular() 
+	{
+		runFunctionNamespaceTest(TEST_NAME6, ScriptType.DML);
+	}
+	
+	@Test
+	public void testFunctionCircularChain() 
+	{
+		runFunctionNoInliningNamespaceTest(TEST_NAME7, ScriptType.DML, true);
+	}
+	
+	@Test
+	public void testFunctionCircularChainNoIPA() 
+	{
+		runFunctionNoInliningNamespaceTest(TEST_NAME7, ScriptType.DML, false);
+	}
+	
+	@Test
 	public void testPyFunctionDefaultNS() 
 	{
 		runFunctionNamespaceTest(TEST_NAME0, ScriptType.PYDML);
@@ -139,6 +161,24 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	public void testPyFunctionNoInliningNoIPA() 
 	{
 		runFunctionNoInliningNamespaceTest(TEST_NAME5, ScriptType.PYDML, false);
+	}
+	
+	@Test
+	public void testPyFunctionCircular() 
+	{
+		runFunctionNamespaceTest(TEST_NAME6, ScriptType.PYDML);
+	}
+	
+	@Test
+	public void testPyFunctionCircularChain() 
+	{
+		runFunctionNoInliningNamespaceTest(TEST_NAME7, ScriptType.PYDML, true);
+	}
+	
+	@Test
+	public void testPyFunctionCircularChainNoIPA() 
+	{
+		runFunctionNoInliningNamespaceTest(TEST_NAME7, ScriptType.PYDML, false);
 	}
 
 	private void runFunctionNamespaceTest(String TEST_NAME, ScriptType scriptType)

--- a/src/test/scripts/functions/misc/Functions6.dml
+++ b/src/test/scripts/functions/misc/Functions6.dml
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+# circular self reference
+source("./src/test/scripts/functions/misc/Functions6.dml") as Functions6
+# circular back reference
+source("./src/test/scripts/functions/misc/FunctionsG.dml") as FunctionsG
+# circular nest reference
+source("./src/test/scripts/functions/misc/FunctionsH.dml") as FunctionsH
+M = matrix("1 2 3 4", rows=2, cols=2)
+nothing = FunctionsG::matrixPrintInfo(M)
+nothing = FunctionsH::matrixPrintMean(M)
+M = matrix("5 6 7 8", rows=2, cols=2)
+nothing = FunctionsG::matrixPrintMoreInfo(M)

--- a/src/test/scripts/functions/misc/Functions6.pydml
+++ b/src/test/scripts/functions/misc/Functions6.pydml
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+# circular self reference
+source("./src/test/scripts/functions/misc/Functions6.pydml") as Functions6
+# circular back reference
+source("./src/test/scripts/functions/misc/FunctionsG.pydml") as FunctionsG
+# circular nest reference
+source("./src/test/scripts/functions/misc/FunctionsH.pydml") as FunctionsH
+M = full("1 2 3 4", rows=2, cols=2)
+nothing = FunctionsG.matrixPrintInfo(M)
+nothing = FunctionsH.matrixPrintMean(M)
+M = full("5 6 7 8", rows=2, cols=2)
+nothing = FunctionsG.matrixPrintMoreInfo(M)

--- a/src/test/scripts/functions/misc/Functions7.dml
+++ b/src/test/scripts/functions/misc/Functions7.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsI1.dml") as FunctionsI1
+
+X = matrix($3, rows=$1, cols=$2)
+Y = FunctionsI1::foo1(X)
+z = sum(Y)
+
+write(z, $4)

--- a/src/test/scripts/functions/misc/Functions7.pydml
+++ b/src/test/scripts/functions/misc/Functions7.pydml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsI1.pydml") as FunctionsI1
+
+X = full($3, rows=$1, cols=$2)
+Y = FunctionsI1.foo1(X)
+z = sum(Y)
+
+save(z, $4)

--- a/src/test/scripts/functions/misc/FunctionsG.dml
+++ b/src/test/scripts/functions/misc/FunctionsG.dml
@@ -1,0 +1,41 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsH.dml") as FunctionsH
+minMax = function(matrix[double] M) return (double minVal, double maxVal)
+{
+    minVal = min(M)
+    maxVal = max(M)
+}
+matrixMean = function(matrix[double] X) return (double m)
+{
+    m = sum(X)/length(X)
+}
+matrixPrintInfo = function(matrix[double] X) return ()
+{
+    result = FunctionsH::matrixPrint(X)
+    [min, max] = minMax(X)
+    print("Minimum is " + min)
+    print("Maximum is " + max)
+}
+matrixPrintMoreInfo = function(matrix[double] X) return ()
+{
+    result = FunctionsH::matrixPrintMeanInfo(X)
+}

--- a/src/test/scripts/functions/misc/FunctionsG.pydml
+++ b/src/test/scripts/functions/misc/FunctionsG.pydml
@@ -1,0 +1,36 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsH.pydml") as FunctionsH
+def minMax(M: matrix[float]) -> (minVal: float, maxVal: float):
+    minVal = min(M)
+    maxVal = max(M)
+
+def matrixMean(X: matrix[float]) -> (m: float):
+    m = sum(X)/length(X)
+
+def matrixPrintInfo(X: matrix[float]) -> ():
+    result = FunctionsH.matrixPrint(X)
+    [min, max] = minMax(X)
+    print("Minimum is " + min)
+    print("Maximum is " + max)
+
+def matrixPrintMoreInfo(X: matrix[float]) -> ():
+    result = FunctionsH.matrixPrintMeanInfo(X)

--- a/src/test/scripts/functions/misc/FunctionsH.dml
+++ b/src/test/scripts/functions/misc/FunctionsH.dml
@@ -1,0 +1,48 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# Circular import with different namespace
+source("./src/test/scripts/functions/misc/FunctionsG.dml") as Utils
+# Circular import with same namespace
+source("./src/test/scripts/functions/misc/FunctionsG.dml") as FunctionsG
+
+matrixPrint = function(matrix[double] X) return ()
+{
+    for (i in 1:nrow(X))
+    {
+        for (j in 1:ncol(X))
+        {
+            xij = as.scalar(X[i,j])
+            print("[" + i + "," + j + "] " + xij)
+        }
+    }
+}
+matrixPrintMeanInfo = function(matrix[double] X) return ()
+{
+    result = matrixPrint(X)
+    result = Utils::matrixMean(X)
+    print("Mean is " + result)
+}
+matrixPrintMean = function(matrix[double] X) return ()
+{
+    result = FunctionsG::matrixMean(X)
+    print("Mean is " + result)
+}

--- a/src/test/scripts/functions/misc/FunctionsH.pydml
+++ b/src/test/scripts/functions/misc/FunctionsH.pydml
@@ -1,0 +1,40 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# Circular import with different namespace
+source("./src/test/scripts/functions/misc/FunctionsG.pydml") as Utils
+# Circular import with same namespace
+source("./src/test/scripts/functions/misc/FunctionsG.pydml") as FunctionsG
+
+def matrixPrint(X: matrix[float]) -> ():
+    for (i in 1:nrow(X)):
+        for (j in 1:ncol(X)):
+            xij = scalar(X[i,j])
+            print("[" + i + "," + j + "] " + xij)
+
+def matrixPrintMeanInfo(X: matrix[float]) -> ():
+    result = matrixPrint(X)
+    result = Utils.matrixMean(X)
+    print("Mean is " + result)
+
+def matrixPrintMean(X: matrix[float]) -> ():
+    result = FunctionsG.matrixMean(X)
+    print("Mean is " + result)

--- a/src/test/scripts/functions/misc/FunctionsI1.dml
+++ b/src/test/scripts/functions/misc/FunctionsI1.dml
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsI2.dml") as I2
+foo1 = function(matrix[double] B) return (matrix[double] V)
+{
+    V = I2::foo2(B)
+}
+foo = function(matrix[double] B) return (matrix[double] V)
+{
+    V = B
+}

--- a/src/test/scripts/functions/misc/FunctionsI1.pydml
+++ b/src/test/scripts/functions/misc/FunctionsI1.pydml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsI2.pydml") as I2
+def foo1(B: matrix[float]) -> (V: matrix[float]):
+    V = I2.foo2(B)
+
+def foo(B: matrix[float]) -> (V: matrix[float]):
+    V = B

--- a/src/test/scripts/functions/misc/FunctionsI2.dml
+++ b/src/test/scripts/functions/misc/FunctionsI2.dml
@@ -1,0 +1,25 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsI3.dml") as I3
+foo2 = function(matrix[double] B) return (matrix[double] V)
+{
+    V = I3::foo3(B+2)
+}

--- a/src/test/scripts/functions/misc/FunctionsI2.pydml
+++ b/src/test/scripts/functions/misc/FunctionsI2.pydml
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsI3.pydml") as I3
+def foo2(B: matrix[float]) -> (V: matrix[float]):
+    V = I3.foo3(B+2)

--- a/src/test/scripts/functions/misc/FunctionsI3.dml
+++ b/src/test/scripts/functions/misc/FunctionsI3.dml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsI1.dml") as I1
+foo3 = function(matrix[double] B) return (matrix[double] V)
+{
+    if (sum(B) > 0)
+    {
+        V = B + B
+    }
+    else
+    {
+        V = I1::foo(B)
+    }
+}

--- a/src/test/scripts/functions/misc/FunctionsI3.pydml
+++ b/src/test/scripts/functions/misc/FunctionsI3.pydml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsI1.pydml") as I1
+def foo3(B: matrix[float]) -> (V: matrix[float]):
+    if (sum(B) > 0):
+        V = B + B
+    else:
+        V = I1.foo(B)


### PR DESCRIPTION
This patch updates parser component to allow scripts to run in cases where circular source references exist.  Previously, a circular import (e.g., a script sources itself) would result in stack overflow error where 
DMLParserWrapper.doParse and DMLSyntacticValidator.exitImportStatement infinitely loop during ParseTreeWalker.walk.  Test scripts are included for both DML and PyDML to exercise various forms of circular dependencies.
