### PR TITLE
[SYSTEMML-676] Improve PyDML Slicing

### DIFF
--- a/src/main/java/org/apache/sysml/parser/pydml/Pydml.g4
+++ b/src/main/java/org/apache/sysml/parser/pydml/Pydml.g4
@@ -220,8 +220,8 @@ dataIdentifier returns [ org.apache.sysml.parser.common.ExpressionInfo dataInfo 
        // $dataInfo.expr = new org.apache.sysml.parser.DataIdentifier();
 } :
     // ------------------------------------------
-    // IndexedIdentifier
-    name=ID OPEN_BRACK (rowLower=expression (':' rowUpper=expression)?)? ',' (colLower=expression (':' colUpper=expression)?)? CLOSE_BRACK # IndexedExpression
+    // IndexedIdentifier -- allows implicit lower and upper bounds
+    name=ID OPEN_BRACK ( (rowLower=expression)? (rowImplicitSlice=':' (rowUpper=expression)?)? )? (',' (((colLower=expression)? (colImplicitSlice=':' (colUpper=expression)?)?)?)?)? CLOSE_BRACK # IndexedExpression
     // ------------------------------------------
     | ID                                            # SimpleDataIdentifierExpression
     | COMMANDLINE_NAMED_ID                          # CommandlineParamExpression

--- a/src/test/java/org/apache/sysml/test/integration/functions/indexing/PyDMLImplicitSlicingBounds.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/indexing/PyDMLImplicitSlicingBounds.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.test.integration.functions.indexing;
+
+import org.apache.sysml.runtime.matrix.data.MatrixValue.CellIndex;
+import org.apache.sysml.test.integration.AutomatedTestBase;
+import org.apache.sysml.test.integration.TestConfiguration;
+import org.apache.sysml.test.utils.TestUtils;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+/**
+ * Test the PyDML implicit slicing.
+ */
+public class PyDMLImplicitSlicingBounds extends AutomatedTestBase {
+
+    private static final String TEST_NAME1 = "RightImplicitRowLowerImplicitRowUpper";
+    private static final String TEST_NAME2 = "RightImplicitRowLowerImplicitRowUpperComma";
+    private static final String TEST_NAME3 = "RightImplicitRowColLowerImplicitRowColUpper";
+    private static final String TEST_NAME4 = "RightImplicitRowLowerImplicitColUpper";
+    private static final String TEST_NAME5 = "RightImplicitColLowerImplicitRowUpper";
+    private static final String TEST_NAME6 = "LeftImplicitRowLowerImplicitRowUpper";
+    private static final String TEST_NAME7 = "LeftImplicitRowLowerImplicitRowUpperComma";
+    private static final String TEST_NAME8 = "LeftImplicitRowColLowerImplicitRowColUpper";
+    private static final String TEST_NAME9 = "LeftImplicitRowLowerImplicitColUpper";
+    private static final String TEST_NAME10 = "LeftImplicitColLowerImplicitRowUpper";
+    private static final String TEST_DIR = "functions/indexing/";
+    private static final String TEST_CLASS_DIR =
+            TEST_DIR + PyDMLImplicitSlicingBounds.class.getSimpleName() + "/";
+    private static final String INPUT_NAME = "X";
+    private static final String OUTPUT_NAME_IMPLICIT = "X_implicit";
+    private static final String OUTPUT_NAME_EXPLICIT = "X_explicit";
+
+    private static final int rows = 123;
+    private static final int cols = 143;
+    private static final double sparsity = 0.7;
+    private static final double eps = Math.pow(10, -10);
+
+    @Override
+    public void setUp() {
+        TestUtils.clearAssertionInformation();
+        addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1));
+        addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2));
+        addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3));
+        addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4));
+        addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5));
+        addTestConfiguration(TEST_NAME6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6));
+        addTestConfiguration(TEST_NAME7, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME7));
+        addTestConfiguration(TEST_NAME8, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME8));
+        addTestConfiguration(TEST_NAME9, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME9));
+        addTestConfiguration(TEST_NAME10, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME10));
+    }
+
+    // Right indexing
+    @Test
+    public void testRightImplicitRowLowerImplicitRowUpper() {
+       testPyDMLImplicitSlicingBounds(TEST_NAME1);
+    }
+
+    @Test
+    public void testRightImplicitRowLowerImplicitRowUpperComma() {
+        testPyDMLImplicitSlicingBounds(TEST_NAME2);
+    }
+
+    @Test
+    public void testRightImplicitRowColLowerImplicitRowColUpper() {
+        testPyDMLImplicitSlicingBounds(TEST_NAME3);
+    }
+
+    @Test
+    public void testRightImplicitRowLowerImplicitColUpper() {
+        testPyDMLImplicitSlicingBounds(TEST_NAME4);
+    }
+
+    @Test
+    public void testRightImplicitColLowerImplicitRowUpper() {
+        testPyDMLImplicitSlicingBounds(TEST_NAME5);
+    }
+
+    // Left indexing
+    @Test
+    public void testLeftImplicitRowLowerImplicitRowUpper() {
+        testPyDMLImplicitSlicingBounds(TEST_NAME6);
+    }
+
+    @Test
+    public void testLeftImplicitRowLowerImplicitRowUpperComma() {
+        testPyDMLImplicitSlicingBounds(TEST_NAME7);
+    }
+
+    @Test
+    public void testLeftImplicitRowColLowerImplicitRowColUpper() {
+        testPyDMLImplicitSlicingBounds(TEST_NAME8);
+    }
+
+    @Test
+    public void testLeftImplicitRowLowerImplicitColUpper() {
+        testPyDMLImplicitSlicingBounds(TEST_NAME9);
+    }
+
+    @Test
+    public void testLeftImplicitColLowerImplicitRowUpper() {
+        testPyDMLImplicitSlicingBounds(TEST_NAME10);
+    }
+    /**
+     * Test the implicit bounds slicing in PyDML.
+     *
+     * @param testName The name of this test case.
+     */
+    private void testPyDMLImplicitSlicingBounds(String testName) {
+        // Create and load test configuration
+        getAndLoadTestConfiguration(testName);
+        String HOME = SCRIPT_DIR + TEST_DIR;
+        fullDMLScriptName = HOME + testName + ".pydml";
+        programArgs = new String[]{"-python", "-args",
+                input(INPUT_NAME), output(OUTPUT_NAME_IMPLICIT), output(OUTPUT_NAME_EXPLICIT)};
+
+        // Generate data
+        double[][] X = getRandomMatrix(rows, cols, -1, 1, sparsity, 7);
+        writeInputMatrixWithMTD(INPUT_NAME, X, true);
+
+        // Run PyDML script
+        runTest(true, false, null, -1);
+
+        // Compare output matrices
+        HashMap<CellIndex, Double> pydmlImplicit = readDMLMatrixFromHDFS(OUTPUT_NAME_IMPLICIT);
+        HashMap<CellIndex, Double> pydmlExplicit = readDMLMatrixFromHDFS(OUTPUT_NAME_EXPLICIT);
+        TestUtils.compareMatrices(pydmlImplicit, pydmlExplicit, eps, "Implicit", "Explicit");
+
+    }
+}

--- a/src/test/scripts/functions/indexing/LeftImplicitColLowerImplicitRowUpper.pydml
+++ b/src/test/scripts/functions/indexing/LeftImplicitColLowerImplicitRowUpper.pydml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = load($1)
+X_implicit = full(0, X.shape(0), X.shape(1))
+X_explicit = full(0, X.shape(0), X.shape(1))
+X_implicit[2:,:4] = X[2:X.shape(0),0:4]
+X_explicit[2:X.shape(0),0:4] = X[2:X.shape(0),0:4]
+save(X_implicit, $2)
+save(X_explicit, $3)

--- a/src/test/scripts/functions/indexing/LeftImplicitRowColLowerImplicitRowColUpper.pydml
+++ b/src/test/scripts/functions/indexing/LeftImplicitRowColLowerImplicitRowColUpper.pydml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = load($1)
+X_implicit = full(0, X.shape(0), X.shape(1))
+X_implicit[:,:] = X
+X_explicit = X
+save(X_implicit, $2)
+save(X_explicit, $3)

--- a/src/test/scripts/functions/indexing/LeftImplicitRowLowerImplicitColUpper.pydml
+++ b/src/test/scripts/functions/indexing/LeftImplicitRowLowerImplicitColUpper.pydml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = load($1)
+X_implicit = full(0, X.shape(0), X.shape(1))
+X_explicit = full(0, X.shape(0), X.shape(1))
+X_implicit[:2,1:] = X[0:2,1:X.shape(1)]
+X_explicit[0:2,1:X.shape(1)] = X[0:2,1:X.shape(1)]
+save(X_implicit, $2)
+save(X_explicit, $3)

--- a/src/test/scripts/functions/indexing/LeftImplicitRowLowerImplicitRowUpper.pydml
+++ b/src/test/scripts/functions/indexing/LeftImplicitRowLowerImplicitRowUpper.pydml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = load($1)
+X_implicit = full(0, X.shape(0), X.shape(1))
+X_implicit[:] = X
+X_explicit = X
+save(X_implicit, $2)
+save(X_explicit, $3)

--- a/src/test/scripts/functions/indexing/LeftImplicitRowLowerImplicitRowUpperComma.pydml
+++ b/src/test/scripts/functions/indexing/LeftImplicitRowLowerImplicitRowUpperComma.pydml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = load($1)
+X_implicit = full(0, X.shape(0), X.shape(1))
+X_implicit[:,] = X
+X_explicit = X
+save(X_implicit, $2)
+save(X_explicit, $3)

--- a/src/test/scripts/functions/indexing/RightImplicitColLowerImplicitRowUpper.pydml
+++ b/src/test/scripts/functions/indexing/RightImplicitColLowerImplicitRowUpper.pydml
@@ -1,0 +1,25 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = load($1)
+X_implicit = X[2:,:4]
+X_explicit = X[2:X.shape(0),0:4]
+save(X_implicit, $2)
+save(X_explicit, $3)

--- a/src/test/scripts/functions/indexing/RightImplicitRowColLowerImplicitRowColUpper.pydml
+++ b/src/test/scripts/functions/indexing/RightImplicitRowColLowerImplicitRowColUpper.pydml
@@ -1,0 +1,25 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = load($1)
+X_implicit = X[:,:]
+X_explicit = X
+save(X_implicit, $2)
+save(X_explicit, $3)

--- a/src/test/scripts/functions/indexing/RightImplicitRowLowerImplicitColUpper.pydml
+++ b/src/test/scripts/functions/indexing/RightImplicitRowLowerImplicitColUpper.pydml
@@ -1,0 +1,25 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = load($1)
+X_implicit = X[:2,1:]
+X_explicit = X[0:2,1:X.shape(1)]
+save(X_implicit, $2)
+save(X_explicit, $3)

--- a/src/test/scripts/functions/indexing/RightImplicitRowLowerImplicitRowUpper.pydml
+++ b/src/test/scripts/functions/indexing/RightImplicitRowLowerImplicitRowUpper.pydml
@@ -1,0 +1,25 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = load($1)
+X_implicit = X[:]
+X_explicit = X
+save(X_implicit, $2)
+save(X_explicit, $3)

--- a/src/test/scripts/functions/indexing/RightImplicitRowLowerImplicitRowUpperComma.pydml
+++ b/src/test/scripts/functions/indexing/RightImplicitRowLowerImplicitRowUpperComma.pydml
@@ -1,0 +1,25 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = load($1)
+X_implicit = X[:,]
+X_explicit = X
+save(X_implicit, $2)
+save(X_explicit, $3)


### PR DESCRIPTION
Currently, slicing correctly uses inclusive lower and exclusive upper bounds. However, a really useful piece of slicing syntax we are currently missing from PyDML is the ability to have implicit lower or upper bounds, i.e., `X[:3,]` should return all rows up to (but not including) 3. This means that the implicit lower bound is 0. Similarly, `X[2:,]` should return all rows starting at row 2 (0-based), which implies that the upper bound is equal to the number of rows of `X`.  We should update the grammar to allow these cases, row both row and column slicing.  More generally, `X[:,:]`, should also be valid, regardless if it is useful.

Example (PyDML):
```
N = 4
D = 3
X = matrix("[1 2 3; 4 5 6; 7 8 9; 10 11 12]")
X = X[:2,1:]  # slice with implicit lower row and upper column bounds

# print
for i in 0:nrow(X)-1:
  for j in 0:ncol(X)-1:
    print("X["+i+","+j+"]: " + scalar(X[i,j]))
```

```
X[0,0]: 2.0
X[0,1]: 3.0
X[1,0]: 5.0
X[1,1]: 6.0
```