### PR TITLE
[SYSTEMML-670] Fix PyDML built-in functions random and cdf

### DIFF
--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -742,9 +742,10 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 				functionName = "ncol";
 			}
 		}
-		else if(namespace.equals(DMLProgram.DEFAULT_NAMESPACE) && functionName.equals("random.normal")) {
+		else if(namespace.equals("random") && functionName.equals("normal")) {
 			if(paramExpression.size() != 3) {
-				notifyErrorListeners("The builtin function \'" + functionName + "\' accepts exactly 3 arguments (number of rows, number of columns, sparsity)", fnName);
+				String qualifiedName = namespace + namespaceResolutionOp() + functionName;
+				notifyErrorListeners("The builtin function \'" + qualifiedName + "\' accepts exactly 3 arguments (number of rows, number of columns, sparsity)", fnName);
 				return null;
 			}
 			paramExpression.get(0).setName("rows");
@@ -754,9 +755,10 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			functionName = "rand";
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
-		else if(namespace.equals(DMLProgram.DEFAULT_NAMESPACE) && functionName.equals("random.uniform")) {
+		else if(namespace.equals("random") && functionName.equals("uniform")) {
 			if(paramExpression.size() != 5) {
-				notifyErrorListeners("The builtin function \'" + functionName + "\' accepts exactly 5 arguments (number of rows, number of columns, sparsity, min, max)", fnName);
+				String qualifiedName = namespace + namespaceResolutionOp() + functionName;
+				notifyErrorListeners("The builtin function \'" + qualifiedName + "\' accepts exactly 5 arguments (number of rows, number of columns, sparsity, min, max)", fnName);
 				return null;
 			}
 			paramExpression.get(0).setName("rows");
@@ -908,58 +910,63 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			functionName = "seq";
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
-		else if(namespace.equals(DMLProgram.DEFAULT_NAMESPACE) && functionName.equals("norm.cdf")) {
+		else if(namespace.equals("norm") && functionName.equals("cdf")) {
 			if(paramExpression.size() != 3) {
-				notifyErrorListeners("The builtin function \'" + functionName + "\' accepts exactly 3 arguments (target, mean, sd)", fnName);
+				String qualifiedName = namespace + namespaceResolutionOp() + functionName;
+				notifyErrorListeners("The builtin function \'" + qualifiedName + "\' accepts exactly 3 arguments (target, mean, sd)", fnName);
 				return null;
 			}
-			functionName = "cumulativeProbability";
+			functionName = "cdf";
 			paramExpression.get(0).setName("target");
 			paramExpression.get(1).setName("mean");
 			paramExpression.get(2).setName("sd");
 			paramExpression.add(new ParameterExpression("dist", new StringIdentifier("normal", fileName, line, col, line, col)));
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
-		else if(namespace.equals(DMLProgram.DEFAULT_NAMESPACE) && functionName.equals("expon.cdf")) {
+		else if(namespace.equals("expon") && functionName.equals("cdf")) {
 			if(paramExpression.size() != 2) {
-				notifyErrorListeners("The builtin function \'" + functionName + "\' accepts exactly 2 arguments (target, mean)", fnName);
+				String qualifiedName = namespace + namespaceResolutionOp() + functionName;
+				notifyErrorListeners("The builtin function \'" + qualifiedName + "\' accepts exactly 2 arguments (target, mean)", fnName);
 				return null;
 			}
-			functionName = "cumulativeProbability";
+			functionName = "cdf";
 			paramExpression.get(0).setName("target");
 			paramExpression.get(1).setName("mean");
 			paramExpression.add(new ParameterExpression("dist", new StringIdentifier("exp", fileName, line, col, line, col)));
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
-		else if(namespace.equals(DMLProgram.DEFAULT_NAMESPACE) && functionName.equals("chi.cdf")) {
+		else if(namespace.equals("chi") && functionName.equals("cdf")) {
 			if(paramExpression.size() != 2) {
-				notifyErrorListeners("The builtin function \'" + functionName + "\' accepts exactly 2 arguments (target, df)", fnName);
+				String qualifiedName = namespace + namespaceResolutionOp() + functionName;
+				notifyErrorListeners("The builtin function \'" + qualifiedName + "\' accepts exactly 2 arguments (target, df)", fnName);
 				return null;
 			}
-			functionName = "cumulativeProbability";
+			functionName = "cdf";
 			paramExpression.get(0).setName("target");
 			paramExpression.get(1).setName("df");
 			paramExpression.add(new ParameterExpression("dist", new StringIdentifier("chisq", fileName, line, col, line, col)));
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
-		else if(namespace.equals(DMLProgram.DEFAULT_NAMESPACE) && functionName.equals("f.cdf")) {
+		else if(namespace.equals("f") && functionName.equals("cdf")) {
 			if(paramExpression.size() != 3) {
-				notifyErrorListeners("The builtin function \'" + functionName + "\' accepts exactly 3 arguments (target, df1, df2)", fnName);
+				String qualifiedName = namespace + namespaceResolutionOp() + functionName;
+				notifyErrorListeners("The builtin function \'" + qualifiedName + "\' accepts exactly 3 arguments (target, df1, df2)", fnName);
 				return null;
 			}
-			functionName = "cumulativeProbability";
+			functionName = "cdf";
 			paramExpression.get(0).setName("target");
 			paramExpression.get(1).setName("df1");
 			paramExpression.get(2).setName("df2");
 			paramExpression.add(new ParameterExpression("dist", new StringIdentifier("f", fileName, line, col, line, col)));
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
-		else if(namespace.equals(DMLProgram.DEFAULT_NAMESPACE) && functionName.equals("t.cdf")) {
+		else if(namespace.equals("t") && functionName.equals("cdf")) {
 			if(paramExpression.size() != 2) {
-				notifyErrorListeners("The builtin function \'" + functionName + "\' accepts exactly 2 arguments (target, df)", fnName);
+				String qualifiedName = namespace + namespaceResolutionOp() + functionName;
+				notifyErrorListeners("The builtin function \'" + qualifiedName + "\' accepts exactly 2 arguments (target, df)", fnName);
 				return null;
 			}
-			functionName = "cumulativeProbability";
+			functionName = "cdf";
 			paramExpression.get(0).setName("target");
 			paramExpression.get(1).setName("df");
 			paramExpression.add(new ParameterExpression("dist", new StringIdentifier("t", fileName, line, col, line, col)));

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionNamespaceTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/FunctionNamespaceTest.java
@@ -47,6 +47,7 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	private final static String TEST_NAME11 = "Functions11";
 	private final static String TEST_NAME12 = "Functions12";
 	private final static String TEST_NAME13 = "Functions13";
+	private final static String TEST_NAME14 = "Functions14";
 	private final static String TEST_DIR = "functions/misc/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FunctionNamespaceTest.class.getSimpleName() + "/";
 	
@@ -71,6 +72,7 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME11, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME11)); 
 		addTestConfiguration(TEST_NAME12, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME12)); 
 		addTestConfiguration(TEST_NAME13, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME13)); 
+		addTestConfiguration(TEST_NAME14, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME14)); 
 	}
 	
 	@Test
@@ -169,6 +171,12 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	}
 	
 	@Test
+	public void testFunctionRandomCDF() 
+	{
+		runFunctionNamespaceTest(TEST_NAME14, ScriptType.DML);
+	}
+	
+	@Test
 	public void testPyFunctionDefaultNS() 
 	{
 		runFunctionNamespaceTest(TEST_NAME0, ScriptType.PYDML);
@@ -262,6 +270,12 @@ public class FunctionNamespaceTest extends AutomatedTestBase
 	public void testPyFunctionErrorOverride() 
 	{
 		runFunctionNamespaceTest(TEST_NAME13, ScriptType.PYDML);
+	}
+	
+	@Test
+	public void testPyFunctionRandomCDF() 
+	{
+		runFunctionNamespaceTest(TEST_NAME14, ScriptType.PYDML);
 	}
 
 	private void runFunctionNamespaceTest(String TEST_NAME, ScriptType scriptType)

--- a/src/test/scripts/functions/misc/Functions14.dml
+++ b/src/test/scripts/functions/misc/Functions14.dml
@@ -1,0 +1,43 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+r = 4
+c = 3
+X = rand(rows=r, cols=c, sparsity=1, pdf="normal")
+print("sum of rand normal matrix is " + sum(X))
+
+Y = rand(rows=r, cols=c, sparsity=1, min=0, max=1, pdf="uniform")
+print("avg of rand uniform matrix is " + avg(Y))
+
+p = cdf(dist="normal", target=0.4, mean=0, sd=1)
+print("normal cdf is " + p)
+
+p = cdf(dist="exp", target=0.7, rate=1.0)
+print("exp cdf is " + p)
+
+p = cdf(dist="chisq", target=0.3, df=5)
+print("chisq cdf is " + p)
+
+p = cdf(dist="f", target=2, df1=100, df2=200)
+print("f cdf is " + p)
+
+p = cdf(dist="t", target=1, df=100)
+print("t cdf is " + p)

--- a/src/test/scripts/functions/misc/Functions14.pydml
+++ b/src/test/scripts/functions/misc/Functions14.pydml
@@ -1,0 +1,43 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+r = 4
+c = 3
+X = random.normal(r, c, 1)
+print("sum of random.normal matrix is " + sum(X))
+
+Y = random.uniform(r, c, 1, 0, 1)
+print("avg of random.uniform matrix is " + avg(Y))
+
+p = norm.cdf(0.4, 0, 1)
+print("norm.cdf is " + p)
+
+p = expon.cdf(0.7, 1.0)
+print("expon.cdf is " + p)
+
+p = chi.cdf(0.3, 5)
+print("chi.cdf is " + p)
+
+p = f.cdf(2, 100, 200)
+print("f.cdf is " + p)
+
+p = t.cdf(1, 100)
+print("t.cdf is " + p)


### PR DESCRIPTION
This patch fixes parsing of PyDML built-in functions random.normal, random.uniform, norm.cdf, expon.cdf, chi.cdf, f.cdf, and t.cdf.  Also added test script to invoke each function to verify parsing issue no longer occurs for PyDML.