### PR TITLE
[SYSTEMML-296] Add elif (else if) to PyDML

### DIFF
--- a/src/main/java/org/apache/sysml/parser/pydml/Pydml.g4
+++ b/src/main/java/org/apache/sysml/parser/pydml/Pydml.g4
@@ -178,7 +178,7 @@ statement returns [ org.apache.sysml.parser.common.StatementInfo info ]
     | targetList=dataIdentifier '=' source=expression NEWLINE   # AssignmentStatement
     // IfStatement
     // | 'if' OPEN_PAREN predicate=expression CLOSE_PAREN (ifBody+=statement ';'* |  NEWLINE INDENT (ifBody+=statement)+  DEDENT )  ('else' (elseBody+=statement ';'* | '{' (elseBody+=statement ';'*)*  '}'))?  # IfStatement
-    | 'if' (OPEN_PAREN predicate=expression CLOSE_PAREN | predicate=expression) ':'  NEWLINE INDENT (ifBody+=statement)+  DEDENT   ('else'  ':'  NEWLINE INDENT (elseBody+=statement)+  DEDENT )?  # IfStatement
+    | 'if' (OPEN_PAREN predicate=expression CLOSE_PAREN | predicate=expression) ':'  NEWLINE INDENT (ifBody+=statement)+  DEDENT (elifBranches += elifBranch)* ('else'  ':'  NEWLINE INDENT (elseBody+=statement)+  DEDENT )?  # IfStatement
     // ------------------------------------------
     // ForStatement & ParForStatement
     | 'for' (OPEN_PAREN iterVar=ID 'in' iterPred=iterablePredicate (',' parForParams+=strictParameterizedExpression)* CLOSE_PAREN |  iterVar=ID 'in' iterPred=iterablePredicate (',' parForParams+=strictParameterizedExpression)* ) ':'  NEWLINE INDENT (body+=statement)+  DEDENT  # ForStatement
@@ -187,6 +187,14 @@ statement returns [ org.apache.sysml.parser.common.StatementInfo info ]
     | 'while' ( OPEN_PAREN predicate=expression CLOSE_PAREN | predicate=expression ) ':' NEWLINE INDENT (body+=statement)+  DEDENT  # WhileStatement
     // ------------------------------------------
     | NEWLINE #IgnoreNewLine
+;
+
+elifBranch returns [ org.apache.sysml.parser.common.StatementInfo info ]
+  @init {
+        // This actions occurs regardless of how many alternatives in this rule
+        $info = new org.apache.sysml.parser.common.StatementInfo();
+  } :
+     'elif' (OPEN_PAREN predicate=expression CLOSE_PAREN | predicate=expression) ':'  NEWLINE INDENT (elifBody+=statement)+  DEDENT
 ;
 
 iterablePredicate returns [ org.apache.sysml.parser.common.ExpressionInfo info ]

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/IfTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/IfTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.test.integration.functions.misc;
+
+
+import org.apache.sysml.api.DMLException;
+import org.apache.sysml.test.integration.AutomatedTestBase;
+import org.apache.sysml.test.integration.TestConfiguration;
+import org.apache.sysml.test.integration.functions.append.StringAppendTest;
+import org.junit.Test;
+
+public class IfTest extends AutomatedTestBase
+{
+
+    private final static String TEST_DIR = "functions/misc/";
+    private final static String TEST_NAME1 = "IfTest";
+    private final static String TEST_NAME2 = "IfTest2";
+    private final static String TEST_NAME3 = "IfTest3";
+    private final static String TEST_NAME4 = "IfTest4";
+    private final static String TEST_NAME5 = "IfTest5";
+    private final static String TEST_NAME6 = "IfTest6";
+    private final static String TEST_CLASS_DIR = TEST_DIR + IfTest.class.getSimpleName() + "/";
+
+    @Override
+    public void setUp()
+    {
+        addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {}));
+        addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {}));
+        addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] {}));
+        addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[] {}));
+        addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5, new String[] {}));
+        addTestConfiguration(TEST_NAME6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6, new String[] {}));
+    }
+
+    @Test
+    public void testIf() { runTest(TEST_NAME1, 1); }
+
+    @Test
+    public void testIfElse() {
+        runTest(TEST_NAME2, 1);
+        runTest(TEST_NAME2, 2);
+    }
+
+    @Test
+    public void testIfElif() {
+        runTest(TEST_NAME3, 1);
+        runTest(TEST_NAME3, 2);
+    }
+
+    @Test
+    public void testIfElifElse() {
+        runTest(TEST_NAME4, 1);
+        runTest(TEST_NAME4, 2);
+        runTest(TEST_NAME4, 3);
+    }
+
+    @Test
+    public void testIfElifElif() {
+        runTest(TEST_NAME5, 1);
+        runTest(TEST_NAME5, 2);
+        runTest(TEST_NAME5, 3);
+    }
+
+    @Test
+    public void testIfElifElifElse() {
+        runTest(TEST_NAME6, 1);
+        runTest(TEST_NAME6, 2);
+        runTest(TEST_NAME6, 3);
+        runTest(TEST_NAME6, 4);
+    }
+
+    private void runTest( String testName, int val )
+    {
+        TestConfiguration config = getTestConfiguration(testName);
+        loadTestConfiguration(config);
+
+        String HOME = SCRIPT_DIR + TEST_DIR;
+        fullDMLScriptName = HOME + testName + ".pydml";
+        programArgs = new String[]{"-python","-nvargs","val=" + Integer.toString(val)};
+
+        if (val == 1)
+            setExpectedStdOut("A");
+        else if (val == 2)
+            setExpectedStdOut("B");
+        else if (val == 3)
+            setExpectedStdOut("C");
+        else
+            setExpectedStdOut("D");
+
+        runTest(true, false, null, -1);
+    }
+}

--- a/src/test/scripts/functions/misc/IfTest.pydml
+++ b/src/test/scripts/functions/misc/IfTest.pydml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+def ifTest(x: int):
+    if (x == 1):
+       print('A')
+
+z = ifTest($val)

--- a/src/test/scripts/functions/misc/IfTest2.pydml
+++ b/src/test/scripts/functions/misc/IfTest2.pydml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+def ifTest(x: int):
+    if (x == 1):
+       print('A')
+    else:
+       print('B')
+
+z = ifTest($val)

--- a/src/test/scripts/functions/misc/IfTest3.pydml
+++ b/src/test/scripts/functions/misc/IfTest3.pydml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+def ifTest(x: int):
+    if (x == 1):
+       print('A')
+    elif (x == 2):
+       print('B')
+
+z = ifTest($val)

--- a/src/test/scripts/functions/misc/IfTest4.pydml
+++ b/src/test/scripts/functions/misc/IfTest4.pydml
@@ -1,0 +1,30 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+def ifTest(x: int):
+    if (x == 1):
+       print('A')
+    elif (x == 2):
+       print('B')
+    else :
+       print('C')
+
+z = ifTest($val)

--- a/src/test/scripts/functions/misc/IfTest5.pydml
+++ b/src/test/scripts/functions/misc/IfTest5.pydml
@@ -1,0 +1,30 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+def ifTest(x: int):
+    if (x == 1):
+       print('A')
+    elif (x == 2):
+       print('B')
+    elif (x == 3):
+       print('C')
+
+z = ifTest($val)

--- a/src/test/scripts/functions/misc/IfTest6.pydml
+++ b/src/test/scripts/functions/misc/IfTest6.pydml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+def ifTest(x: int):
+    if (x == 1):
+       print('A')
+    elif (x == 2):
+       print('B')
+    elif (x == 3):
+       print('C')
+    else :
+       print('D')
+
+z = ifTest($val)

--- a/src/test_suites/java/org/apache/sysml/test/integration/functions/misc/ZPackageSuite.java
+++ b/src/test_suites/java/org/apache/sysml/test/integration/functions/misc/ZPackageSuite.java
@@ -31,6 +31,7 @@ import org.junit.runners.Suite;
 	DataTypeChangeTest.class,
 	FunctionInliningTest.class,
 	FunctionNamespaceTest.class,
+	IfTest.class,
 	InvalidFunctionAssignmentTest.class,
 	InvalidFunctionSignatureTest.class,
 	IPALiteralReplacementTest.class,


### PR DESCRIPTION
This patch adds "elif" to PyDML for addressing the [SYSTEMML-296](https://issues.apache.org/jira/browse/SYSTEMML-296). The "elif" statements are used as follows:
```
x = 6
if (x == 1):
    print('A')
elif (x == 2):
    print('B')
elif (x == 3):
    print('C')
elif (x == 4):
    print('D')
elif (x == 5):
    print('E')
else:
    print('F')
```

Please review @deroneriksson .