### PR TITLE
[SYSTEMML-654] Support DML functions override built-in functions

### DIFF
--- a/src/main/java/org/apache/sysml/parser/DataExpression.java
+++ b/src/main/java/org/apache/sysml/parser/DataExpression.java
@@ -200,7 +200,7 @@ public class DataExpression extends DataIdentifier
 				String pname = currExpr.getName();
 				Expression pexpr = currExpr.getExpr();
 				if (pname == null){
-					dataExpr.raiseValidateError("for Rand Statment all arguments must be named parameters");	
+					dataExpr.raiseValidateError("for Rand Statement all arguments must be named parameters");	
 				}
 				dataExpr.addRandExprParam(pname, pexpr); 
 			}

--- a/src/main/java/org/apache/sysml/parser/dml/DMLParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DMLParserWrapper.java
@@ -174,7 +174,11 @@ public class DMLParserWrapper extends AParserWrapper
 		ParseTree tree = ast;
 		// And also do syntactic validation
 		ParseTreeWalker walker = new ParseTreeWalker();
-		DmlSyntacticValidator validator = new DmlSyntacticValidator(errorListener, argVals, sourceNamespace);
+		// Get list of function definitions which take precedence over built-in functions if same name
+		DmlPreprocessor prep = new DmlPreprocessor(errorListener);
+		walker.walk(prep,  tree);
+		// Syntactic validation
+		DmlSyntacticValidator validator = new DmlSyntacticValidator(errorListener, argVals, sourceNamespace, prep.getFunctionDefs());
 		walker.walk(validator, tree);
 		errorListener.unsetCurrentFileName();
 		this.parseIssues = errorListener.getParseIssues();

--- a/src/main/java/org/apache/sysml/parser/dml/DmlPreprocessor.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlPreprocessor.java
@@ -1,0 +1,374 @@
+package org.apache.sysml.parser.dml;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ErrorNode;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.apache.sysml.parser.common.CustomErrorListener;
+import org.apache.sysml.parser.dml.DmlParser.AddSubExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.AssignmentStatementContext;
+import org.apache.sysml.parser.dml.DmlParser.AtomicExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.BooleanAndExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.BooleanNotExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.BooleanOrExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.BuiltinFunctionExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.CommandlineParamExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.CommandlinePositionExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.ConstDoubleIdExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.ConstFalseExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.ConstIntIdExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.ConstStringIdExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.ConstTrueExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.DataIdExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.ExternalFunctionDefExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.ForStatementContext;
+import org.apache.sysml.parser.dml.DmlParser.FunctionCallAssignmentStatementContext;
+import org.apache.sysml.parser.dml.DmlParser.FunctionCallMultiAssignmentStatementContext;
+import org.apache.sysml.parser.dml.DmlParser.IfStatementContext;
+import org.apache.sysml.parser.dml.DmlParser.IfdefAssignmentStatementContext;
+import org.apache.sysml.parser.dml.DmlParser.ImportStatementContext;
+import org.apache.sysml.parser.dml.DmlParser.IndexedExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.InternalFunctionDefExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.IterablePredicateColonExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.IterablePredicateSeqExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.MatrixDataTypeCheckContext;
+import org.apache.sysml.parser.dml.DmlParser.MatrixMulExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.Ml_typeContext;
+import org.apache.sysml.parser.dml.DmlParser.ModIntDivExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.MultDivExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.ParForStatementContext;
+import org.apache.sysml.parser.dml.DmlParser.ParameterizedExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.PathStatementContext;
+import org.apache.sysml.parser.dml.DmlParser.PowerExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.ProgramrootContext;
+import org.apache.sysml.parser.dml.DmlParser.RelationalExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.SimpleDataIdentifierExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.StrictParameterizedExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.StrictParameterizedKeyValueStringContext;
+import org.apache.sysml.parser.dml.DmlParser.TypedArgNoAssignContext;
+import org.apache.sysml.parser.dml.DmlParser.UnaryExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.ValueTypeContext;
+import org.apache.sysml.parser.dml.DmlParser.WhileStatementContext;
+
+/**
+ * Minimal pre-processing of user function definitions which take precedence over built-in 
+ * functions in cases where names conflict.  This pre-processing takes place outside of 
+ * DmlSyntacticValidator since the function definition can be located after the function
+ * is used in a statement.
+ */
+public class DmlPreprocessor implements DmlListener {
+
+	protected final CustomErrorListener errorListener;
+	// Names of user internal and external functions definitions
+	protected Set<String> functions;
+
+	public DmlPreprocessor(CustomErrorListener errorListener) {
+		this.errorListener = errorListener;
+		functions = new HashSet<String>();
+	}
+
+	public Set<String> getFunctionDefs() {
+		return functions;
+	}
+	
+	@Override
+	public void enterExternalFunctionDefExpression(ExternalFunctionDefExpressionContext ctx) {
+		validateFunctionName(ctx.name.getText(), ctx);
+	}
+
+	@Override
+	public void exitExternalFunctionDefExpression(ExternalFunctionDefExpressionContext ctx) {}
+
+	@Override
+	public void enterInternalFunctionDefExpression(InternalFunctionDefExpressionContext ctx) {
+		validateFunctionName(ctx.name.getText(), ctx);
+	}
+
+	@Override
+	public void exitInternalFunctionDefExpression(InternalFunctionDefExpressionContext ctx) {}
+
+	protected void validateFunctionName(String name, ParserRuleContext ctx) {
+		if (!functions.contains(name)) {
+			functions.add(name);
+		}
+		else {
+			notifyErrorListeners("Function Name Conflict: '" + name + "' already defined in " + errorListener.getCurrentFileName(), ctx.start);
+		}
+	}
+
+	protected void notifyErrorListeners(String message, Token op) {
+		errorListener.validationError(op.getLine(), op.getCharPositionInLine(), message);
+	}
+
+	// -----------------------------------------------------------------
+	// 			Not overridden
+	// -----------------------------------------------------------------
+
+	@Override
+	public void visitTerminal(TerminalNode node) {}
+
+	@Override
+	public void visitErrorNode(ErrorNode node) {}
+
+	@Override
+	public void enterEveryRule(ParserRuleContext ctx) {}
+
+	@Override
+	public void exitEveryRule(ParserRuleContext ctx) {}
+
+	@Override
+	public void enterFunctionCallMultiAssignmentStatement(FunctionCallMultiAssignmentStatementContext ctx) {}
+
+	@Override
+	public void exitFunctionCallMultiAssignmentStatement(FunctionCallMultiAssignmentStatementContext ctx) {}
+
+	@Override
+	public void enterMatrixDataTypeCheck(MatrixDataTypeCheckContext ctx) {}
+
+	@Override
+	public void exitMatrixDataTypeCheck(MatrixDataTypeCheckContext ctx) {}
+
+	@Override
+	public void enterStrictParameterizedKeyValueString(StrictParameterizedKeyValueStringContext ctx) {}
+
+	@Override
+	public void exitStrictParameterizedKeyValueString(StrictParameterizedKeyValueStringContext ctx) {}
+
+	@Override
+	public void enterPathStatement(PathStatementContext ctx) {}
+
+	@Override
+	public void exitPathStatement(PathStatementContext ctx) {}
+
+	@Override
+	public void enterConstTrueExpression(ConstTrueExpressionContext ctx) {}
+
+	@Override
+	public void exitConstTrueExpression(ConstTrueExpressionContext ctx) {}
+
+	@Override
+	public void enterTypedArgNoAssign(TypedArgNoAssignContext ctx) {}
+
+	@Override
+	public void exitTypedArgNoAssign(TypedArgNoAssignContext ctx) {}
+
+	@Override
+	public void enterWhileStatement(WhileStatementContext ctx) {}
+
+	@Override
+	public void exitWhileStatement(WhileStatementContext ctx) {}
+
+	@Override
+	public void enterConstStringIdExpression(ConstStringIdExpressionContext ctx) {}
+
+	@Override
+	public void exitConstStringIdExpression(ConstStringIdExpressionContext ctx) {}
+
+	@Override
+	public void enterDataIdExpression(DataIdExpressionContext ctx) {}
+
+	@Override
+	public void exitDataIdExpression(DataIdExpressionContext ctx) {}
+
+	@Override
+	public void enterAtomicExpression(AtomicExpressionContext ctx) {}
+
+	@Override
+	public void exitAtomicExpression(AtomicExpressionContext ctx) {}
+
+	@Override
+	public void enterPowerExpression(PowerExpressionContext ctx) {}
+
+	@Override
+	public void exitPowerExpression(PowerExpressionContext ctx) {}
+
+	@Override
+	public void enterFunctionCallAssignmentStatement(FunctionCallAssignmentStatementContext ctx) {}
+
+	@Override
+	public void exitFunctionCallAssignmentStatement(FunctionCallAssignmentStatementContext ctx) {}
+
+	@Override
+	public void enterMatrixMulExpression(MatrixMulExpressionContext ctx) {}
+
+	@Override
+	public void exitMatrixMulExpression(MatrixMulExpressionContext ctx) {}
+
+	@Override
+	public void enterModIntDivExpression(ModIntDivExpressionContext ctx) {}
+
+	@Override
+	public void exitModIntDivExpression(ModIntDivExpressionContext ctx) {}
+
+	@Override
+	public void enterSimpleDataIdentifierExpression(SimpleDataIdentifierExpressionContext ctx) {}
+
+	@Override
+	public void exitSimpleDataIdentifierExpression(SimpleDataIdentifierExpressionContext ctx) {}
+
+	@Override
+	public void enterBuiltinFunctionExpression(BuiltinFunctionExpressionContext ctx) {}
+
+	@Override
+	public void exitBuiltinFunctionExpression(BuiltinFunctionExpressionContext ctx) {}
+
+	@Override
+	public void enterConstIntIdExpression(ConstIntIdExpressionContext ctx) {}
+
+	@Override
+	public void exitConstIntIdExpression(ConstIntIdExpressionContext ctx) {}
+
+	@Override
+	public void enterForStatement(ForStatementContext ctx) {}
+
+	@Override
+	public void exitForStatement(ForStatementContext ctx) {}
+
+	@Override
+	public void enterValueType(ValueTypeContext ctx) {}
+
+	@Override
+	public void exitValueType(ValueTypeContext ctx) {}
+
+	@Override
+	public void enterParameterizedExpression(ParameterizedExpressionContext ctx) {}
+
+	@Override
+	public void exitParameterizedExpression(ParameterizedExpressionContext ctx) {}
+
+	@Override
+	public void enterConstFalseExpression(ConstFalseExpressionContext ctx) {}
+
+	@Override
+	public void exitConstFalseExpression(ConstFalseExpressionContext ctx) {}
+
+	@Override
+	public void enterBooleanOrExpression(BooleanOrExpressionContext ctx) {}
+
+	@Override
+	public void exitBooleanOrExpression(BooleanOrExpressionContext ctx) {}
+
+	@Override
+	public void enterAssignmentStatement(AssignmentStatementContext ctx) {}
+
+	@Override
+	public void exitAssignmentStatement(AssignmentStatementContext ctx) {}
+
+	@Override
+	public void enterIterablePredicateColonExpression(IterablePredicateColonExpressionContext ctx) {}
+
+	@Override
+	public void exitIterablePredicateColonExpression(IterablePredicateColonExpressionContext ctx) {}
+
+	@Override
+	public void enterParForStatement(ParForStatementContext ctx) {}
+
+	@Override
+	public void exitParForStatement(ParForStatementContext ctx) {}
+
+	@Override
+	public void enterStrictParameterizedExpression(StrictParameterizedExpressionContext ctx) {}
+
+	@Override
+	public void exitStrictParameterizedExpression(StrictParameterizedExpressionContext ctx) {}
+
+	@Override
+	public void enterCommandlineParamExpression(CommandlineParamExpressionContext ctx) {}
+
+	@Override
+	public void exitCommandlineParamExpression(CommandlineParamExpressionContext ctx) {}
+
+	@Override
+	public void enterMultDivExpression(MultDivExpressionContext ctx) {}
+
+	@Override
+	public void exitMultDivExpression(MultDivExpressionContext ctx) {}
+
+	@Override
+	public void enterAddSubExpression(AddSubExpressionContext ctx) {}
+
+	@Override
+	public void exitAddSubExpression(AddSubExpressionContext ctx) {}
+
+	@Override
+	public void enterImportStatement(ImportStatementContext ctx) {}
+
+	@Override
+	public void exitImportStatement(ImportStatementContext ctx) {}
+
+	@Override
+	public void enterProgramroot(ProgramrootContext ctx) {}
+
+	@Override
+	public void exitProgramroot(ProgramrootContext ctx) {}
+
+	@Override
+	public void enterIterablePredicateSeqExpression(IterablePredicateSeqExpressionContext ctx) {}
+
+	@Override
+	public void exitIterablePredicateSeqExpression(IterablePredicateSeqExpressionContext ctx) {}
+
+	@Override
+	public void enterIfdefAssignmentStatement(IfdefAssignmentStatementContext ctx) {}
+
+	@Override
+	public void exitIfdefAssignmentStatement(IfdefAssignmentStatementContext ctx) {}
+
+	@Override
+	public void enterBooleanAndExpression(BooleanAndExpressionContext ctx) {}
+
+	@Override
+	public void exitBooleanAndExpression(BooleanAndExpressionContext ctx) {}
+
+	@Override
+	public void enterIndexedExpression(IndexedExpressionContext ctx) {}
+
+	@Override
+	public void exitIndexedExpression(IndexedExpressionContext ctx) {}
+
+	@Override
+	public void enterBooleanNotExpression(BooleanNotExpressionContext ctx) {}
+
+	@Override
+	public void exitBooleanNotExpression(BooleanNotExpressionContext ctx) {}
+
+	@Override
+	public void enterIfStatement(IfStatementContext ctx) {}
+
+	@Override
+	public void exitIfStatement(IfStatementContext ctx) {}
+
+	@Override
+	public void enterRelationalExpression(RelationalExpressionContext ctx) {}
+
+	@Override
+	public void exitRelationalExpression(RelationalExpressionContext ctx) {}
+
+	@Override
+	public void enterCommandlinePositionExpression(CommandlinePositionExpressionContext ctx) {}
+
+	@Override
+	public void exitCommandlinePositionExpression(CommandlinePositionExpressionContext ctx) {}
+
+	@Override
+	public void enterConstDoubleIdExpression(ConstDoubleIdExpressionContext ctx) {}
+
+	@Override
+	public void exitConstDoubleIdExpression(ConstDoubleIdExpressionContext ctx) {}
+
+	@Override
+	public void enterUnaryExpression(UnaryExpressionContext ctx) {}
+
+	@Override
+	public void exitUnaryExpression(UnaryExpressionContext ctx) {}
+
+	@Override
+	public void enterMl_type(Ml_typeContext ctx) {}
+
+	@Override
+	public void exitMl_type(Ml_typeContext ctx) {}
+
+}

--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -112,8 +112,8 @@ import org.apache.sysml.parser.dml.DmlParser.WhileStatementContext;
 
 public class DmlSyntacticValidator extends CommonSyntacticValidator implements DmlListener {
 
-	public DmlSyntacticValidator(CustomErrorListener errorListener, Map<String,String> argVals, String sourceNamespace) {
-		super(errorListener, argVals, sourceNamespace);
+	public DmlSyntacticValidator(CustomErrorListener errorListener, Map<String,String> argVals, String sourceNamespace, Set<String> prepFunctions) {
+		super(errorListener, argVals, sourceNamespace, prepFunctions);
 	}
 	
 	@Override public String namespaceResolutionOp() { return "::"; }
@@ -789,8 +789,6 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		// set function name
 		functionStmt.setName(ctx.name.getText());
 
-		validateFunctionName(ctx.name.getText(), ctx);
-
 		if(ctx.body.size() > 0) {
 			// handle function body
 			// Create arraylist of one statement block
@@ -824,8 +822,6 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 
 		// set function name
 		functionStmt.setName(ctx.name.getText());
-
-		validateFunctionName(ctx.name.getText(), ctx);
 
 		// set other parameters
 		HashMap<String, String> otherParams = new HashMap<String,String>();

--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -789,6 +789,7 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		// set function name
 		functionStmt.setName(ctx.name.getText());
 
+		validateFunctionName(ctx.name.getText(), ctx);
 
 		if(ctx.body.size() > 0) {
 			// handle function body
@@ -823,6 +824,8 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 
 		// set function name
 		functionStmt.setName(ctx.name.getText());
+
+		validateFunctionName(ctx.name.getText(), ctx);
 
 		// set other parameters
 		HashMap<String, String> otherParams = new HashMap<String,String>();

--- a/src/main/java/org/apache/sysml/parser/pydml/PyDMLParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PyDMLParserWrapper.java
@@ -161,7 +161,11 @@ public class PyDMLParserWrapper extends AParserWrapper
 		ParseTree tree = ast;
 		// And also do syntactic validation
 		ParseTreeWalker walker = new ParseTreeWalker();
-		PydmlSyntacticValidator validator = new PydmlSyntacticValidator(errorListener, argVals, sourceNamespace);
+		// Get list of function definitions which take precedence over built-in functions if same name
+		PydmlPreprocessor prep = new PydmlPreprocessor(errorListener);
+		walker.walk(prep, tree);
+		// Syntactic validation
+		PydmlSyntacticValidator validator = new PydmlSyntacticValidator(errorListener, argVals, sourceNamespace, prep.getFunctionDefs());
 		walker.walk(validator, tree);
 		errorListener.unsetCurrentFileName();
 		this.parseIssues = errorListener.getParseIssues();

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlPreprocessor.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlPreprocessor.java
@@ -1,0 +1,374 @@
+package org.apache.sysml.parser.pydml;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ErrorNode;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.apache.sysml.parser.common.CustomErrorListener;
+import org.apache.sysml.parser.pydml.PydmlParser.AddSubExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.AssignmentStatementContext;
+import org.apache.sysml.parser.pydml.PydmlParser.AtomicExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.BooleanAndExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.BooleanNotExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.BooleanOrExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.BuiltinFunctionExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.CommandlineParamExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.CommandlinePositionExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ConstDoubleIdExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ConstFalseExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ConstIntIdExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ConstStringIdExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ConstTrueExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.DataIdExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ExternalFunctionDefExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ForStatementContext;
+import org.apache.sysml.parser.pydml.PydmlParser.FunctionCallAssignmentStatementContext;
+import org.apache.sysml.parser.pydml.PydmlParser.FunctionCallMultiAssignmentStatementContext;
+import org.apache.sysml.parser.pydml.PydmlParser.IfStatementContext;
+import org.apache.sysml.parser.pydml.PydmlParser.IfdefAssignmentStatementContext;
+import org.apache.sysml.parser.pydml.PydmlParser.IgnoreNewLineContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ImportStatementContext;
+import org.apache.sysml.parser.pydml.PydmlParser.IndexedExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.InternalFunctionDefExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.IterablePredicateColonExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.IterablePredicateSeqExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.MatrixDataTypeCheckContext;
+import org.apache.sysml.parser.pydml.PydmlParser.Ml_typeContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ModIntDivExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.MultDivExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ParForStatementContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ParameterizedExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.PathStatementContext;
+import org.apache.sysml.parser.pydml.PydmlParser.PowerExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ProgramrootContext;
+import org.apache.sysml.parser.pydml.PydmlParser.RelationalExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.SimpleDataIdentifierExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.StrictParameterizedExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.StrictParameterizedKeyValueStringContext;
+import org.apache.sysml.parser.pydml.PydmlParser.TypedArgNoAssignContext;
+import org.apache.sysml.parser.pydml.PydmlParser.UnaryExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.ValueDataTypeCheckContext;
+import org.apache.sysml.parser.pydml.PydmlParser.WhileStatementContext;
+
+/**
+ * Minimal pre-processing of user function definitions which take precedence over built-in 
+ * functions in cases where names conflict.  This pre-processing takes place outside of 
+ * PymlSyntacticValidator since the function definition can be located after the function
+ * is used in a statement.
+ */
+public class PydmlPreprocessor implements PydmlListener {
+
+	protected final CustomErrorListener errorListener;
+	// Names of user internal and external functions definitions
+	protected Set<String> functions;
+
+	public PydmlPreprocessor(CustomErrorListener errorListener) {
+		this.errorListener = errorListener;
+		functions = new HashSet<String>();
+	}
+
+	public Set<String> getFunctionDefs() {
+		return functions;
+	}
+
+	@Override
+	public void enterExternalFunctionDefExpression(ExternalFunctionDefExpressionContext ctx) {
+		validateFunctionName(ctx.name.getText(), ctx);
+	}
+
+	@Override
+	public void exitExternalFunctionDefExpression(ExternalFunctionDefExpressionContext ctx) {}
+
+	@Override
+	public void enterInternalFunctionDefExpression(InternalFunctionDefExpressionContext ctx) {
+		validateFunctionName(ctx.name.getText(), ctx);
+	}
+
+	@Override
+	public void exitInternalFunctionDefExpression(InternalFunctionDefExpressionContext ctx) {}
+
+	protected void validateFunctionName(String name, ParserRuleContext ctx) {
+		if (!functions.contains(name)) {
+			functions.add(name);
+		}
+		else {
+			notifyErrorListeners("Function Name Conflict: '" + name + "' already defined in " + errorListener.getCurrentFileName(), ctx.start);
+		}
+	}
+
+	protected void notifyErrorListeners(String message, Token op) {
+		errorListener.validationError(op.getLine(), op.getCharPositionInLine(), message);
+	}
+
+	// -----------------------------------------------------------------
+	// 			Not overridden
+	// -----------------------------------------------------------------
+
+	@Override
+	public void visitTerminal(TerminalNode node) {}
+
+	@Override
+	public void visitErrorNode(ErrorNode node) {}
+
+	@Override
+	public void enterEveryRule(ParserRuleContext ctx) {}
+
+	@Override
+	public void exitEveryRule(ParserRuleContext ctx) {}
+
+	@Override
+	public void enterFunctionCallMultiAssignmentStatement(FunctionCallMultiAssignmentStatementContext ctx) {}
+
+	@Override
+	public void exitFunctionCallMultiAssignmentStatement(FunctionCallMultiAssignmentStatementContext ctx) {}
+
+	@Override
+	public void enterIgnoreNewLine(IgnoreNewLineContext ctx) {}
+
+	@Override
+	public void exitIgnoreNewLine(IgnoreNewLineContext ctx) {}
+
+	@Override
+	public void enterMatrixDataTypeCheck(MatrixDataTypeCheckContext ctx) {}
+
+	@Override
+	public void exitMatrixDataTypeCheck(MatrixDataTypeCheckContext ctx) {}
+
+	@Override
+	public void enterStrictParameterizedKeyValueString(StrictParameterizedKeyValueStringContext ctx) {}
+
+	@Override
+	public void exitStrictParameterizedKeyValueString(StrictParameterizedKeyValueStringContext ctx) {}
+
+	@Override
+	public void enterPathStatement(PathStatementContext ctx) {}
+
+	@Override
+	public void exitPathStatement(PathStatementContext ctx) {}
+
+	@Override
+	public void enterConstTrueExpression(ConstTrueExpressionContext ctx) {}
+
+	@Override
+	public void exitConstTrueExpression(ConstTrueExpressionContext ctx) {}
+
+	@Override
+	public void enterTypedArgNoAssign(TypedArgNoAssignContext ctx) {}
+
+	@Override
+	public void exitTypedArgNoAssign(TypedArgNoAssignContext ctx) {}
+
+	@Override
+	public void enterWhileStatement(WhileStatementContext ctx) {}
+
+	@Override
+	public void exitWhileStatement(WhileStatementContext ctx) {}
+
+	@Override
+	public void enterConstStringIdExpression(ConstStringIdExpressionContext ctx) {}
+
+	@Override
+	public void exitConstStringIdExpression(ConstStringIdExpressionContext ctx) {}
+
+	@Override
+	public void enterDataIdExpression(DataIdExpressionContext ctx) {}
+
+	@Override
+	public void exitDataIdExpression(DataIdExpressionContext ctx) {}
+
+	@Override
+	public void enterAtomicExpression(AtomicExpressionContext ctx) {}
+
+	@Override
+	public void exitAtomicExpression(AtomicExpressionContext ctx) {}
+
+	@Override
+	public void enterPowerExpression(PowerExpressionContext ctx) {}
+
+	@Override
+	public void exitPowerExpression(PowerExpressionContext ctx) {}
+
+	@Override
+	public void enterFunctionCallAssignmentStatement(FunctionCallAssignmentStatementContext ctx) {}
+
+	@Override
+	public void exitFunctionCallAssignmentStatement(FunctionCallAssignmentStatementContext ctx) {}
+
+	@Override
+	public void enterModIntDivExpression(ModIntDivExpressionContext ctx) {}
+
+	@Override
+	public void exitModIntDivExpression(ModIntDivExpressionContext ctx) {}
+
+	@Override
+	public void enterSimpleDataIdentifierExpression(SimpleDataIdentifierExpressionContext ctx) {}
+
+	@Override
+	public void exitSimpleDataIdentifierExpression(SimpleDataIdentifierExpressionContext ctx) {}
+
+	@Override
+	public void enterBuiltinFunctionExpression(BuiltinFunctionExpressionContext ctx) {}
+
+	@Override
+	public void exitBuiltinFunctionExpression(BuiltinFunctionExpressionContext ctx) {}
+
+	@Override
+	public void enterConstIntIdExpression(ConstIntIdExpressionContext ctx) {}
+
+	@Override
+	public void exitConstIntIdExpression(ConstIntIdExpressionContext ctx) {}
+
+	@Override
+	public void enterForStatement(ForStatementContext ctx) {}
+
+	@Override
+	public void exitForStatement(ForStatementContext ctx) {}
+
+	@Override
+	public void enterParameterizedExpression(ParameterizedExpressionContext ctx) {}
+
+	@Override
+	public void exitParameterizedExpression(ParameterizedExpressionContext ctx) {}
+
+	@Override
+	public void enterConstFalseExpression(ConstFalseExpressionContext ctx) {}
+
+	@Override
+	public void exitConstFalseExpression(ConstFalseExpressionContext ctx) {}
+
+	@Override
+	public void enterBooleanOrExpression(BooleanOrExpressionContext ctx) {}
+
+	@Override
+	public void exitBooleanOrExpression(BooleanOrExpressionContext ctx) {}
+
+	@Override
+	public void enterAssignmentStatement(AssignmentStatementContext ctx) {}
+
+	@Override
+	public void exitAssignmentStatement(AssignmentStatementContext ctx) {}
+
+	@Override
+	public void enterIterablePredicateColonExpression(IterablePredicateColonExpressionContext ctx) {}
+
+	@Override
+	public void exitIterablePredicateColonExpression(IterablePredicateColonExpressionContext ctx) {}
+
+	@Override
+	public void enterParForStatement(ParForStatementContext ctx) {}
+
+	@Override
+	public void exitParForStatement(ParForStatementContext ctx) {}
+
+	@Override
+	public void enterStrictParameterizedExpression(StrictParameterizedExpressionContext ctx) {}
+
+	@Override
+	public void exitStrictParameterizedExpression(StrictParameterizedExpressionContext ctx) {}
+
+	@Override
+	public void enterCommandlineParamExpression(CommandlineParamExpressionContext ctx) {}
+
+	@Override
+	public void exitCommandlineParamExpression(CommandlineParamExpressionContext ctx) {}
+
+	@Override
+	public void enterMultDivExpression(MultDivExpressionContext ctx) {}
+
+	@Override
+	public void exitMultDivExpression(MultDivExpressionContext ctx) {}
+
+	@Override
+	public void enterAddSubExpression(AddSubExpressionContext ctx) {}
+
+	@Override
+	public void exitAddSubExpression(AddSubExpressionContext ctx) {}
+
+	@Override
+	public void enterImportStatement(ImportStatementContext ctx) {}
+
+	@Override
+	public void exitImportStatement(ImportStatementContext ctx) {}
+
+	@Override
+	public void enterProgramroot(ProgramrootContext ctx) {}
+
+	@Override
+	public void exitProgramroot(ProgramrootContext ctx) {}
+
+	@Override
+	public void enterIterablePredicateSeqExpression(IterablePredicateSeqExpressionContext ctx) {}
+
+	@Override
+	public void exitIterablePredicateSeqExpression(IterablePredicateSeqExpressionContext ctx) {}
+
+	@Override
+	public void enterIfdefAssignmentStatement(IfdefAssignmentStatementContext ctx) {}
+
+	@Override
+	public void exitIfdefAssignmentStatement(IfdefAssignmentStatementContext ctx) {}
+
+	@Override
+	public void enterBooleanAndExpression(BooleanAndExpressionContext ctx) {}
+
+	@Override
+	public void exitBooleanAndExpression(BooleanAndExpressionContext ctx) {}
+
+	@Override
+	public void enterIndexedExpression(IndexedExpressionContext ctx) {}
+
+	@Override
+	public void exitIndexedExpression(IndexedExpressionContext ctx) {}
+
+	@Override
+	public void enterBooleanNotExpression(BooleanNotExpressionContext ctx) {}
+
+	@Override
+	public void exitBooleanNotExpression(BooleanNotExpressionContext ctx) {}
+
+	@Override
+	public void enterIfStatement(IfStatementContext ctx) {}
+
+	@Override
+	public void exitIfStatement(IfStatementContext ctx) {}
+
+	@Override
+	public void enterRelationalExpression(RelationalExpressionContext ctx) {}
+
+	@Override
+	public void exitRelationalExpression(RelationalExpressionContext ctx) {}
+
+	@Override
+	public void enterCommandlinePositionExpression(CommandlinePositionExpressionContext ctx) {}
+
+	@Override
+	public void exitCommandlinePositionExpression(CommandlinePositionExpressionContext ctx) {}
+
+	@Override
+	public void enterConstDoubleIdExpression(ConstDoubleIdExpressionContext ctx) {}
+
+	@Override
+	public void exitConstDoubleIdExpression(ConstDoubleIdExpressionContext ctx) {}
+
+	@Override
+	public void enterUnaryExpression(UnaryExpressionContext ctx) {}
+
+	@Override
+	public void exitUnaryExpression(UnaryExpressionContext ctx) {}
+
+	@Override
+	public void enterValueDataTypeCheck(ValueDataTypeCheckContext ctx) {}
+
+	@Override
+	public void exitValueDataTypeCheck(ValueDataTypeCheckContext ctx) {}
+
+	@Override
+	public void enterMl_type(Ml_typeContext ctx) {}
+
+	@Override
+	public void exitMl_type(Ml_typeContext ctx) {}
+
+}

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -600,7 +600,9 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 	 */
 	private ConvertedDMLSyntax convertPythonBuiltinFunctionToDMLSyntax(ParserRuleContext ctx, String namespace, String functionName, ArrayList<ParameterExpression> paramExpression,
 			Token fnName) {
-
+		if (!namespace.equals(DMLProgram.DEFAULT_NAMESPACE) || functions.contains(functionName)) {
+			return new ConvertedDMLSyntax(namespace, functionName, paramExpression);
+		}
 
 		String fileName = currentFile;
 		int line = ctx.start.getLine();
@@ -1345,7 +1347,8 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		// set function name
 		functionStmt.setName(ctx.name.getText());
 
-
+		validateFunctionName(functionStmt.getName(), ctx);
+		
 		if(ctx.body.size() > 0) {
 			// handle function body
 			// Create arraylist of one statement block
@@ -1380,6 +1383,8 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		// set function name
 		functionStmt.setName(ctx.name.getText());
 
+		validateFunctionName(functionStmt.getName(), ctx);
+		
 		// set other parameters
 		HashMap<String, String> otherParams = new HashMap<String,String>();
 		boolean atleastOneClassName = false;

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -600,7 +600,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 	 */
 	private ConvertedDMLSyntax convertPythonBuiltinFunctionToDMLSyntax(ParserRuleContext ctx, String namespace, String functionName, ArrayList<ParameterExpression> paramExpression,
 			Token fnName) {
-		if (!namespace.equals(DMLProgram.DEFAULT_NAMESPACE) || functions.contains(functionName)) {
+		if (sources.containsValue(namespace) || functions.contains(functionName)) {
 			return new ConvertedDMLSyntax(namespace, functionName, paramExpression);
 		}
 

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -122,8 +122,8 @@ import org.apache.sysml.parser.pydml.PydmlParser.WhileStatementContext;
  */
 public class PydmlSyntacticValidator extends CommonSyntacticValidator implements PydmlListener {
 
-	public PydmlSyntacticValidator(CustomErrorListener errorListener, Map<String,String> argVals, String sourceNamespace) {
-		super(errorListener, argVals, sourceNamespace);
+	public PydmlSyntacticValidator(CustomErrorListener errorListener, Map<String,String> argVals, String sourceNamespace, Set<String> prepFunctions) {
+		super(errorListener, argVals, sourceNamespace, prepFunctions);
 	}
 
 	@Override public String namespaceResolutionOp() { return "."; }
@@ -1346,8 +1346,6 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 
 		// set function name
 		functionStmt.setName(ctx.name.getText());
-
-		validateFunctionName(functionStmt.getName(), ctx);
 		
 		if(ctx.body.size() > 0) {
 			// handle function body
@@ -1382,8 +1380,6 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 
 		// set function name
 		functionStmt.setName(ctx.name.getText());
-
-		validateFunctionName(functionStmt.getName(), ctx);
 		
 		// set other parameters
 		HashMap<String, String> otherParams = new HashMap<String,String>();

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionNamespaceTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionNamespaceTest.java
@@ -44,6 +44,9 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	private final static String TEST_NAME8 = "Functions8";
 	private final static String TEST_NAME9 = "Functions9";
 	private final static String TEST_NAME10 = "Functions10";
+	private final static String TEST_NAME11 = "Functions11";
+	private final static String TEST_NAME12 = "Functions12";
+	private final static String TEST_NAME13 = "Functions13";
 	private final static String TEST_DIR = "functions/misc/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FunctionNamespaceTest.class.getSimpleName() + "/";
 	
@@ -65,6 +68,9 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME8, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME8)); 
 		addTestConfiguration(TEST_NAME9, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME9)); 
 		addTestConfiguration(TEST_NAME10, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME10)); 
+		addTestConfiguration(TEST_NAME11, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME11)); 
+		addTestConfiguration(TEST_NAME12, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME12)); 
+		addTestConfiguration(TEST_NAME13, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME13)); 
 	}
 	
 	@Test
@@ -145,6 +151,24 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	}
 	
 	@Test
+	public void testFunctionBuiltinOverride() 
+	{
+		runFunctionNamespaceTest(TEST_NAME11, ScriptType.DML);
+	}
+	
+	@Test
+	public void testFunctionMultiOverride() 
+	{
+		runFunctionNamespaceTest(TEST_NAME12, ScriptType.DML);
+	}
+	
+	@Test
+	public void testFunctionErrorOverride() 
+	{
+		runFunctionNamespaceTest(TEST_NAME13, ScriptType.DML);
+	}
+	
+	@Test
 	public void testPyFunctionDefaultNS() 
 	{
 		runFunctionNamespaceTest(TEST_NAME0, ScriptType.PYDML);
@@ -221,6 +245,24 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	{
 		runFunctionNamespaceTest(TEST_NAME10, ScriptType.PYDML);
 	}
+	
+	@Test
+	public void testPyFunctionBuiltinOverride() 
+	{
+		runFunctionNamespaceTest(TEST_NAME11, ScriptType.PYDML);
+	}
+	
+	@Test
+	public void testPyFunctionMultiOverride() 
+	{
+		runFunctionNamespaceTest(TEST_NAME12, ScriptType.PYDML);
+	}
+	
+	@Test
+	public void testPyFunctionErrorOverride() 
+	{
+		runFunctionNamespaceTest(TEST_NAME13, ScriptType.PYDML);
+	}
 
 	private void runFunctionNamespaceTest(String TEST_NAME, ScriptType scriptType)
 	{		
@@ -253,6 +295,13 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 					if (TEST_NAME8.equals(TEST_NAME))
 					{
 						if (!stdErrString.contains("Namespace Conflict"))
+						{
+							Assert.fail("Expected parse issue not detected.");
+						}
+					}
+					else if (TEST_NAME13.equals(TEST_NAME))
+					{
+						if (stdErrString != null && !stdErrString.contains("Function Name Conflict"))
 						{
 							Assert.fail("Expected parse issue not detected.");
 						}

--- a/src/test/scripts/functions/misc/Functions11.dml
+++ b/src/test/scripts/functions/misc/Functions11.dml
@@ -1,0 +1,46 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# Import internal function definition override of built-in sum
+source("./src/test/scripts/functions/misc/FunctionsL1.dml") as Functions
+
+# Local internal function definition override of built-in min
+min = function(integer i)
+{
+    print("min" + i)
+}
+
+M1 = matrix("1 2 3 4", rows=2, cols=2)
+M2 = matrix("5 6 7 8", rows=2, cols=2)
+
+# access local min
+nothing = min(1)
+
+# built-in min not directly accessible in this script due to local override
+#result = min(M1)
+result = Functions::min(M1)
+
+# access imported sum
+result = Functions::sum(M1)
+
+# built-in sum accessible since imported override
+result = sum(M2)
+print("Built-in sum is " + result)

--- a/src/test/scripts/functions/misc/Functions11.dml
+++ b/src/test/scripts/functions/misc/Functions11.dml
@@ -19,28 +19,48 @@
 #
 #-------------------------------------------------------------
 
-# Import internal function definition override of built-in sum
+# Import function definition override of built-in sum
 source("./src/test/scripts/functions/misc/FunctionsL1.dml") as Functions
 
-# Local internal function definition override of built-in min
-min = function(integer i)
+# Local function definition override of built-in min returning scalar
+min = function(integer x) return (integer y)
 {
-    print("min" + i)
+    print("override min")
+    Z = matrix(x, rows=4, cols=2)
+    y = x*2
 }
+
+# Use local min after definition
+result = min(1)
+print("min is " + result)
 
 M1 = matrix("1 2 3 4", rows=2, cols=2)
 M2 = matrix("5 6 7 8", rows=2, cols=2)
 
-# access local min
-nothing = min(1)
-
-# built-in min not directly accessible in this script due to local override
+# Built-in min not directly accessible in this script due to local override
 #result = min(M1)
+
+# Use imported min
 result = Functions::min(M1)
 
-# access imported sum
+# Use imported function with overrides
+[min, max] = Functions::minMax(M2)
+
+# Use imported sum
 result = Functions::sum(M1)
 
-# built-in sum accessible since imported override
+# Built-in sum accessible since imported override
 result = sum(M2)
 print("Built-in sum is " + result)
+
+# Use local override before function definition
+Z = rand(2)
+print("rand sum is " + sum(Z))
+
+# Local function definition override of built-in rand returning matrix
+rand = function(int x) return (matrix[double] Z)
+{
+    print("override rand")
+    Z = matrix(x, rows=4, cols=2)
+    y = x*2
+}

--- a/src/test/scripts/functions/misc/Functions11.pydml
+++ b/src/test/scripts/functions/misc/Functions11.pydml
@@ -19,26 +19,44 @@
 #
 #-------------------------------------------------------------
 
-# Import internal function definition override of built-in sum
+# Import function definition override of built-in sum
 source("./src/test/scripts/functions/misc/FunctionsL1.pydml") as Functions
 
-# Local internal function definition override of built-in min
-def min(i: int):
-    print("min" + i)
+# Local function definition override of built-in min returning scalar
+def min(x: int) -> (y: int):
+    print("override min")
+    Z = full(x, rows=4, cols=2)
+    y = x*2
+
+# Use local min after definition
+result = min(1)
+print("min is " + result)
 
 M1 = full("1 2 3 4", rows=2, cols=2)
 M2 = full("5 6 7 8", rows=2, cols=2)
 
-# access local min
-nothing = min(1)
-
-# built-in min not directly accessible in this script due to local override
+# Built-in min not directly accessible in this script due to local override
 #result = min(M1)
+
+# Use imported min
 result = Functions.min(M1)
 
-# access imported sum
+# Use imported function with overrides
+[min, max] = Functions.minMax(M2)
+
+# Use imported sum
 result = Functions.sum(M1)
 
-# built-in sum accessible since imported override
+# Built-in sum accessible since imported override
 result = sum(M2)
 print("Built-in sum is " + result)
+
+# Use local override before function definition
+Z = rand(2)
+print("rand sum is " + sum(Z))
+
+# Local function definition override of built-in rand returning matrix
+def rand(x: int) -> (Z: matrix[float]):
+    print("override rand")
+    Z = full(x, rows=4, cols=2)
+    y = x*2

--- a/src/test/scripts/functions/misc/Functions11.pydml
+++ b/src/test/scripts/functions/misc/Functions11.pydml
@@ -1,0 +1,44 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# Import internal function definition override of built-in sum
+source("./src/test/scripts/functions/misc/FunctionsL1.pydml") as Functions
+
+# Local internal function definition override of built-in min
+def min(i: int):
+    print("min" + i)
+
+M1 = full("1 2 3 4", rows=2, cols=2)
+M2 = full("5 6 7 8", rows=2, cols=2)
+
+# access local min
+nothing = min(1)
+
+# built-in min not directly accessible in this script due to local override
+#result = min(M1)
+result = Functions.min(M1)
+
+# access imported sum
+result = Functions.sum(M1)
+
+# built-in sum accessible since imported override
+result = sum(M2)
+print("Built-in sum is " + result)

--- a/src/test/scripts/functions/misc/Functions12.dml
+++ b/src/test/scripts/functions/misc/Functions12.dml
@@ -1,0 +1,44 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# Override specific built-in function definition types
+source("./src/test/scripts/functions/misc/FunctionsL2.dml") as Functions
+
+M1 = matrix("1 2 3 4", rows=2, cols=2)
+M2 = matrix("5 6 7 8", rows=2, cols=2)
+
+# access imported external function t
+now = Functions::t()
+print("Time is " + now)
+
+# built-in transpose accessible
+result = t(M2)
+nothing = Functions::print(result)
+
+# access imported qr multiple return function
+[min, max] = Functions::qr(M1)
+
+# access built-in qr
+[Q, R] = qr(M2)
+
+# access imported print
+nothing = Functions::print(Q)
+nothing = Functions::print(R)

--- a/src/test/scripts/functions/misc/Functions12.dml
+++ b/src/test/scripts/functions/misc/Functions12.dml
@@ -25,20 +25,30 @@ source("./src/test/scripts/functions/misc/FunctionsL2.dml") as Functions
 M1 = matrix("1 2 3 4", rows=2, cols=2)
 M2 = matrix("5 6 7 8", rows=2, cols=2)
 
-# access imported external function t
+# Use imported external function t
 now = Functions::t()
 print("Time is " + now)
 
-# built-in transpose accessible
+# Built-in transpose accessible since imported override
 result = t(M2)
-nothing = Functions::print(result)
+nothing = Functions::printMatrix(result)
 
-# access imported qr multiple return function
+# Use imported qr multiple return function
 [min, max] = Functions::qr(M1)
 
-# access built-in qr
+# Use built-in qr
 [Q, R] = qr(M2)
+nothing = Functions::printMatrix(Q)
+nothing = Functions::printMatrix(R)
 
-# access imported print
-nothing = Functions::print(Q)
-nothing = Functions::print(R)
+# Use local override before function definition
+[y, Z] = rand(2)
+print("rand is " + y + ", " + sum(Z))
+
+# Local function definition override of built-in rand returning matrix and scalar
+rand = function(int x) return (int y, matrix[double] Z)
+{
+    print("override rand")
+    y = x*2
+    Z = matrix(y, rows=4, cols=2)
+}

--- a/src/test/scripts/functions/misc/Functions12.pydml
+++ b/src/test/scripts/functions/misc/Functions12.pydml
@@ -25,20 +25,28 @@ source("./src/test/scripts/functions/misc/FunctionsL2.pydml") as Functions
 M1 = full("1 2 3 4", rows=2, cols=2)
 M2 = full("5 6 7 8", rows=2, cols=2)
 
-# access imported external function t
+# Use imported external function t
 now = Functions.t()
 print("Time is " + now)
 
-# built-in transpose accessible
+# Built-in transpose accessible since imported override
 result = t(M2)
-nothing = Functions.print(result)
+nothing = Functions.printMatrix(result)
 
-# access imported qr multiple return function
+# Use imported qr multiple return function
 [min, max] = Functions.qr(M1)
 
-# access built-in qr
+# Use built-in qr
 [Q, R] = qr(M2)
+nothing = Functions.printMatrix(Q)
+nothing = Functions.printMatrix(R)
 
-# access imported print
-nothing = Functions.print(Q)
-nothing = Functions.print(R)
+# Use local override before function definition
+[y, Z] = rand(2)
+print("rand is " + y + ", " + sum(Z))
+
+# Local function definition override of built-in rand returning matrix and scalar
+def rand(x: int) -> (y: int, Z: matrix[float]):
+    print("override rand")
+    y = x*2
+    Z = full(y, rows=4, cols=2)

--- a/src/test/scripts/functions/misc/Functions12.pydml
+++ b/src/test/scripts/functions/misc/Functions12.pydml
@@ -1,0 +1,44 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# Override specific built-in function definition types
+source("./src/test/scripts/functions/misc/FunctionsL2.pydml") as Functions
+
+M1 = full("1 2 3 4", rows=2, cols=2)
+M2 = full("5 6 7 8", rows=2, cols=2)
+
+# access imported external function t
+now = Functions.t()
+print("Time is " + now)
+
+# built-in transpose accessible
+result = t(M2)
+nothing = Functions.print(result)
+
+# access imported qr multiple return function
+[min, max] = Functions.qr(M1)
+
+# access built-in qr
+[Q, R] = qr(M2)
+
+# access imported print
+nothing = Functions.print(Q)
+nothing = Functions.print(R)

--- a/src/test/scripts/functions/misc/Functions13.dml
+++ b/src/test/scripts/functions/misc/Functions13.dml
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+min = function(integer i)
+{
+    print("min" + i)
+}
+
+write = function(String message) return ()
+{
+    print(message)
+}
+
+nothing = min(1)
+nothing = write("goodbye")
+
+# Report parse issue if attempt to redefine function in same file
+min = function(integer i)
+{
+    print("max" + i)
+}

--- a/src/test/scripts/functions/misc/Functions13.pydml
+++ b/src/test/scripts/functions/misc/Functions13.pydml
@@ -1,0 +1,33 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+def min(i: int):
+    print("min" + i)
+
+def save(message: str) -> ():
+    print(message)
+
+nothing = min(1)
+nothing = save("goodbye")
+
+# Report parse issue if attempt to redefine function in same file
+def min(i: int):
+    print("max" + i)

--- a/src/test/scripts/functions/misc/FunctionsL1.dml
+++ b/src/test/scripts/functions/misc/FunctionsL1.dml
@@ -33,6 +33,23 @@ sum = function(matrix[double] X) return (double total)
 
 min = function(matrix[double] X) return (double minimum)
 {
-    minimum = min(X)
+    MinRow = rowMins(X)
+    MinCol = colMins(MinRow)
+    minimum = as.scalar(MinCol[1,1])
     print("Minimum is " + minimum)
+}
+
+minMax = function(matrix[double] M) return (double minVal, double maxVal)
+{
+    # Access local overrides (defined before or after) instead of built-ins
+    minVal = min(M)
+    maxVal = max(M)
+}
+
+max = function(matrix[double] X) return (double maximum)
+{
+    MaxRow = rowMaxs(X)
+    MaxCol = colMaxs(MaxRow)
+    maximum = as.scalar(MaxCol[1,1])
+    print("Maximum is " + maximum)
 }

--- a/src/test/scripts/functions/misc/FunctionsL1.dml
+++ b/src/test/scripts/functions/misc/FunctionsL1.dml
@@ -1,0 +1,38 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+sum = function(matrix[double] X) return (double total)
+{
+    total = 0
+    for (i in 1:nrow(X))
+    {
+        for (j in 1:ncol(X))
+        {
+            total = total + as.scalar(X[i,j])
+        }
+    }
+    print("Override sum is " + total)
+}
+
+min = function(matrix[double] X) return (double minimum)
+{
+    minimum = min(X)
+    print("Minimum is " + minimum)
+}

--- a/src/test/scripts/functions/misc/FunctionsL1.pydml
+++ b/src/test/scripts/functions/misc/FunctionsL1.pydml
@@ -1,0 +1,30 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+def sum(X: matrix[float]) -> (total: float):
+    total = 0
+    for (i in 1:nrow(X)):
+        for (j in 1:ncol(X)):
+            total = total + scalar(X[i,j])
+    print("Override sum is " + total)
+
+def min(X: matrix[float]) -> (minimum: float):
+    minimum = min(X)
+    print("Minimum is " + minimum)

--- a/src/test/scripts/functions/misc/FunctionsL1.pydml
+++ b/src/test/scripts/functions/misc/FunctionsL1.pydml
@@ -20,11 +20,24 @@
 #-------------------------------------------------------------
 def sum(X: matrix[float]) -> (total: float):
     total = 0
-    for (i in 1:nrow(X)):
-        for (j in 1:ncol(X)):
+    for (i in 0:nrow(X)-1):
+        for (j in 0:ncol(X)-1):
             total = total + scalar(X[i,j])
     print("Override sum is " + total)
 
 def min(X: matrix[float]) -> (minimum: float):
-    minimum = min(X)
+    MinRow = rowMins(X)
+    MinCol = colMins(MinRow)
+    minimum = scalar(MinCol[0,0])
     print("Minimum is " + minimum)
+
+def minMax(M: matrix[float]) -> (minVal: float, maxVal: float):
+    # Access local overrides (defined before or after) instead of built-ins
+    minVal = min(M)
+    maxVal = max(M)
+
+def max(X: matrix[float]) -> (maximum: float):
+    MaxRow = rowMaxs(X)
+    MaxCol = colMaxs(MaxRow)
+    maximum = scalar(MaxCol[0,0])
+    print("Maximum is " + maximum)

--- a/src/test/scripts/functions/misc/FunctionsL2.dml
+++ b/src/test/scripts/functions/misc/FunctionsL2.dml
@@ -31,7 +31,7 @@ qr = function(matrix[double] M) return (double minVal, double maxVal) {
     print("Maximum is " + maxVal)
 }
 
-print = function(matrix[double] X) return ()
+printMatrix = function(matrix[double] X) return ()
 {
     for (i in 1:nrow(X))
     {

--- a/src/test/scripts/functions/misc/FunctionsL2.dml
+++ b/src/test/scripts/functions/misc/FunctionsL2.dml
@@ -1,0 +1,44 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# External function definition override (t built-in matrix transpose)
+t = externalFunction() return (double B) 
+    implemented in (classname="org.apache.sysml.udf.lib.TimeWrapper", exectype="mem")
+
+# Multiple return function definition override (qr built-in matrix QR decomposition)
+qr = function(matrix[double] M) return (double minVal, double maxVal) {
+    minVal = min(M)
+    maxVal = max(M)
+    print("Minimum is " + minVal)
+    print("Maximum is " + maxVal)
+}
+
+print = function(matrix[double] X) return ()
+{
+    for (i in 1:nrow(X))
+    {
+        for (j in 1:ncol(X))
+        {
+            xij = as.scalar(X[i,j])
+            print("[" + i + "," + j + "] " + xij)
+        }
+    }
+}

--- a/src/test/scripts/functions/misc/FunctionsL2.pydml
+++ b/src/test/scripts/functions/misc/FunctionsL2.pydml
@@ -1,0 +1,36 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# External function definition override (t built-in matrix transpose)
+defExternal t() -> (B: float) implemented in (classname="org.apache.sysml.udf.lib.TimeWrapper", exectype="mem")
+
+# Multiple return function definition override (qr built-in matrix QR decomposition)
+def qr(M: matrix[float]) -> (minVal: float, maxVal: float):
+    minVal = min(M)
+    maxVal = max(M)
+    print("Minimum is " + minVal)
+    print("Maximum is " + maxVal)
+
+def print(X: matrix[float]) -> ():
+    for (i in 1:nrow(X)):
+        for (j in 1:ncol(X)):
+            xij = scalar(X[i,j])
+            print("[" + i + "," + j + "] " + xij)

--- a/src/test/scripts/functions/misc/FunctionsL2.pydml
+++ b/src/test/scripts/functions/misc/FunctionsL2.pydml
@@ -29,8 +29,8 @@ def qr(M: matrix[float]) -> (minVal: float, maxVal: float):
     print("Minimum is " + minVal)
     print("Maximum is " + maxVal)
 
-def print(X: matrix[float]) -> ():
-    for (i in 1:nrow(X)):
-        for (j in 1:ncol(X)):
+def printMatrix(X: matrix[float]) -> ():
+    for (i in 0:nrow(X)-1):
+        for (j in 0:ncol(X)-1):
             xij = scalar(X[i,j])
             print("[" + i + "," + j + "] " + xij)


### PR DESCRIPTION
This patch adds support for overriding built-in functions.  The approach was to track new internal and external function definition names per script and skip built-in function call handling if the function name was also defined by user (or imported when converting pydml syntax).  Also added parse error detection/reporting if user attempts to define two functions with same name in same script.  Previously, the second definition would overwrite the first.