### PR TITLE
[SYSTEMML-668] Python MLOutput.getDF() Can't Access JVM SQLContext

### DIFF
--- a/src/main/java/org/apache/sysml/api/python/SystemML.py
+++ b/src/main/java/org/apache/sysml/api/python/SystemML.py
@@ -226,7 +226,7 @@ class MLOutput(object):
 
     def getDF(self, sqlContext, varName):
         try:
-            jdf = self.jmlOut.getDF(sqlContext._scala_SQLContext, varName)
+            jdf = self.jmlOut.getDF(sqlContext._ssql_ctx, varName)
             df = DataFrame(jdf, sqlContext)
             return df
         except Py4JJavaError:


### PR DESCRIPTION
In PySpark, access to the JVM SQLContext from a PySpark SQLContext instance has changed from `sqlContext._scala_SQLContext` to `sqlContext._ssql_ctx`, breaking any previous code using the former construct, such as our Python `MLOutput.getDF(...)` method.  This updates the latter method.