### PR TITLE
[SYSTEMML-631] Improve handling namespace conflicts

### DIFF
--- a/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
@@ -69,6 +69,8 @@ public abstract class CommonSyntacticValidator {
 	protected static ThreadLocal<HashMap<String, String>> _scripts = new ThreadLocal<HashMap<String, String>>() {
 		@Override protected HashMap<String, String> initialValue() { return new HashMap<String, String>(); }
 	};
+	// mapping of namespaces to full paths as defined only from source statements in this script (i.e., currentFile)
+	protected HashMap<String, String> sources;
 	
 	public static void init() {
 		_scripts.get().clear();
@@ -79,6 +81,7 @@ public abstract class CommonSyntacticValidator {
 		currentFile = errorListener.getCurrentFileName();
 		this.argVals = argVals;
 		this.sourceNamespace = sourceNamespace;
+		sources = new HashMap<String, String>();
 	}
 
 	protected void notifyErrorListeners(String message, int line, int charPositionInLine) {
@@ -107,7 +110,7 @@ public abstract class CommonSyntacticValidator {
 			functionName = fnNames[0].trim();
 		}
 		else if(fnNames.length == 2) {
-			namespace = fnNames[0].trim();
+			namespace = getQualifiedNamespace(fnNames[0].trim());
 			functionName = fnNames[1].trim();
 		}
 		else
@@ -118,7 +121,21 @@ public abstract class CommonSyntacticValidator {
 		retVal[1] = functionName;
 		return retVal;
 	}
+	
+	protected String getQualifiedNamespace(String namespace) {
+		String path = sources.get(namespace);
+		return (path != null && path.length() > 0) ? path : namespace;
+	}
 
+	protected void validateNamespace(String namespace, String filePath, ParserRuleContext ctx) {
+		if (!sources.containsKey(namespace)) {
+			sources.put(namespace, filePath);
+		}
+		else {
+			notifyErrorListeners("Namespace Conflict: '" + namespace + "' already defined as " + sources.get(namespace), ctx.start);
+		}
+	}
+	
 	protected boolean validateBuiltinFunctions(String function) {
 		String functionName = function.replaceAll(" ", "").trim();
 		if(functionName.equals("write") || functionName.equals(DMLProgram.DEFAULT_NAMESPACE + namespaceResolutionOp() + "write")) {

--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -335,14 +335,15 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 
 		//concatenate working directory to filepath
 		filePath = _workingDir + File.separator + filePath;
+		validateNamespace(namespace, filePath, ctx);
 		String scriptID = DMLProgram.constructFunctionKey(namespace, filePath);
 
 		DMLProgram prog = null;
 		if (!_scripts.get().containsKey(scriptID))
 		{
-			_scripts.get().put(scriptID, this.currentFile);
+			_scripts.get().put(scriptID, namespace);
 			try {
-				prog = (new DMLParserWrapper()).doParse(filePath, null, namespace, argVals);
+				prog = (new DMLParserWrapper()).doParse(filePath, null, getQualifiedNamespace(namespace), argVals);
 			} catch (ParseException e) {
 				notifyErrorListeners(e.getMessage(), ctx.start);
 				return;
@@ -354,7 +355,7 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 			}
 			else {
 				ctx.info.namespaces = new HashMap<String, DMLProgram>();
-				ctx.info.namespaces.put(namespace, prog);
+				ctx.info.namespaces.put(getQualifiedNamespace(namespace), prog);
 				ctx.info.stmt = new ImportStatement();
 				((ImportStatement) ctx.info.stmt).setCompletePath(filePath);
 				((ImportStatement) ctx.info.stmt).setFilePath(ctx.filePath.getText());
@@ -367,7 +368,7 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 			// create empty program for this context to allow processing to continue.
 			prog = new DMLProgram();
 			ctx.info.namespaces = new HashMap<String, DMLProgram>();
-			ctx.info.namespaces.put(namespace, prog);
+			ctx.info.namespaces.put(getQualifiedNamespace(namespace), prog);
 			ctx.info.stmt = new ImportStatement();
 			((ImportStatement) ctx.info.stmt).setCompletePath(filePath);
 			((ImportStatement) ctx.info.stmt).setFilePath(ctx.filePath.getText());

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -382,6 +382,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 
 		//concatenate working directory to filepath
 		filePath = _workingDir + File.separator + filePath;
+		validateNamespace(namespace, filePath, ctx);
 		String scriptID = DMLProgram.constructFunctionKey(namespace, filePath);
 
 		DMLProgram prog = null;
@@ -389,7 +390,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		{
 			_scripts.get().put(scriptID, namespace);
 			try {
-				prog = (new PyDMLParserWrapper()).doParse(filePath, null, namespace, argVals);
+				prog = (new PyDMLParserWrapper()).doParse(filePath, null, getQualifiedNamespace(namespace), argVals);
 			} catch (ParseException e) {
 				notifyErrorListeners(e.getMessage(), ctx.start);
 				return;
@@ -401,7 +402,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			}
 			else {
 				ctx.info.namespaces = new HashMap<String, DMLProgram>();
-				ctx.info.namespaces.put(namespace, prog);
+				ctx.info.namespaces.put(getQualifiedNamespace(namespace), prog);
 				ctx.info.stmt = new ImportStatement();
 				((ImportStatement) ctx.info.stmt).setCompletePath(filePath);
 				((ImportStatement) ctx.info.stmt).setFilePath(ctx.filePath.getText());
@@ -414,7 +415,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			// create empty program for this context to allow processing to continue.
 			prog = new DMLProgram();
 			ctx.info.namespaces = new HashMap<String, DMLProgram>();
-			ctx.info.namespaces.put(namespace, prog);
+			ctx.info.namespaces.put(getQualifiedNamespace(namespace), prog);
 			ctx.info.stmt = new ImportStatement();
 			((ImportStatement) ctx.info.stmt).setCompletePath(filePath);
 			((ImportStatement) ctx.info.stmt).setFilePath(ctx.filePath.getText());

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionNamespaceTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionNamespaceTest.java
@@ -41,6 +41,9 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	private final static String TEST_NAME5 = "Functions5";
 	private final static String TEST_NAME6 = "Functions6";
 	private final static String TEST_NAME7 = "Functions7";
+	private final static String TEST_NAME8 = "Functions8";
+	private final static String TEST_NAME9 = "Functions9";
+	private final static String TEST_NAME10 = "Functions10";
 	private final static String TEST_DIR = "functions/misc/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FunctionNamespaceTest.class.getSimpleName() + "/";
 	
@@ -59,6 +62,9 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5)); 
 		addTestConfiguration(TEST_NAME6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6)); 
 		addTestConfiguration(TEST_NAME7, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME7)); 
+		addTestConfiguration(TEST_NAME8, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME8)); 
+		addTestConfiguration(TEST_NAME9, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME9)); 
+		addTestConfiguration(TEST_NAME10, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME10)); 
 	}
 	
 	@Test
@@ -120,6 +126,23 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	{
 		runFunctionNoInliningNamespaceTest(TEST_NAME7, ScriptType.DML, false);
 	}
+	@Test
+	public void testFunctionErrorConflict() 
+	{
+		runFunctionNamespaceTest(TEST_NAME8, ScriptType.DML);
+	}
+	
+	@Test
+	public void testFunctionIndirectConflict() 
+	{
+		runFunctionNoInliningNamespaceTest(TEST_NAME9, ScriptType.DML, true);
+	}
+	
+	@Test
+	public void testFunctionMultiConflict() 
+	{
+		runFunctionNamespaceTest(TEST_NAME10, ScriptType.DML);
+	}
 	
 	@Test
 	public void testPyFunctionDefaultNS() 
@@ -180,6 +203,24 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	{
 		runFunctionNoInliningNamespaceTest(TEST_NAME7, ScriptType.PYDML, false);
 	}
+	
+	@Test
+	public void testPyFunctionErrorConflict() 
+	{
+		runFunctionNamespaceTest(TEST_NAME8, ScriptType.PYDML);
+	}
+	
+	@Test
+	public void testPyFunctionIndirectConflict() 
+	{
+		runFunctionNoInliningNamespaceTest(TEST_NAME9, ScriptType.PYDML, true);
+	}
+	
+	@Test
+	public void testPyFunctionMultiConflict() 
+	{
+		runFunctionNamespaceTest(TEST_NAME10, ScriptType.PYDML);
+	}
 
 	private void runFunctionNamespaceTest(String TEST_NAME, ScriptType scriptType)
 	{		
@@ -209,7 +250,17 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 				String stdErrString = baos.toString();
 				if (null != stdErrString && stdErrString.length() > 0)
 				{
-					Assert.fail("Unexpected parse error or DML script error: " + stdErrString);
+					if (TEST_NAME8.equals(TEST_NAME))
+					{
+						if (!stdErrString.contains("Namespace Conflict"))
+						{
+							Assert.fail("Expected parse issue not detected.");
+						}
+					}
+					else
+					{
+						Assert.fail("Unexpected parse error or DML script error: " + stdErrString);
+					}
 				}
 			}
 		}

--- a/src/test/scripts/functions/misc/Functions10.dml
+++ b/src/test/scripts/functions/misc/Functions10.dml
@@ -1,0 +1,30 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+setwd("./src/test/scripts/functions/misc")
+source("FunctionsK1.dml") as Functions
+source("FunctionsK2.dml") as K2
+M = matrix("1 2 3 4", rows=2, cols=2)
+nothing = Functions::matrixPrintMinMax(M)
+M = matrix("5 6 7 8", rows=2, cols=2)
+nothing = Functions::matrixPrint(M)
+[min, max] = K2::minMax(M)
+print("Minimum is " + min)
+print("Maximum is " + max)

--- a/src/test/scripts/functions/misc/Functions10.pydml
+++ b/src/test/scripts/functions/misc/Functions10.pydml
@@ -1,0 +1,30 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+setwd("./src/test/scripts/functions/misc")
+source("FunctionsK1.pydml") as Functions
+source("FunctionsK2.pydml") as K2
+M = full("1 2 3 4", rows=2, cols=2)
+nothing = Functions.matrixPrintMinMax(M)
+M = full("5 6 7 8", rows=2, cols=2)
+nothing = Functions.matrixPrint(M)
+[min, max] = K2.minMax(M)
+print("Minimum is " + min)
+print("Maximum is " + max)

--- a/src/test/scripts/functions/misc/Functions8.dml
+++ b/src/test/scripts/functions/misc/Functions8.dml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsA.dml") as fns1
+# verify duplicate namespace not allowed within same script
+source("./src/test/scripts/functions/misc/FunctionsB.dml") as fns1
+M = matrix("1 2 3 4", rows=2, cols=2)
+nothing = fns1::matrixPrint(M)
+nothing = fns1::matrixPrintMinMax(M)

--- a/src/test/scripts/functions/misc/Functions8.pydml
+++ b/src/test/scripts/functions/misc/Functions8.pydml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsA.pydml") as fns1
+# verify duplicate namespace not allowed within same script
+source("./src/test/scripts/functions/misc/FunctionsB.pydml") as fns1
+M = matrix("1 2 3 4", rows=2, cols=2)
+nothing = fns1.matrixPrint(M)
+nothing = fns1.matrixPrintMinMax(M)

--- a/src/test/scripts/functions/misc/Functions9.dml
+++ b/src/test/scripts/functions/misc/Functions9.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsJ1.dml") as FunctionsJ1
+
+X = matrix($3, rows=$1, cols=$2)
+Y = FunctionsJ1::foo1(X)
+z = sum(Y)
+
+write(z, $4)

--- a/src/test/scripts/functions/misc/Functions9.pydml
+++ b/src/test/scripts/functions/misc/Functions9.pydml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsJ1.pydml") as FunctionsJ1
+
+X = full($3, rows=$1, cols=$2)
+Y = FunctionsJ1.foo1(X)
+z = sum(Y)
+
+save(z, $4)

--- a/src/test/scripts/functions/misc/FunctionsJ1.dml
+++ b/src/test/scripts/functions/misc/FunctionsJ1.dml
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsJ2.dml") as J
+foo1 = function(matrix[double] B) return (matrix[double] V)
+{
+    V = J::foo2(B)
+}
+foo = function(matrix[double] B) return (matrix[double] V)
+{
+    V = B
+}

--- a/src/test/scripts/functions/misc/FunctionsJ1.pydml
+++ b/src/test/scripts/functions/misc/FunctionsJ1.pydml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsJ2.pydml") as J
+def foo1(B: matrix[float]) -> (V: matrix[float]):
+    V = J.foo2(B)
+
+def foo(B: matrix[float]) -> (V: matrix[float]):
+    V = B

--- a/src/test/scripts/functions/misc/FunctionsJ2.dml
+++ b/src/test/scripts/functions/misc/FunctionsJ2.dml
@@ -1,0 +1,25 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsJ3.dml") as J
+foo2 = function(matrix[double] B) return (matrix[double] V)
+{
+    V = J::foo3(B+2)
+}

--- a/src/test/scripts/functions/misc/FunctionsJ2.pydml
+++ b/src/test/scripts/functions/misc/FunctionsJ2.pydml
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsJ3.pydml") as J
+def foo2(B: matrix[float]) -> (V: matrix[float]):
+    V = J.foo3(B+2)

--- a/src/test/scripts/functions/misc/FunctionsJ3.dml
+++ b/src/test/scripts/functions/misc/FunctionsJ3.dml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsJ1.dml") as J1
+foo3 = function(matrix[double] B) return (matrix[double] V)
+{
+    if (sum(B) > 0)
+    {
+        V = B + B
+    }
+    else
+    {
+        V = J1::foo(B)
+    }
+}

--- a/src/test/scripts/functions/misc/FunctionsJ3.pydml
+++ b/src/test/scripts/functions/misc/FunctionsJ3.pydml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+source("./src/test/scripts/functions/misc/FunctionsJ1.pydml") as J1
+def foo3(B: matrix[float]) -> (V: matrix[float]):
+    if (sum(B) > 0):
+        V = B + B
+    else:
+        V = J1.foo(B)

--- a/src/test/scripts/functions/misc/FunctionsK1.dml
+++ b/src/test/scripts/functions/misc/FunctionsK1.dml
@@ -1,0 +1,40 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+setwd("./src/test/scripts/functions")
+source("misc/FunctionsK2.dml") as Functions
+matrixPrint = function(matrix[double] X) return ()
+{
+    for (i in 1:nrow(X))
+    {
+        for (j in 1:ncol(X))
+        {
+            xij = as.scalar(X[i,j])
+            print("[" + i + "," + j + "] " + xij)
+        }
+    }
+}
+matrixPrintMinMax = function(matrix[double] X) return ()
+{
+    nothing = matrixPrint(X)
+    [min, max] = Functions::minMax(X)
+    print("Minimum is " + min)
+    print("Maximum is " + max)
+}

--- a/src/test/scripts/functions/misc/FunctionsK1.pydml
+++ b/src/test/scripts/functions/misc/FunctionsK1.pydml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+setwd("./src/test/scripts/functions")
+source("misc/FunctionsK2.pydml") as Functions
+def matrixPrint(X: matrix[float]) -> ():
+    for (i in 1:nrow(X)):
+        for (j in 1:ncol(X)) :
+            xij = scalar(X[i,j])
+            print("[" + i + "," + j + "] " + xij)
+
+def matrixPrintMinMax(X: matrix[float]) -> ():
+    [min, max] = Functions.minMax(X)
+    print("Minimum is " + min)
+    print("Maximum is " + max)

--- a/src/test/scripts/functions/misc/FunctionsK2.dml
+++ b/src/test/scripts/functions/misc/FunctionsK2.dml
@@ -1,0 +1,24 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+minMax = function(matrix[double] M) return (double minVal, double maxVal) {
+    minVal = min(M)
+    maxVal = max(M)
+}

--- a/src/test/scripts/functions/misc/FunctionsK2.pydml
+++ b/src/test/scripts/functions/misc/FunctionsK2.pydml
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+def minMax(M: matrix[float]) -> (minVal: float, maxVal: float):
+    minVal = min(M)
+    maxVal = max(M)


### PR DESCRIPTION
This patch with new tests changes the way namespaces are tracked internally (i.e., uses qualified script file path) to prevent collisions. Previously, functions would be lost if the same namespace was specified when importing different scripts which resulted in error being reported as function undefined in namespace.  With this change, 'source(file1) as namespace1' in one script does not interfere with 'source(file2) as namespace1' in another script.  Note an error is reported at source statement if same namespace specified for different scripts within the same file only.
