### PR TITLE
[SYSTEMML-698] Remove Guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -806,13 +806,6 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- Adding Gauva version 14.0.1 to workaround conflict between spark and hadoop dependency -->
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>14.0.1</version>
-		</dependency>
-
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>

--- a/src/assembly/distrib/LICENSE
+++ b/src/assembly/distrib/LICENSE
@@ -204,7 +204,6 @@
 
 The following compile-scope dependencies come under the Apache Software License 2.0.
 
-Guava: Google Core Libraries for Java (http://code.google.com/p/guava-libraries/guava) com.google.guava:guava:14.0.1
 Apache Wink :: JSON4J (http://www.apache.org/wink/wink-json4j/) org.apache.wink:wink-json4j:1.4
 
 ===============================================================================

--- a/src/assembly/inmemory/LICENSE
+++ b/src/assembly/inmemory/LICENSE
@@ -215,7 +215,6 @@ org.apache.hadoop:hadoop-common:2.4.1
 org.apache.hadoop:hadoop-mapreduce-client-core:2.4.1
 
 Compile-scope dependencies:
-com.google.guava:guava:14.0.1
 org.apache.wink:wink-json4j:1.4
 
 ===============================================================================

--- a/src/assembly/jar/LICENSE
+++ b/src/assembly/jar/LICENSE
@@ -204,7 +204,6 @@
 
 The following compile-scope dependencies come under the Apache Software License 2.0.
 
-Guava: Google Core Libraries for Java (http://code.google.com/p/guava-libraries/guava) com.google.guava:guava:14.0.1
 Apache Wink :: JSON4J (http://www.apache.org/wink/wink-json4j/) org.apache.wink:wink-json4j:1.4
 
 ===============================================================================

--- a/src/assembly/standalone-jar/LICENSE
+++ b/src/assembly/standalone-jar/LICENSE
@@ -232,7 +232,6 @@ org.codehaus.jackson:jackson-core-asl:1.8.8
 org.codehaus.jackson:jackson-mapper-asl:1.8.8
 
 Compile-scope dependencies:
-com.google.guava:guava:14.0.1
 org.apache.wink:wink-json4j:1.4
 
 ===============================================================================

--- a/src/assembly/standalone.xml
+++ b/src/assembly/standalone.xml
@@ -109,7 +109,6 @@
 				<!-- Exclude compile-scoped dependencies since they are in main artifact jar -->
 				<exclude>*:antlr4-annotations*</exclude>
 				<exclude>*:antlr4-runtime*</exclude>
-				<exclude>*:guava*</exclude>
 				<exclude>*:org.abego.treelayout.core*</exclude>
 				<exclude>*:wink-json4j*</exclude>
 			</excludes>

--- a/src/main/java/org/apache/sysml/hops/globalopt/InterestingProperties.java
+++ b/src/main/java/org/apache/sysml/hops/globalopt/InterestingProperties.java
@@ -19,7 +19,7 @@
 
 package org.apache.sysml.hops.globalopt;
 
-import com.google.common.base.Objects;
+import java.util.Arrays;
 
 /**
  * An instance of this class represents one 'interesting property set' defined by the instances
@@ -101,15 +101,10 @@ public class InterestingProperties
 	@Override
 	public int hashCode()
 	{
-		//relies on google's guava library 
-		return Objects.hashCode(
-				   _blocksize, 
-				   (_format!=null)?_format.ordinal():-1,
-				   (_location!=null)?_location.ordinal():-1,
-				   (_pformat!=null)?_pformat.ordinal():-1,
-				   _replication,
-				   _emptyblocks
-			   );
+		Object[] array = new Object[] { _blocksize, (_format != null) ? _format.ordinal() : -1,
+				(_location != null) ? _location.ordinal() : -1, (_pformat != null) ? _pformat.ordinal() : -1,
+				_replication, _emptyblocks };
+		return Arrays.hashCode(array);
 	}
 	
 	@Override

--- a/src/main/java/org/apache/sysml/runtime/io/IOUtilFunctions.java
+++ b/src/main/java/org/apache/sysml/runtime/io/IOUtilFunctions.java
@@ -121,8 +121,6 @@ public class IOUtilFunctions
 	 */
 	public static String[] split(String str, String delim)
 	{
-		//note: split via stringutils faster than precompiled pattern / guava splitter
-		
 		//split by whole separator required for multi-character delimiters, preserve
 		//all tokens required for empty cells and in order to keep cell alignment
 		return StringUtils.splitByWholeSeparatorPreserveAllTokens(str, delim);

--- a/src/main/java/org/apache/sysml/runtime/transform/DummycodeAgent.java
+++ b/src/main/java/org/apache/sysml/runtime/transform/DummycodeAgent.java
@@ -23,10 +23,15 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
 import org.apache.hadoop.fs.FileSystem;
@@ -34,17 +39,13 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCollector;
-import org.apache.wink.json4j.JSONArray;
-import org.apache.wink.json4j.JSONException;
-import org.apache.wink.json4j.JSONObject;
-
-import com.google.common.base.Functions;
-import com.google.common.collect.Ordering;
-
 import org.apache.sysml.runtime.matrix.data.FrameBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.transform.encode.Encoder;
 import org.apache.sysml.runtime.util.UtilFunctions;
+import org.apache.wink.json4j.JSONArray;
+import org.apache.wink.json4j.JSONException;
+import org.apache.wink.json4j.JSONObject;
 
 public class DummycodeAgent extends Encoder 
 {		
@@ -228,8 +229,20 @@ public class DummycodeAgent extends Encoder
 				if ( map != null  ) 
 				{
 					// order map entries by their recodeID
-					Ordering<String> valueComparator = Ordering.natural().onResultOf(Functions.forMap(map));
-					newNames = valueComparator.sortedCopy(map.keySet());
+					List<Map.Entry<String, Long>> entryList = new ArrayList<Map.Entry<String, Long>>(map.entrySet());
+					Comparator<Map.Entry<String, Long>> comp = new Comparator<Map.Entry<String, Long>>() {
+						@Override
+						public int compare(Entry<String, Long> entry1, Entry<String, Long> entry2) {
+							Long value1 = entry1.getValue();
+							Long value2 = entry2.getValue();
+							return (int) (value1 - value2);
+						}
+					};
+					Collections.sort(entryList, comp);
+					newNames = new ArrayList<String>();
+					for (Entry<String, Long> entry : entryList) {
+						newNames.add(entry.getKey());
+					}
 					
 					// construct concatenated string of map entries
 					sb.setLength(0);
@@ -252,15 +265,23 @@ public class DummycodeAgent extends Encoder
 				
 				if ( map != null ) 
 				{
-					// order map entries by their recodeID (represented as Strings .. "1", "2", etc.)
-					Ordering<String> orderByID = new Ordering<String>() 
-					{
-			    		public int compare(String s1, String s2) {
-			        		return (Integer.parseInt(s1) - Integer.parseInt(s2));
-			    		}
-					};
 					
-					newNames = orderByID.onResultOf(Functions.forMap(map)).sortedCopy(map.keySet());
+					// order map entries by their recodeID (represented as Strings .. "1", "2", etc.)
+					List<Map.Entry<String, String>> entryList = new ArrayList<Map.Entry<String, String>>(map.entrySet());
+					Comparator<Map.Entry<String, String>> comp = new Comparator<Map.Entry<String, String>>() {
+						@Override
+						public int compare(Entry<String, String> entry1, Entry<String, String> entry2) {
+							String value1 = entry1.getValue();
+							String value2 = entry2.getValue();
+							return (Integer.parseInt(value1) - Integer.parseInt(value2));
+						}
+					};
+					Collections.sort(entryList, comp);
+					newNames = new ArrayList<String>();
+					for (Entry<String, String> entry : entryList) {
+						newNames.add(entry.getKey());
+					}
+					
 					// construct concatenated string of map entries
 					sb.setLength(0);
 					for(int idx=0; idx < newNames.size(); idx++) 
@@ -403,31 +424,24 @@ public class DummycodeAgent extends Encoder
 
 	@Override
 	public double[] encode(String[] in, double[] out) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public MatrixBlock encode(FrameBlock in, MatrixBlock out) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public void build(String[] in) {
-		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
 	public void build(FrameBlock in) {
-		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
 	public FrameBlock getMetaData(FrameBlock out) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/transform/RecodeAgent.java
+++ b/src/main/java/org/apache/sysml/runtime/transform/RecodeAgent.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -35,12 +36,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCollector;
-import org.apache.wink.json4j.JSONArray;
-import org.apache.wink.json4j.JSONException;
-import org.apache.wink.json4j.JSONObject;
-
-import com.google.common.collect.Ordering;
-
 import org.apache.sysml.lops.Lop;
 import org.apache.sysml.runtime.matrix.data.FrameBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
@@ -49,6 +44,9 @@ import org.apache.sysml.runtime.transform.MVImputeAgent.MVMethod;
 import org.apache.sysml.runtime.transform.decode.DecoderRecode;
 import org.apache.sysml.runtime.transform.encode.Encoder;
 import org.apache.sysml.runtime.util.UtilFunctions;
+import org.apache.wink.json4j.JSONArray;
+import org.apache.wink.json4j.JSONException;
+import org.apache.wink.json4j.JSONObject;
 
 public class RecodeAgent extends Encoder 
 {	
@@ -261,8 +259,8 @@ public class RecodeAgent extends Encoder
 			throw new RuntimeException("Can not proceed since \"" + agents.getName(colID) + "\" (id=" + colID + ") contains only the missing values, and not a single valid value -- set imputation method to \"constant\".");
 		
 		// Order entries by category (string) value
-		Ordering<String> valueComparator = Ordering.natural();
-		List<String> newNames = valueComparator.sortedCopy(map.keySet());
+		List<String> newNames = new ArrayList<String>(map.keySet());
+		Collections.sort(newNames);
 
 		for(String w : newNames) { //map.keySet()) {
 				count = map.get(w);


### PR DESCRIPTION
Remove compile-scope Guava dependency and replace Guava code with equivalent non-library version.

Since the Guava dependency is compile-scope, it is included in the main jar file. By removing the Guava dependency, the main jar file decreases in size from ~6.6MB to ~4.4MB.
