### PR TITLE
[SYSTEMML-629] source statement not resolve absolute paths

### DIFF
--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -390,8 +390,12 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 			filePath = filePath.substring(1, filePath.length()-1);
 		}
 
-		//concatenate working directory to filepath
-		filePath = _workingDir + File.separator + filePath;
+		File file = new File(filePath);
+		if (!file.isAbsolute()) {
+			//concatenate working directory to filepath
+			filePath = _workingDir + File.separator + filePath;
+		}
+
 		validateNamespace(namespace, filePath, ctx);
 		String scriptID = DMLProgram.constructFunctionKey(namespace, filePath);
 

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -507,8 +507,11 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			filePath = filePath.substring(1, filePath.length()-1);
 		}
 
-		//concatenate working directory to filepath
-		filePath = _workingDir + File.separator + filePath;
+		File file = new File(filePath);
+		if (!file.isAbsolute()) {
+			//concatenate working directory to filepath
+			filePath = _workingDir + File.separator + filePath;
+		}
 		validateNamespace(namespace, filePath, ctx);
 		String scriptID = DMLProgram.constructFunctionKey(namespace, filePath);
 


### PR DESCRIPTION
This patch make some minor changes to dml and pydml parser for addressing the issue in [JIRA](https://issues.apache.org/jira/browse/SYSTEMML-626). Please review.