### PR TITLE
[SYSTEMML-656] Fix scalar input boolean addition test

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/functions/jmlc/JMLCInputOutputTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/jmlc/JMLCInputOutputTest.java
@@ -76,23 +76,21 @@ public class JMLCInputOutputTest extends AutomatedTestBase {
 		conn.close();
 	}
 
-	// See: https://issues.apache.org/jira/browse/SYSTEMML-656
-	// @Test
-	// public void testScalarInputBoolean() throws IOException, DMLException {
-	// Connection conn = new Connection();
-	// String str = conn.readScript(baseDirectory + File.separator +
-	// "scalar-input.dml");
-	// PreparedScript script = conn.prepareScript(str, new String[] {
-	// "inScalar1", "inScalar2" }, new String[] {},
-	// false);
-	// boolean inScalar1 = true;
-	// boolean inScalar2 = true;
-	// script.setScalar("inScalar1", inScalar1);
-	// script.setScalar("inScalar2", inScalar2);
-	//
-	// setExpectedStdOut("total:TRUE");
-	// script.executeScript();
-	// }
+	@Test
+	public void testScalarInputBoolean() throws IOException, DMLException {
+		Connection conn = new Connection();
+		String str = conn.readScript(baseDirectory + File.separator + "scalar-input.dml");
+		PreparedScript script = conn.prepareScript(str, new String[] { "inScalar1", "inScalar2" }, new String[] {},
+				false);
+		boolean inScalar1 = true;
+		boolean inScalar2 = true;
+		script.setScalar("inScalar1", inScalar1);
+		script.setScalar("inScalar2", inScalar2);
+
+		setExpectedStdOut("total:2.0");
+		script.executeScript();
+		conn.close();
+	}
 
 	@Test
 	public void testScalarInputLong() throws IOException, DMLException {

--- a/src/test_suites/java/org/apache/sysml/test/integration/functions/jmlc/ZPackageSuite.java
+++ b/src/test_suites/java/org/apache/sysml/test/integration/functions/jmlc/ZPackageSuite.java
@@ -33,6 +33,7 @@ import org.junit.runners.Suite;
 	FrameLeftIndexingTest.class,
 	FrameReadMetaTest.class,
 	FrameTransformTest.class,
+	JMLCInputOutputTest.class,
 	ReuseModelVariablesTest.class,
 	SystemTMulticlassSVMScoreTest.class
 })


### PR DESCRIPTION
Uncomment scalar input boolean addition test and set result to be "2.0" (R behavior) rather than "TRUE".