### PR TITLE
[SYSTEMML-778] Handle escaped quotes in parser

### DIFF
--- a/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
@@ -332,7 +332,9 @@ public abstract class CommonSyntacticValidator {
 						.replaceAll("\\\\t","\t")
 						.replaceAll("\\\\n","\n")
 						.replaceAll("\\\\f","\f")
-						.replaceAll("\\\\r","\r");
+						.replaceAll("\\\\r","\r")
+						.replace("\\'","'")
+						.replace("\\\"","\"");
 				}
 				else if(text.equals("\"\"") || text.equals("\'\'")) {
 					val = "";
@@ -344,7 +346,9 @@ public abstract class CommonSyntacticValidator {
 					.replaceAll("\\\\t","\t")
 					.replaceAll("\\\\n","\n")
 					.replaceAll("\\\\f","\f")
-					.replaceAll("\\\\r","\r");
+					.replaceAll("\\\\r","\r")
+					.replace("\\'","'")
+					.replace("\\\"","\"");
 		}
 		return val;
 	}


### PR DESCRIPTION
The following DML
```
print('this is a string');
print("deron's string");
print('"deron" string');
print('"deron\'s" string');
print("\"fred's\" string");
print("\"mike\'s\" string");
```
will now produce:
```
this is a string
deron's string
"deron" string
"deron's" string
"fred's" string
"mike's" string
```
Tests completed successfully [here](https://sparktc.ibmcloud.com/jenkins/job/SystemML-OnDemand/188/).