### PR TITLE
[SYSTEMML-757] Removed abego, ANTLR and SLF4J from NOTICE files

### DIFF
--- a/src/assembly/distrib/NOTICE
+++ b/src/assembly/distrib/NOTICE
@@ -3,12 +3,3 @@ Copyright [2015-2016] The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
-This product includes abego software (http://www.abego.org)
-Copyright (c) 2011, abego Software GmbH, Germany
-All rights reserved.
-
-This product includes ANTLR software (http://www.antlr.org/)
-Copyright (c) 2012 Terence Parr and Sam Harwell
-All rights reserved.
-

--- a/src/assembly/inmemory/NOTICE
+++ b/src/assembly/inmemory/NOTICE
@@ -3,15 +3,3 @@ Copyright [2015-2016] The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
-This product includes abego software (http://www.abego.org)
-Copyright (c) 2011, abego Software GmbH, Germany
-All rights reserved.
-
-This product includes ANTLR software (http://www.antlr.org/)
-Copyright (c) 2012 Terence Parr and Sam Harwell
-All rights reserved.
-
-This product includes SLF4J software (http://www.slf4j.org/)
-Copyright (c) 2004-2008 QOS.ch
-All rights reserved.

--- a/src/assembly/jar/NOTICE
+++ b/src/assembly/jar/NOTICE
@@ -3,12 +3,3 @@ Copyright [2015-2016] The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
-This product includes abego software (http://www.abego.org)
-Copyright (c) 2011, abego Software GmbH, Germany
-All rights reserved.
-
-This product includes ANTLR software (http://www.antlr.org/)
-Copyright (c) 2012 Terence Parr and Sam Harwell
-All rights reserved.
-

--- a/src/assembly/standalone-jar/NOTICE
+++ b/src/assembly/standalone-jar/NOTICE
@@ -3,15 +3,3 @@ Copyright [2015-2016] The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
-This product includes abego software (http://www.abego.org)
-Copyright (c) 2011, abego Software GmbH, Germany
-All rights reserved.
-
-This product includes ANTLR software (http://www.antlr.org/)
-Copyright (c) 2012 Terence Parr and Sam Harwell
-All rights reserved.
-
-This product includes SLF4J software (http://www.slf4j.org/)
-Copyright (c) 2004-2008 QOS.ch
-All rights reserved.

--- a/src/assembly/standalone/NOTICE
+++ b/src/assembly/standalone/NOTICE
@@ -3,15 +3,3 @@ Copyright [2015-2016] The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
-This product includes abego software (http://www.abego.org)
-Copyright (c) 2011, abego Software GmbH, Germany
-All rights reserved.
-
-This product includes ANTLR software (http://www.antlr.org/)
-Copyright (c) 2012 Terence Parr and Sam Harwell
-All rights reserved.
-
-This product includes SLF4J software (http://www.slf4j.org/)
-Copyright (c) 2004-2008 QOS.ch
-All rights reserved.


### PR DESCRIPTION
Permissively-Licensed Dependencies under BSD and MIT/X11 licenses do not need to be included in NOTICE file as per instructions at http://www.apache.org/dev/licensing-howto.html#permissive-deps.  This applies to abego, ANTRL and SLF4J which are referenced in LICENSE file.
