### PR TITLE
[WIP] Initial implementation of hop_rewrite explain

### DIFF
--- a/src/main/java/org/apache/sysml/api/DMLScript.java
+++ b/src/main/java/org/apache/sysml/api/DMLScript.java
@@ -125,7 +125,7 @@ public class DMLScript
 			//+ "   -debug: <flags> (optional) run in debug mode\n"
 			//+ "			Optional <flags> that is supported for this mode is optimize=(on|off)\n"
 			+ "   -exec: <mode> (optional) execution mode (hadoop, singlenode, [hybrid], hybrid_spark)\n"
-			+ "   -explain: <type> (optional) explain plan (hops, [runtime], recompile_hops, recompile_runtime)\n"
+			+ "   -explain: <type> (optional) explain plan (hops, hops_rewrite, [runtime], recompile_hops, recompile_runtime)\n"
 			+ "   -stats: (optional) monitor and report caching/recompilation statistics\n"
 			+ "   -clean: (optional) cleanup all SystemML working directories (FS, DFS).\n"
 			+ "         All other flags are ignored in this mode. \n"
@@ -591,6 +591,9 @@ public class DMLScript
 		dmlt.liveVariableAnalysis(prog);			
 		dmlt.validateParseTree(prog);
 		dmlt.constructHops(prog);
+		
+		if(EXPLAIN == ExplainType.HOPS_REWRITE)
+			LOG.info(Explain.explain(prog, null, EXPLAIN));
 		
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("\n********************** HOPS DAG (Before Rewrite) *******************");

--- a/src/main/java/org/apache/sysml/hops/recompile/Recompiler.java
+++ b/src/main/java/org/apache/sysml/hops/recompile/Recompiler.java
@@ -219,7 +219,7 @@ public class Recompiler
 			newInst = ProgramConverter.createDeepCopyInstructionSet(newInst, tid, -1, null, null, null, false, false);
 		
 		// explain recompiled hops / instructions
-		if( DMLScript.EXPLAIN == ExplainType.RECOMPILE_HOPS ){
+		if( DMLScript.EXPLAIN == ExplainType.RECOMPILE_HOPS  || DMLScript.EXPLAIN == ExplainType.HOPS_REWRITE){
 			LOG.info("EXPLAIN RECOMPILE \nGENERIC (lines "+sb.getBeginLine()+"-"+sb.getEndLine()+"):\n" + 
 		    Explain.explainHops(hops, 1));
 		}
@@ -308,7 +308,7 @@ public class Recompiler
 			newInst = ProgramConverter.createDeepCopyInstructionSet(newInst, tid, -1, null, null, null, false, false);
 		
 		// explain recompiled instructions
-		if( DMLScript.EXPLAIN == ExplainType.RECOMPILE_HOPS )
+		if( DMLScript.EXPLAIN == ExplainType.RECOMPILE_HOPS || DMLScript.EXPLAIN == ExplainType.HOPS_REWRITE)
 			LOG.info("EXPLAIN RECOMPILE \nPRED (line "+hops.getBeginLine()+"):\n" + Explain.explain(hops,1));
 		if( DMLScript.EXPLAIN == ExplainType.RECOMPILE_RUNTIME )
 			LOG.info("EXPLAIN RECOMPILE \nPRED (line "+hops.getBeginLine()+"):\n" + Explain.explain(newInst,1));
@@ -461,7 +461,7 @@ public class Recompiler
 		}
 		
 		// explain recompiled hops / instructions
-		if( DMLScript.EXPLAIN == ExplainType.RECOMPILE_HOPS ){
+		if( DMLScript.EXPLAIN == ExplainType.RECOMPILE_HOPS  || DMLScript.EXPLAIN == ExplainType.HOPS_REWRITE ){
 			LOG.info("EXPLAIN RECOMPILE \nGENERIC (lines "+sb.getBeginLine()+"-"+sb.getEndLine()+"):\n" + 
 		    Explain.explainHops(hops, 1));
 		}
@@ -507,7 +507,7 @@ public class Recompiler
 		}
 
 		// explain recompiled instructions
-		if( DMLScript.EXPLAIN == ExplainType.RECOMPILE_HOPS )
+		if( DMLScript.EXPLAIN == ExplainType.RECOMPILE_HOPS  || DMLScript.EXPLAIN == ExplainType.HOPS_REWRITE )
 			LOG.info("EXPLAIN RECOMPILE \nPRED (line "+hops.getBeginLine()+"):\n" + Explain.explain(hops,1));
 		if( DMLScript.EXPLAIN == ExplainType.RECOMPILE_RUNTIME )
 			LOG.info("EXPLAIN RECOMPILE \nPRED (line "+hops.getBeginLine()+"):\n" + Explain.explain(newInst,1));

--- a/src/main/java/org/apache/sysml/utils/Explain.java
+++ b/src/main/java/org/apache/sysml/utils/Explain.java
@@ -83,7 +83,8 @@ public class Explain
 		HOPS,     // explain program and hops
 		RUNTIME,  // explain runtime program (default)
 		RECOMPILE_HOPS, // explain hops, incl recompile
-		RECOMPILE_RUNTIME, // explain runtime program, incl recompile 
+		RECOMPILE_RUNTIME, // explain runtime program, incl recompile
+		HOPS_REWRITE		// explain program and hops along with rewrites
 	};
 	
 	public static class ExplainCounts {
@@ -208,8 +209,9 @@ public class Explain
 		//dispatch to individual explain utils
 		switch( type ) {
 			//explain hops with stats
+			case HOPS_REWRITE:
 			case HOPS:     	
-			case RECOMPILE_HOPS:	
+			case RECOMPILE_HOPS:
 				return explain(prog);
 			//explain runtime program	
 			case RUNTIME:  
@@ -523,6 +525,8 @@ public class Explain
 		{
 			if( arg.equalsIgnoreCase("hops") )
 				ret = ExplainType.HOPS;
+			else if( arg.equalsIgnoreCase("hops_rewrite") )
+				ret = ExplainType.HOPS_REWRITE;
 			else if( arg.equalsIgnoreCase("runtime") )
 				ret = ExplainType.RUNTIME;
 			else if( arg.equalsIgnoreCase("recompile_hops") )
@@ -531,7 +535,7 @@ public class Explain
 				ret = ExplainType.RECOMPILE_RUNTIME;
 			else 
 				throw new DMLException("Failed to parse explain type: "+arg+" " +
-						               "(valid types: hops, runtime, recompile_hops, recompile_runtime).");
+						               "(valid types: hops, hops_rewrite, runtime, recompile_hops, recompile_runtime).");
 		}
 		
 		return ret;


### PR DESCRIPTION
This commit adds functionality to print rewrites that have been applied
to HOPs in intuitive fashion. Since I wanted to get feedback, I only
implemented this for static algebraic simplification. 

Example usage: Let's assume that test.dml contains:
X = matrix("1 2 3 4", rows=2, cols=2)
X = -(-X)
print(sum(X))

Then invoking `java -jar
systemml-0.11.0-incubating-SNAPSHOT-standalone.jar -f test.dml -explain
hops_rewrite` will output:
```bash

PROGRAM
--MAIN PROGRAM
----GENERIC (lines 1-4) [recompile=false]
------(9) dg(sinit) [2,2,-1,-1,-1] [-,0,- -> 0MB]
------(11) b(*) (9) [2,2,-1,-1,-1] [0,0,- -> 0MB]
------(13) b(*) (11) [2,2,-1,-1,-1] [0,0,- -> 0MB]
------(14) ua(+RC) (13) [0,0,0,0,-1] [0,0,- -> 0MB]
------(15) u(print) (14) [-1,-1,-1,-1,-1] [0,0,- -> 0MB]

hops_rewrite: X * -1 -> -X where X = (11) (line 3)
hops_rewrite: X * -1 -> -X where X = (9) (line 3)
hops_rewrite: -(-X) -> X where X = (9) (line 1)
16/05/31 14:57:02 INFO api.DMLScript: EXPLAIN (HOPS_REWRITE):
# Memory Budget local/remote = 2549MB/140MB/140MB
# Degree of Parallelism (vcores) local/remote = 8/1/1
PROGRAM
--MAIN PROGRAM
----GENERIC (lines 1-4) [recompile=false]
------(9) dg(sinit) [2,2,1000,1000,-1] [0,0,0 -> 0MB], CP
------(14) ua(+RC) (9) [0,0,-1,-1,-1] [0,0,0 -> 0MB], CP
------(15) u(print) (14) [-1,-1,-1,-1,-1] [0,0,0 -> 0MB]
```