### PR TITLE
Fix NegativeParForIncrTest case for unix

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/NegativeLoopIncrementsTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/NegativeLoopIncrementsTest.java
@@ -35,7 +35,7 @@ import org.apache.sysml.test.utils.TestUtils;
 public class NegativeLoopIncrementsTest extends AutomatedTestBase 
 {
 	private final static String TEST_NAME1 = "NegativeForIncrTest";
-	private final static String TEST_NAME2 = "NegativeParforIncrTest";
+	private final static String TEST_NAME2 = "NegativeParForIncrTest";
 	
 	private final static String TEST_DIR = "functions/misc/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + NegativeLoopIncrementsTest.class.getSimpleName() + "/";


### PR DESCRIPTION
Change "NegativeParforIncrTest" to "NegativeParForIncrTest" so NegativeParForIncrTest.dml and NegativeParForIncrTest.R are found on Linux.