### PR TITLE
Include guava in standalone distributions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -806,6 +806,14 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- Adding Gauva version 14.0.1 to workaround conflict between spark and hadoop dependency -->
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>14.0.1</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>

--- a/src/assembly/standalone-jar.xml
+++ b/src/assembly/standalone-jar.xml
@@ -91,6 +91,7 @@
 				<include>*:commons-lang</include>
 				<include>*:commons-logging*</include>
 				<include>*:commons-math3*</include>
+				<include>*:guava*</include>
 				<include>*:hadoop-auth*</include>
 				<include>*:hadoop-client*</include>
 				<include>*:hadoop-common*</include>

--- a/src/assembly/standalone-jar.xml
+++ b/src/assembly/standalone-jar.xml
@@ -102,6 +102,7 @@
 				<include>*:jackson-mapper-asl*</include>
 				<include>*:log4j*</include>
 				<include>*:opencsv*</include>
+				<include>*:protobuf-java*</include>
 				<include>*:slf4j-api*</include>
 				<include>*:slf4j-log4j*</include>
 			</includes>

--- a/src/assembly/standalone-jar/LICENSE
+++ b/src/assembly/standalone-jar/LICENSE
@@ -314,6 +314,41 @@ POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
+The following Protocol Buffer Java API dependencies are distributed under the BSD license.
+
+Protocol Buffer Java API (http://code.google.com/p/protobuf) com.google.protobuf:protobuf-java:2.5.0 (protobuf-java-2.5.0.jar)
+Protocol Buffer Java API (http://code.google.com/p/protobuf) org.spark-project.protobuf:protobuf-java:2.5.0-spark (protobuf-java-2.5.0-spark.jar)
+
+Copyright 2014, Google Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================================
+
 The following SLF4J dependencies are distributed under the MIT license.
 
 SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:1.7.10

--- a/src/assembly/standalone-jar/LICENSE
+++ b/src/assembly/standalone-jar/LICENSE
@@ -204,6 +204,7 @@
 
 The following dependencies come under the Apache Software License 2.0.
 
+com.google.guava:guava:11.0.2
 commons-cli:commons-cli:1.2
 commons-collections:commons-collections:3.2.1
 commons-configuration:commons-configuration:1.6

--- a/src/assembly/standalone-jar/LICENSE
+++ b/src/assembly/standalone-jar/LICENSE
@@ -204,7 +204,7 @@
 
 The following dependencies come under the Apache Software License 2.0.
 
-com.google.guava:guava:11.0.2
+com.google.guava:guava:14.0.1
 commons-cli:commons-cli:1.2
 commons-collections:commons-collections:3.2.1
 commons-configuration:commons-configuration:1.6

--- a/src/assembly/standalone-jar/NOTICE
+++ b/src/assembly/standalone-jar/NOTICE
@@ -12,6 +12,10 @@ This product includes ANTLR software (http://www.antlr.org/)
 Copyright (c) 2012 Terence Parr and Sam Harwell
 All rights reserved.
 
+This product includes protobuf-java software (http://code.google.com/p/protobuf)
+Copyright 2014, Google Inc.
+All rights reserved.
+
 This product includes SLF4J software (http://www.slf4j.org/)
 Copyright (c) 2004-2008 QOS.ch
 All rights reserved.

--- a/src/assembly/standalone.xml
+++ b/src/assembly/standalone.xml
@@ -137,6 +137,7 @@
 				<include>*:jackson-mapper-asl*</include>
 				<include>*:log4j*</include>
 				<include>*:opencsv*</include>
+				<include>*:protobuf-java*</include>
 				<include>*:slf4j-api*</include>
 				<include>*:slf4j-log4j*</include>
 			</includes>

--- a/src/assembly/standalone.xml
+++ b/src/assembly/standalone.xml
@@ -126,6 +126,7 @@
 				<include>*:commons-lang</include>
 				<include>*:commons-logging*</include>
 				<include>*:commons-math3*</include>
+				<include>*:guava*</include>
 				<include>*:hadoop-auth*</include>
 				<include>*:hadoop-client*</include>
 				<include>*:hadoop-common*</include>

--- a/src/assembly/standalone/LICENSE
+++ b/src/assembly/standalone/LICENSE
@@ -212,6 +212,7 @@ commons-httpclient-3.1.jar
 commons-lang-2.6.jar
 commons-logging-1.1.1.jar
 commons-math3-3.1.1.jar
+guava-11.0.2.jar
 hadoop-auth-2.4.1.jar
 hadoop-client-2.4.1.jar
 hadoop-common-2.4.1.jar

--- a/src/assembly/standalone/LICENSE
+++ b/src/assembly/standalone/LICENSE
@@ -212,7 +212,7 @@ commons-httpclient-3.1.jar
 commons-lang-2.6.jar
 commons-logging-1.1.1.jar
 commons-math3-3.1.1.jar
-guava-11.0.2.jar
+guava-14.0.1.jar
 hadoop-auth-2.4.1.jar
 hadoop-client-2.4.1.jar
 hadoop-common-2.4.1.jar

--- a/src/assembly/standalone/LICENSE
+++ b/src/assembly/standalone/LICENSE
@@ -322,6 +322,41 @@ POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
+The following Protocol Buffer Java API dependencies are distributed under the BSD license.
+
+Protocol Buffer Java API (http://code.google.com/p/protobuf) com.google.protobuf:protobuf-java:2.5.0 (protobuf-java-2.5.0.jar)
+Protocol Buffer Java API (http://code.google.com/p/protobuf) org.spark-project.protobuf:protobuf-java:2.5.0-spark (protobuf-java-2.5.0-spark.jar)
+
+Copyright 2014, Google Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================================
+
 The following SLF4J dependencies are distributed under the MIT license.
 
 SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:1.7.10 (slf4j-api-1.7.10.jar)

--- a/src/assembly/standalone/NOTICE
+++ b/src/assembly/standalone/NOTICE
@@ -12,6 +12,10 @@ This product includes ANTLR software (http://www.antlr.org/)
 Copyright (c) 2012 Terence Parr and Sam Harwell
 All rights reserved.
 
+This product includes protobuf-java software (http://code.google.com/p/protobuf)
+Copyright 2014, Google Inc.
+All rights reserved.
+
 This product includes SLF4J software (http://www.slf4j.org/)
 Copyright (c) 2004-2008 QOS.ch
 All rights reserved.

--- a/src/main/java/org/apache/sysml/api/monitoring/SparkMonitoringUtil.java
+++ b/src/main/java/org/apache/sysml/api/monitoring/SparkMonitoringUtil.java
@@ -42,9 +42,6 @@ import org.apache.sysml.runtime.instructions.spark.functions.SparkListener;
 import scala.collection.Seq;
 import scala.xml.Node;
 
-import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
-
 /**
  * Usage guide:
  * MLContext mlCtx = new MLContext(sc, true);
@@ -58,8 +55,7 @@ public class SparkMonitoringUtil {
 	private MultiMap<Location, String> instructions = new MultiMap<Location, String>();
 	private MultiMap<String, Integer> stageIDs = new MultiMap<String, Integer>();
 	private MultiMap<String, Integer> jobIDs = new MultiMap<String, Integer>();
-	
-	private Multimap<Integer, String> rddInstructionMapping = TreeMultimap.create();
+	private MultiMap<Integer, String> rddInstructionMapping = new MultiMap<Integer, String>();
 	
 	private HashSet<String> getRelatedInstructions(int stageID) {
 		HashSet<String> retVal = new HashSet<String>();


### PR DESCRIPTION
Guava needs to be included in the standalone distributions (tar.gz, zip, and uberjar) in order for them to work. Thank you for finding this @dusenberrymw 