### PR TITLE
[SYSTEMML-771] Fix warnings in CsplineCG.dml and CsplineDS.dml

### DIFF
--- a/scripts/algorithms/CsplineCG.dml
+++ b/scripts/algorithms/CsplineCG.dml
@@ -102,7 +102,7 @@ y_mat = matrix(y, 1, 1)
 if (fileO != " ") {
   write (y_mat, fileO);
 } else {
-  print(y_mat)
+  print(y)
 }
 
 print ("END CUBIC SPLINE REGRESSION SCRIPT");

--- a/scripts/algorithms/CsplineDS.dml
+++ b/scripts/algorithms/CsplineDS.dml
@@ -82,7 +82,7 @@ y_mat = matrix(y, 1, 1)
 if (fileO != " ") {
    write (y_mat, fileO);
  } else {
-   print(y_mat)
+   print(y)
 }
 
 

--- a/src/test/scripts/applications/cspline/CsplineCG.dml
+++ b/src/test/scripts/applications/cspline/CsplineCG.dml
@@ -102,7 +102,7 @@ y_mat = matrix(y, 1, 1)
 if (fileO != " ") {
   write (y_mat, fileO);
 } else {
-  print(y_mat)
+  print(y)
 }
 
 print ("END CUBIC SPLINE REGRESSION SCRIPT");

--- a/src/test/scripts/applications/cspline/CsplineCG.pydml
+++ b/src/test/scripts/applications/cspline/CsplineCG.pydml
@@ -96,7 +96,7 @@ y_mat = full(y, 1, 1)
 if (fileO != " "):
     save (y_mat, fileO)
 else:
-    print(y_mat)
+    print(y)
 
 print ("END CUBIC SPLINE REGRESSION SCRIPT")
 

--- a/src/test/scripts/applications/cspline/CsplineDS.dml
+++ b/src/test/scripts/applications/cspline/CsplineDS.dml
@@ -82,7 +82,7 @@ y_mat = matrix(y, 1, 1)
 if (fileO != " ") {
    write (y_mat, fileO);
  } else {
-   print(y_mat)
+   print(y)
 }
 
 

--- a/src/test/scripts/applications/cspline/CsplineDS.pydml
+++ b/src/test/scripts/applications/cspline/CsplineDS.pydml
@@ -77,7 +77,7 @@ y_mat = full(y, 1, 1)
 if (fileO != " "):
     save (y_mat, fileO)
 else:
-    print(y_mat)
+    print(y)
 
 print ("END CUBIC SPLINE REGRESSION SCRIPT")
 


### PR DESCRIPTION
Fixed 'print statement can only print scalars' warnings by replacing 1x1 wrapper matrix with actual scalar variable for algorithm and corresponding dml and pydml test scripts.