### PR TITLE
[SYSTEMML-776][WIP] Update SystemML to Support Spark 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 	<properties>
 		<hadoop.version>2.4.1</hadoop.version>
 		<antlr.version>4.3</antlr.version>
-		<spark.version>1.4.1</spark.version>
+		<spark.version>2.0.0</spark.version>
 		<scala.version>2.11.8</scala.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<scala.test.version>2.2.6</scala.test.version>

--- a/src/main/java/org/apache/sysml/api/MLBlock.java
+++ b/src/main/java/org/apache/sysml/api/MLBlock.java
@@ -20,6 +20,7 @@ package org.apache.sysml.api;
 
 import java.math.BigDecimal;
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +29,6 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 
@@ -253,9 +253,15 @@ public class MLBlock implements Row {
 	public static StructType getDefaultSchemaForBinaryBlock() {
 		// TODO:
 		StructField[] fields = new StructField[2];
-		fields[0] = new StructField("IgnoreSchema", DataType.fromCaseClassString("DoubleType"), true, null);
-		fields[1] = new StructField("IgnoreSchema1", DataType.fromCaseClassString("DoubleType"), true, null);
+		fields[0] = new StructField("IgnoreSchema", DataType.fromJson("DoubleType"), true, null);
+		fields[1] = new StructField("IgnoreSchema1", DataType.fromJson("DoubleType"), true, null);
 		return new StructType(fields);
+	}
+
+	@Override
+	public Timestamp getTimestamp(int arg0) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 

--- a/src/main/java/org/apache/sysml/api/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/MLContext.java
@@ -34,7 +34,8 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.rdd.RDD;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.api.jmlc.JMLCUtils;
@@ -258,7 +259,7 @@ public class MLContext {
 	 * @param df
 	 * @throws DMLRuntimeException
 	 */
-	public void registerInput(String varName, DataFrame df) throws DMLRuntimeException {
+	public void registerInput(String varName, Dataset<Row> df) throws DMLRuntimeException {
 		registerInput(varName, df, false);
 	}
 	
@@ -272,7 +273,7 @@ public class MLContext {
 	 * @param containsID false if the DataFrame has an column ID which denotes the row ID.
 	 * @throws DMLRuntimeException
 	 */
-	public void registerInput(String varName, DataFrame df, boolean containsID) throws DMLRuntimeException {
+	public void registerInput(String varName, Dataset<Row> df, boolean containsID) throws DMLRuntimeException {
 		MatrixCharacteristics mcOut = new MatrixCharacteristics();
 		JavaPairRDD<MatrixIndexes, MatrixBlock> rdd = RDDConverterUtilsExt.dataFrameToBinaryBlock(new JavaSparkContext(_sc), df, mcOut, containsID);
 		registerInput(varName, rdd, mcOut);

--- a/src/main/java/org/apache/sysml/api/MLMatrix.java
+++ b/src/main/java/org/apache/sysml/api/MLMatrix.java
@@ -25,10 +25,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.rdd.RDD;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoder;
+import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
-import org.apache.spark.sql.SQLContext.QueryExecution;
+import org.apache.spark.sql.execution.QueryExecution;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.types.StructType;
 
@@ -66,27 +68,27 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
  result.write("Result_small.mtx", "text")
  
  */
-public class MLMatrix extends DataFrame {
+public class MLMatrix extends Dataset<Row> {
 	private static final long serialVersionUID = -7005940673916671165L;
 	protected static final Log LOG = LogFactory.getLog(DMLScript.class.getName());
 	
 	protected MatrixCharacteristics mc = null;
 	protected MLContext ml = null;
 	
-	protected MLMatrix(SQLContext sqlContext, LogicalPlan logicalPlan, MLContext ml) {
-		super(sqlContext, logicalPlan);
+	protected MLMatrix(SQLContext sqlContext, LogicalPlan logicalPlan, MLContext ml, Encoder<Row> encoder) {
+		super(sqlContext, logicalPlan, encoder);
 		this.ml = ml;
 	}
 
-	protected MLMatrix(SQLContext sqlContext, QueryExecution queryExecution, MLContext ml) {
-		super(sqlContext, queryExecution);
+	protected MLMatrix(SQLContext sqlContext, QueryExecution queryExecution, MLContext ml, Encoder<Row> encoder) {
+		super(sqlContext.sparkSession(), queryExecution, encoder);
 		this.ml = ml;
 	}
 	
 	// Only used internally to set a new MLMatrix after one of matrix operations.
 	// Not to be used externally.
-	protected MLMatrix(DataFrame df, MatrixCharacteristics mc, MLContext ml) throws DMLRuntimeException {
-		super(df.sqlContext(), df.logicalPlan());
+	protected MLMatrix(Dataset<Row> df, MatrixCharacteristics mc, MLContext ml) throws DMLRuntimeException {
+		super(df.sqlContext(), df.logicalPlan(), null); //TODO: Encoder
 		this.mc = mc;
 		this.ml = ml;
 	}

--- a/src/main/java/org/apache/sysml/api/MLMatrix.java
+++ b/src/main/java/org/apache/sysml/api/MLMatrix.java
@@ -27,7 +27,6 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoder;
-import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.execution.QueryExecution;

--- a/src/main/java/org/apache/sysml/api/MLOutput.java
+++ b/src/main/java/org/apache/sysml/api/MLOutput.java
@@ -21,6 +21,7 @@ package org.apache.sysml.api;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -31,7 +32,7 @@ import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.apache.spark.mllib.linalg.DenseVector;
 import org.apache.spark.mllib.linalg.VectorUDT;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SQLContext;
@@ -86,7 +87,7 @@ public class MLOutput {
 	 * @return
 	 * @throws DMLRuntimeException
 	 */
-	public DataFrame getDF(SQLContext sqlContext, String varName) throws DMLRuntimeException {
+	public Dataset<Row> getDF(SQLContext sqlContext, String varName) throws DMLRuntimeException {
 		if(sqlContext == null) {
 			throw new DMLRuntimeException("SQLContext is not created.");
 		}
@@ -106,7 +107,7 @@ public class MLOutput {
 	 * @return
 	 * @throws DMLRuntimeException
 	 */
-	public DataFrame getDF(SQLContext sqlContext, String varName, boolean outputVector) throws DMLRuntimeException {
+	public Dataset<Row> getDF(SQLContext sqlContext, String varName, boolean outputVector) throws DMLRuntimeException {
 		if(sqlContext == null) {
 			throw new DMLRuntimeException("SQLContext is not created.");
 		}
@@ -132,7 +133,7 @@ public class MLOutput {
 	 * @return
 	 * @throws DMLRuntimeException
 	 */
-	public DataFrame getDF(SQLContext sqlContext, String varName, Map<String, Tuple2<Long, Long>> range) throws DMLRuntimeException {
+	public Dataset<Row> getDF(SQLContext sqlContext, String varName, Map<String, Tuple2<Long, Long>> range) throws DMLRuntimeException {
 		if(sqlContext == null) {
 			throw new DMLRuntimeException("SQLContext is not created.");
 		}
@@ -227,7 +228,7 @@ public class MLOutput {
 		}
 
 		@Override
-		public Iterable<Tuple2<Long, Tuple2<Long, Double[]>>> call(Tuple2<MatrixIndexes, MatrixBlock> kv) throws Exception {
+		public Iterator<Tuple2<Long, Tuple2<Long, Double[]>>> call(Tuple2<MatrixIndexes, MatrixBlock> kv) throws Exception {
 			// ------------------------------------------------------------------
     		//	Compute local block size: 
     		// Example: For matrix: 1500 X 1100 with block length 1000 X 1000
@@ -248,7 +249,7 @@ public class MLOutput {
 				}
 				retVal.add(new Tuple2<Long, Tuple2<Long,Double[]>>(startRowIndex + i, new Tuple2<Long,Double[]>(kv._1.getColumnIndex(), partialRow)));
 			}
-			return retVal;
+			return retVal.iterator();
 		}
 	}
 	

--- a/src/main/java/org/apache/sysml/api/javaml/LogisticRegression.java
+++ b/src/main/java/org/apache/sysml/api/javaml/LogisticRegression.java
@@ -31,9 +31,11 @@ import org.apache.spark.ml.classification.ProbabilisticClassifier;
 import org.apache.spark.ml.param.BooleanParam;
 import org.apache.spark.ml.param.DoubleParam;
 import org.apache.spark.ml.param.IntParam;
+import org.apache.spark.ml.param.Param;
 import org.apache.spark.ml.param.StringArrayParam;
-import org.apache.spark.mllib.linalg.Vector;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.ml.linalg.Vector;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.apache.sysml.api.MLContext;
 import org.apache.sysml.api.MLOutput;
@@ -63,7 +65,7 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
  * import org.apache.spark.ml.Pipeline
  * import org.apache.sysml.api.ml.LogisticRegression
  * import org.apache.spark.ml.feature.{HashingTF, Tokenizer}
- * import org.apache.spark.mllib.linalg.Vector
+ * import org.apache.spark.ml.linalg.Vector
  * case class LabeledDocument(id: Long, text: String, label: Double)
  * case class Document(id: Long, text: String)
  * val training = sc.parallelize(Seq(
@@ -97,7 +99,7 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
  * import org.apache.spark.ml.evaluation.BinaryClassificationEvaluator
  * import org.apache.spark.ml.feature.{HashingTF, Tokenizer}
  * import org.apache.spark.ml.tuning.{ParamGridBuilder, CrossValidator}
- * import org.apache.spark.mllib.linalg.Vector
+ * import org.apache.spark.ml.linalg.Vector
  * case class LabeledDocument(id: Long, text: String, label: Double)
  * case class Document(id: Long, text: String)
  * val training = sc.parallelize(Seq(
@@ -411,8 +413,9 @@ public class LogisticRegression extends ProbabilisticClassifier<Vector, Logistic
 		return outputCol;
 	}
 	
+	@SuppressWarnings("unchecked")
 	@Override
-	public LogisticRegressionModel train(DataFrame df) {
+	public LogisticRegressionModel train(Dataset<?> df) {
 		MLContext ml = null;
 		MLOutput out = null;
 		
@@ -427,7 +430,7 @@ public class LogisticRegression extends ProbabilisticClassifier<Vector, Logistic
 		MatrixCharacteristics mcXin = new MatrixCharacteristics();
 		JavaPairRDD<MatrixIndexes, MatrixBlock> Xin;
 		try {
-			Xin = RDDConverterUtilsExt.vectorDataFrameToBinaryBlock(new JavaSparkContext(this.sc), df, mcXin, false, "features");
+			Xin = RDDConverterUtilsExt.vectorDataFrameToBinaryBlock(new JavaSparkContext(this.sc), (Dataset<Row>) df, mcXin, false, "features");
 		} catch (DMLRuntimeException e1) {
 			e1.printStackTrace();
 			return null;
@@ -469,5 +472,55 @@ public class LogisticRegression extends ProbabilisticClassifier<Vector, Logistic
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		} 
+	}
+
+	@Override
+	public boolean getStandardization() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void org$apache$spark$ml$param$shared$HasStandardization$_setter_$standardization_$eq(
+			BooleanParam arg0) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public BooleanParam standardization() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String getWeightCol() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void org$apache$spark$ml$param$shared$HasWeightCol$_setter_$weightCol_$eq(
+			Param arg0) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public Param<String> weightCol() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void checkThresholdConsistency() {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public LogisticRegressionParams setThreshold(double arg0) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 }

--- a/src/main/java/org/apache/sysml/api/mlcontext/BinaryBlockMatrix.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/BinaryBlockMatrix.java
@@ -20,7 +20,8 @@
 package org.apache.sysml.api.mlcontext;
 
 import org.apache.spark.api.java.JavaPairRDD;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
@@ -42,7 +43,7 @@ public class BinaryBlockMatrix {
 	 * @param matrixMetadata
 	 *            matrix metadata, such as number of rows and columns
 	 */
-	public BinaryBlockMatrix(DataFrame dataFrame, MatrixMetadata matrixMetadata) {
+	public BinaryBlockMatrix(Dataset<Row> dataFrame, MatrixMetadata matrixMetadata) {
 		this.matrixMetadata = matrixMetadata;
 		binaryBlocks = MLContextConversionUtil.dataFrameToBinaryBlocks(dataFrame, matrixMetadata);
 	}
@@ -58,7 +59,7 @@ public class BinaryBlockMatrix {
 	 * @param numCols
 	 *            the number of columns
 	 */
-	public BinaryBlockMatrix(DataFrame dataFrame, long numRows, long numCols) {
+	public BinaryBlockMatrix(Dataset<Row> dataFrame, long numRows, long numCols) {
 		this(dataFrame, new MatrixMetadata(numRows, numCols, MLContextUtil.defaultBlockSize(),
 				MLContextUtil.defaultBlockSize()));
 	}
@@ -69,7 +70,7 @@ public class BinaryBlockMatrix {
 	 * @param dataFrame
 	 *            the Spark DataFrame
 	 */
-	public BinaryBlockMatrix(DataFrame dataFrame) {
+	public BinaryBlockMatrix(Dataset<Row> dataFrame) {
 		this(dataFrame, new MatrixMetadata());
 	}
 

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
@@ -60,7 +60,7 @@ public class MLContext {
 	/**
 	 * Minimum Spark version supported by SystemML.
 	 */
-	public static final String SYSTEMML_MINIMUM_SPARK_VERSION = "1.4.0";
+	public static final String SYSTEMML_MINIMUM_SPARK_VERSION = "2.0.0";
 
 	/**
 	 * SparkContext object.

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextConversionUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextConversionUtil.java
@@ -31,7 +31,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.rdd.RDD;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.apache.sysml.api.MLContextProxy;
@@ -177,7 +177,7 @@ public class MLContextConversionUtil {
 	 * @return the {@code DataFrame} matrix converted to a converted to a
 	 *         {@code MatrixObject}
 	 */
-	public static MatrixObject dataFrameToMatrixObject(String variableName, DataFrame dataFrame) {
+	public static MatrixObject dataFrameToMatrixObject(String variableName, Dataset<Row> dataFrame) {
 		return dataFrameToMatrixObject(variableName, dataFrame, null);
 	}
 
@@ -193,7 +193,7 @@ public class MLContextConversionUtil {
 	 * @return the {@code DataFrame} matrix converted to a converted to a
 	 *         {@code MatrixObject}
 	 */
-	public static MatrixObject dataFrameToMatrixObject(String variableName, DataFrame dataFrame,
+	public static MatrixObject dataFrameToMatrixObject(String variableName, Dataset<Row> dataFrame,
 			MatrixMetadata matrixMetadata) {
 		if (matrixMetadata == null) {
 			matrixMetadata = new MatrixMetadata();
@@ -215,7 +215,7 @@ public class MLContextConversionUtil {
 	 *         {@code JavaPairRDD<MatrixIndexes,
 	 *         MatrixBlock>} binary-block matrix
 	 */
-	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlocks(DataFrame dataFrame) {
+	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlocks(Dataset<Row> dataFrame) {
 		return dataFrameToBinaryBlocks(dataFrame, null);
 	}
 
@@ -231,7 +231,7 @@ public class MLContextConversionUtil {
 	 *         {@code JavaPairRDD<MatrixIndexes,
 	 *         MatrixBlock>} binary-block matrix
 	 */
-	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlocks(DataFrame dataFrame,
+	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlocks(Dataset<Row> dataFrame,
 			MatrixMetadata matrixMetadata) {
 
 		MatrixCharacteristics matrixCharacteristics;
@@ -267,7 +267,7 @@ public class MLContextConversionUtil {
 	 * @param matrixCharacteristics
 	 *            the matrix metadata
 	 */
-	public static void determineDataFrameDimensionsIfNeeded(DataFrame dataFrame,
+	public static void determineDataFrameDimensionsIfNeeded(Dataset<Row> dataFrame,
 			MatrixCharacteristics matrixCharacteristics) {
 		if (!matrixCharacteristics.dimsKnown(true)) {
 			// only available to the new MLContext API, not the old API
@@ -675,7 +675,7 @@ public class MLContextConversionUtil {
 	 *            the Spark execution context
 	 * @return the {@code MatrixObject} converted to a {@code DataFrame}
 	 */
-	public static DataFrame matrixObjectToDataFrame(MatrixObject matrixObject,
+	public static Dataset<Row> matrixObjectToDataFrame(MatrixObject matrixObject,
 			SparkExecutionContext sparkExecutionContext) {
 		try {
 			@SuppressWarnings("unchecked")
@@ -686,7 +686,7 @@ public class MLContextConversionUtil {
 			MLContext activeMLContext = (MLContext) MLContextProxy.getActiveMLContext();
 			SparkContext sc = activeMLContext.getSparkContext();
 			SQLContext sqlContext = new SQLContext(sc);
-			DataFrame df = RDDConverterUtilsExt.binaryBlockToDataFrame(binaryBlockMatrix, matrixCharacteristics,
+			Dataset<Row> df = RDDConverterUtilsExt.binaryBlockToDataFrame(binaryBlockMatrix, matrixCharacteristics,
 					sqlContext);
 			return df;
 		} catch (DMLRuntimeException e) {

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
@@ -38,7 +38,8 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.rdd.RDD;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.sysml.conf.CompilerConfig;
 import org.apache.sysml.conf.CompilerConfig.ConfigType;
 import org.apache.sysml.conf.ConfigurationManager;
@@ -71,7 +72,7 @@ public final class MLContextUtil {
 	 * Complex data types supported by the MLContext API
 	 */
 	@SuppressWarnings("rawtypes")
-	public static final Class[] COMPLEX_DATA_TYPES = { JavaRDD.class, RDD.class, DataFrame.class,
+	public static final Class[] COMPLEX_DATA_TYPES = { JavaRDD.class, RDD.class, Dataset.class,
 			BinaryBlockMatrix.class, Matrix.class, (new double[][] {}).getClass() };
 
 	/**
@@ -448,8 +449,9 @@ public final class MLContextUtil {
 			}
 
 			return matrixObject;
-		} else if (value instanceof DataFrame) {
-			DataFrame dataFrame = (DataFrame) value;
+		} else if (value instanceof Dataset<?>) {
+			@SuppressWarnings("unchecked")
+			Dataset<Row> dataFrame = (Dataset<Row>) value;
 			MatrixObject matrixObject = MLContextConversionUtil
 					.dataFrameToMatrixObject(name, dataFrame, matrixMetadata);
 			return matrixObject;

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
@@ -23,7 +23,8 @@ import java.util.Set;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.rdd.RDD;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.controlprogram.LocalVariableMap;
 import org.apache.sysml.runtime.controlprogram.caching.CacheException;
@@ -253,9 +254,9 @@ public class MLResults {
 	 *            the name of the output
 	 * @return the output as a {@code DataFrame} of doubles
 	 */
-	public DataFrame getDataFrame(String outputName) {
+	public Dataset<Row> getDataFrame(String outputName) {
 		MatrixObject mo = getMatrixObject(outputName);
-		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext);
+		Dataset<Row> df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext);
 		return df;
 	}
 

--- a/src/main/java/org/apache/sysml/api/mlcontext/Matrix.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/Matrix.java
@@ -21,7 +21,8 @@ package org.apache.sysml.api.mlcontext;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.rdd.RDD;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysml.runtime.controlprogram.context.SparkExecutionContext;
 import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
@@ -107,8 +108,8 @@ public class Matrix {
 	 * 
 	 * @return the matrix as a {@code DataFrame}
 	 */
-	public DataFrame asDataFrame() {
-		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext);
+	public Dataset<Row> asDataFrame() {
+		Dataset<Row> df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext);
 		return df;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/DataPartitionerRemoteSparkMapper.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/DataPartitionerRemoteSparkMapper.java
@@ -20,12 +20,12 @@
 package org.apache.sysml.runtime.controlprogram.parfor;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.hadoop.io.Writable;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
-
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.controlprogram.ParForProgramBlock.PDataPartitionFormat;
 import org.apache.sysml.runtime.controlprogram.parfor.util.PairWritableBlock;
@@ -73,7 +73,7 @@ public class DataPartitionerRemoteSparkMapper extends ParWorker implements PairF
 
 
 	@Override
-	public Iterable<Tuple2<Long, Writable>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) 
+	public Iterator<Tuple2<Long, Writable>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) 
 		throws Exception 
 	{	
 		List<Tuple2<Long, Writable>> ret = new LinkedList<Tuple2<Long, Writable>>();
@@ -148,7 +148,7 @@ public class DataPartitionerRemoteSparkMapper extends ParWorker implements PairF
 				throw new DMLRuntimeException("Unsupported partition format: "+_dpf);
 		}
 		
-		return ret;
+		return ret.iterator();
 	}
 	
 }

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteDPParForSparkWorker.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteDPParForSparkWorker.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.io.Writable;
 import org.apache.spark.Accumulator;
 import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
-
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.controlprogram.ParForProgramBlock.PDataPartitionFormat;
 import org.apache.sysml.runtime.controlprogram.caching.CacheableData;
@@ -97,7 +96,7 @@ public class RemoteDPParForSparkWorker extends ParWorker implements PairFlatMapF
 	}
 	
 	@Override 
-	public Iterable<Tuple2<Long, String>> call(Iterator<Tuple2<Long, Iterable<Writable>>> arg0)
+	public Iterator<Tuple2<Long, String>> call(Iterator<Tuple2<Long, Iterable<Writable>>> arg0)
 		throws Exception 
 	{
 		ArrayList<Tuple2<Long,String>> ret = new ArrayList<Tuple2<Long,String>>();
@@ -140,7 +139,7 @@ public class RemoteDPParForSparkWorker extends ParWorker implements PairFlatMapF
 				ret.add(new Tuple2<Long,String>(_workerID, val));
 		}	
 		
-		return ret;
+		return ret.iterator();
 	}
 	
 	/**

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForSparkWorker.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForSparkWorker.java
@@ -21,11 +21,11 @@ package org.apache.sysml.runtime.controlprogram.parfor;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import org.apache.spark.Accumulator;
 import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
-
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.controlprogram.caching.CacheableData;
 import org.apache.sysml.runtime.controlprogram.parfor.util.IDHandler;
@@ -64,7 +64,7 @@ public class RemoteParForSparkWorker extends ParWorker implements PairFlatMapFun
 	}
 	
 	@Override 
-	public Iterable<Tuple2<Long, String>> call(Task arg0)
+	public Iterator<Tuple2<Long, String>> call(Task arg0)
 		throws Exception 
 	{
 		//lazy parworker initialization
@@ -86,7 +86,7 @@ public class RemoteParForSparkWorker extends ParWorker implements PairFlatMapFun
 		for( String val : tmp )
 			ret.add(new Tuple2<Long,String>(_workerID, val));
 			
-		return ret;
+		return ret.iterator();
 	}
 	
 	/**

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/AppendGSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/AppendGSPInstruction.java
@@ -182,7 +182,7 @@ public class AppendGSPInstruction extends BinarySPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> kv) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> kv) 
 			throws Exception 
 		{
 			//common preparation
@@ -246,7 +246,7 @@ public class AppendGSPInstruction extends BinarySPInstruction
 				}
 			}
 			
-			return retVal;
+			return retVal.iterator();
 		}
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/CumulativeOffsetSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/CumulativeOffsetSPInstruction.java
@@ -20,6 +20,7 @@
 package org.apache.sysml.runtime.instructions.spark;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.function.Function;
@@ -145,7 +146,7 @@ public class CumulativeOffsetSPInstruction extends BinarySPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
 			throws Exception 
 		{
 			ArrayList<Tuple2<MatrixIndexes, MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes, MatrixBlock>>();
@@ -178,7 +179,7 @@ public class CumulativeOffsetSPInstruction extends BinarySPInstruction
 					ret.add(new Tuple2<MatrixIndexes,MatrixBlock>(tmpix, tmpblk));
 				}
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 	

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/FrameAppendMSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/FrameAppendMSPInstruction.java
@@ -121,7 +121,7 @@ public class FrameAppendMSPInstruction extends AppendMSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<Long, FrameBlock>> call(Iterator<Tuple2<Long, FrameBlock>> arg0)
+		public Iterator<Tuple2<Long, FrameBlock>> call(Iterator<Tuple2<Long, FrameBlock>> arg0)
 			throws Exception 
 		{
 			return new MapAppendPartitionIterator(arg0);

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/FrameIndexingSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/FrameIndexingSPInstruction.java
@@ -222,13 +222,13 @@ public class FrameIndexingSPInstruction  extends IndexingSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<Long, FrameBlock>> call(Tuple2<Long, FrameBlock> rightKV) 
+		public Iterator<Tuple2<Long, FrameBlock>> call(Tuple2<Long, FrameBlock> rightKV) 
 			throws Exception 
 		{
 			Pair<Long,FrameBlock> in = SparkUtils.toIndexedFrameBlock(rightKV);			
 			ArrayList<Pair<Long,FrameBlock>> out = new ArrayList<Pair<Long,FrameBlock>>();
 			OperationsOnMatrixValues.performShift(in, _ixrange, _brlen, _bclen, _rlen, _clen, out);
-			return SparkUtils.fromIndexedFrameBlock(out);
+			return SparkUtils.fromIndexedFrameBlock(out).iterator();
 		}		
 	}
 	
@@ -254,7 +254,7 @@ public class FrameIndexingSPInstruction  extends IndexingSPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<Long, FrameBlock>> call(Tuple2<Long, FrameBlock> kv) 
+		public Iterator<Tuple2<Long, FrameBlock>> call(Tuple2<Long, FrameBlock> kv) 
 			throws Exception 
 		{
 			ArrayList<Pair<Long,FrameBlock>> out = new ArrayList<Pair<Long,FrameBlock>>();
@@ -286,7 +286,7 @@ public class FrameIndexingSPInstruction  extends IndexingSPInstruction
 				curBlockRange.rowStart =  lGblStartRow + _brlen;
 				iRowStartDest = UtilFunctions.computeCellInBlock(iRowStartDest+iMaxRowsToCopy+1, _brlen);
 			}
-			return SparkUtils.fromIndexedFrameBlock(out);
+			return SparkUtils.fromIndexedFrameBlock(out).iterator();
 		}
 	}
 	
@@ -307,7 +307,7 @@ public class FrameIndexingSPInstruction  extends IndexingSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<Long, FrameBlock>> call(Iterator<Tuple2<Long, FrameBlock>> arg0)
+		public Iterator<Tuple2<Long, FrameBlock>> call(Iterator<Tuple2<Long, FrameBlock>> arg0)
 			throws Exception 
 		{
 			return new LeftIndexPartitionIterator(arg0);
@@ -389,7 +389,7 @@ public class FrameIndexingSPInstruction  extends IndexingSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<Long, FrameBlock>> call(Tuple2<Long, FrameBlock> kv) 
+		public Iterator<Tuple2<Long, FrameBlock>> call(Tuple2<Long, FrameBlock> kv) 
 			throws Exception 
 		{	
 			Pair<Long, FrameBlock> in = SparkUtils.toIndexedFrameBlock(kv);
@@ -397,7 +397,7 @@ public class FrameIndexingSPInstruction  extends IndexingSPInstruction
 			ArrayList<Pair<Long, FrameBlock>> outlist = new ArrayList<Pair<Long, FrameBlock>>();
 			OperationsOnMatrixValues.performSlice(in, _ixrange, _brlen, _bclen, outlist);
 			
-			return SparkUtils.fromIndexedFrameBlock(outlist);
+			return SparkUtils.fromIndexedFrameBlock(outlist).iterator();
 		}		
 	}
 
@@ -419,7 +419,7 @@ public class FrameIndexingSPInstruction  extends IndexingSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<Long, FrameBlock>> call(Iterator<Tuple2<Long, FrameBlock>> arg0)
+		public Iterator<Tuple2<Long, FrameBlock>> call(Iterator<Tuple2<Long, FrameBlock>> arg0)
 			throws Exception 
 		{
 			return new SliceBlockPartitionIterator(arg0);

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MapmmSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MapmmSPInstruction.java
@@ -265,7 +265,7 @@ public class MapmmSPInstruction extends BinarySPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0)
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0)
 			throws Exception 
 		{
 			return new MapMMPartitionIterator(arg0);
@@ -335,7 +335,7 @@ public class MapmmSPInstruction extends BinarySPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
 			throws Exception 
 		{
 			ArrayList<Tuple2<MatrixIndexes, MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes, MatrixBlock>>();
@@ -379,7 +379,7 @@ public class MapmmSPInstruction extends BinarySPInstruction
 				}
 			}
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixAppendMSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixAppendMSPInstruction.java
@@ -154,7 +154,7 @@ public class MatrixAppendMSPInstruction extends AppendMSPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> kv) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> kv) 
 			throws Exception 
 		{
 			ArrayList<Tuple2<MatrixIndexes, MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes, MatrixBlock>>();
@@ -216,7 +216,7 @@ public class MatrixAppendMSPInstruction extends AppendMSPInstruction
 				ret.addAll(SparkUtils.fromIndexedMatrixBlock(outlist));
 			}
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 	
@@ -242,7 +242,7 @@ public class MatrixAppendMSPInstruction extends AppendMSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0)
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0)
 			throws Exception 
 		{
 			return new MapAppendPartitionIterator(arg0);

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixIndexingSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixIndexingSPInstruction.java
@@ -222,13 +222,13 @@ public class MatrixIndexingSPInstruction  extends IndexingSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> rightKV) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> rightKV) 
 			throws Exception 
 		{
 			IndexedMatrixValue in = SparkUtils.toIndexedMatrixBlock(rightKV);			
 			ArrayList<IndexedMatrixValue> out = new ArrayList<IndexedMatrixValue>();
 			OperationsOnMatrixValues.performShift(in, _ixrange, _brlen, _bclen, _rlen, _clen, out);
-			return SparkUtils.fromIndexedMatrixBlock(out);
+			return SparkUtils.fromIndexedMatrixBlock(out).iterator();
 		}		
 	}
 	
@@ -290,7 +290,7 @@ public class MatrixIndexingSPInstruction  extends IndexingSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0)
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0)
 			throws Exception 
 		{
 			return new LeftIndexPartitionIterator(arg0);
@@ -357,7 +357,7 @@ public class MatrixIndexingSPInstruction  extends IndexingSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> kv) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> kv) 
 			throws Exception 
 		{	
 			IndexedMatrixValue in = SparkUtils.toIndexedMatrixBlock(kv);
@@ -365,7 +365,7 @@ public class MatrixIndexingSPInstruction  extends IndexingSPInstruction
 			ArrayList<IndexedMatrixValue> outlist = new ArrayList<IndexedMatrixValue>();
 			OperationsOnMatrixValues.performSlice(in, _ixrange, _brlen, _bclen, outlist);
 			
-			return SparkUtils.fromIndexedMatrixBlock(outlist);
+			return SparkUtils.fromIndexedMatrixBlock(outlist).iterator();
 		}		
 	}
 	
@@ -387,7 +387,7 @@ public class MatrixIndexingSPInstruction  extends IndexingSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0)
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0)
 			throws Exception 
 		{
 			return new SliceBlockPartitionIterator(arg0);

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixReshapeSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixReshapeSPInstruction.java
@@ -20,6 +20,7 @@
 package org.apache.sysml.runtime.instructions.spark;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
@@ -136,7 +137,7 @@ public class MatrixReshapeSPInstruction extends UnarySPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
 			throws Exception 
 		{
 			//input conversion (for libmatrixreorg compatibility)
@@ -148,7 +149,7 @@ public class MatrixReshapeSPInstruction extends UnarySPInstruction
                     out, _mcOut.getRows(), _mcOut.getCols(), _mcOut.getRowsPerBlock(), _mcOut.getColsPerBlock(), _byrow);
 
 			//output conversion (for compatibility w/ rdd schema)
-			return SparkUtils.fromIndexedMatrixBlock(out);
+			return SparkUtils.fromIndexedMatrixBlock(out).iterator();
 		}
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MultiReturnParameterizedBuiltinSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MultiReturnParameterizedBuiltinSPInstruction.java
@@ -224,7 +224,7 @@ public class MultiReturnParameterizedBuiltinSPInstruction extends ComputationSPI
 		}
 		
 		@Override
-		public Iterable<Tuple2<Integer, String>> call(Iterator<Tuple2<Long, FrameBlock>> iter)
+		public Iterator<Tuple2<Integer, String>> call(Iterator<Tuple2<Long, FrameBlock>> iter)
 			throws Exception 
 		{
 			//build meta data (e.g., recode maps)
@@ -244,7 +244,7 @@ public class MultiReturnParameterizedBuiltinSPInstruction extends ComputationSPI
 								ret.add(new Tuple2<Integer,String>(e1.getKey(), token));
 					}
 				
-			return ret;
+			return ret.iterator();
 		}
 	}
 	
@@ -262,7 +262,7 @@ public class MultiReturnParameterizedBuiltinSPInstruction extends ComputationSPI
 		}
 		
 		@Override
-		public Iterable<String> call(Tuple2<Integer, Iterable<String>> arg0)
+		public Iterator<String> call(Tuple2<Integer, Iterable<String>> arg0)
 			throws Exception 
 		{
 			String colID = String.valueOf(arg0._1());
@@ -283,7 +283,7 @@ public class MultiReturnParameterizedBuiltinSPInstruction extends ComputationSPI
 			}
 			_accMax.add(rowID-1);
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 	
@@ -324,7 +324,7 @@ public class MultiReturnParameterizedBuiltinSPInstruction extends ComputationSPI
 		}
 		
 		@Override
-		public Iterable<Tuple2<Integer, ColumnMetadata>> call(Iterator<Tuple2<Long, FrameBlock>> iter)
+		public Iterator<Tuple2<Integer, ColumnMetadata>> call(Iterator<Tuple2<Long, FrameBlock>> iter)
 			throws Exception 
 		{
 			//build meta data (e.g., histograms and means)
@@ -353,7 +353,7 @@ public class MultiReturnParameterizedBuiltinSPInstruction extends ComputationSPI
 				}
 			}
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 	
@@ -371,7 +371,7 @@ public class MultiReturnParameterizedBuiltinSPInstruction extends ComputationSPI
 		}
 
 		@Override
-		public Iterable<String> call(Tuple2<Integer, Iterable<ColumnMetadata>> arg0)
+		public Iterator<String> call(Tuple2<Integer, Iterable<ColumnMetadata>> arg0)
 				throws Exception 
 		{
 			int colix = arg0._1();
@@ -413,7 +413,7 @@ public class MultiReturnParameterizedBuiltinSPInstruction extends ComputationSPI
 					ret.add("-2 " + colix + " " + iter.next().getMvValue());
 			}
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/PMapmmSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/PMapmmSPInstruction.java
@@ -21,6 +21,7 @@ package org.apache.sysml.runtime.instructions.spark;
 
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
@@ -192,7 +193,7 @@ public class PMapmmSPInstruction extends BinarySPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0)
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0)
 			throws Exception 
 		{
 			PartitionedBlock<MatrixBlock> pm = _pbc.value();
@@ -218,7 +219,7 @@ public class PMapmmSPInstruction extends BinarySPInstruction
 				ret.add(new Tuple2<MatrixIndexes, MatrixBlock>(ixOut, blkOut));
 			}
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/ParameterizedBuiltinSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/ParameterizedBuiltinSPInstruction.java
@@ -21,6 +21,7 @@ package org.apache.sysml.runtime.instructions.spark;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 
 import org.apache.spark.api.java.JavaPairRDD;
@@ -533,7 +534,7 @@ public class ParameterizedBuiltinSPInstruction  extends ComputationSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, Tuple2<MatrixBlock, MatrixBlock>> arg0)
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, Tuple2<MatrixBlock, MatrixBlock>> arg0)
 			throws Exception 
 		{
 			//prepare inputs (for internal api compatibility)
@@ -545,7 +546,7 @@ public class ParameterizedBuiltinSPInstruction  extends ComputationSPInstruction
 			LibMatrixReorg.rmempty(data, offsets, _rmRows, _len, _brlen, _bclen, out);
 
 			//prepare and return outputs
-			return SparkUtils.fromIndexedMatrixBlock(out);
+			return SparkUtils.fromIndexedMatrixBlock(out).iterator();
 		}
 	}
 	
@@ -573,7 +574,7 @@ public class ParameterizedBuiltinSPInstruction  extends ComputationSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0)
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0)
 			throws Exception 
 		{
 			//prepare inputs (for internal api compatibility)
@@ -590,7 +591,7 @@ public class ParameterizedBuiltinSPInstruction  extends ComputationSPInstruction
 			LibMatrixReorg.rmempty(data, offsets, _rmRows, _len, _brlen, _bclen, out);
 
 			//prepare and return outputs
-			return SparkUtils.fromIndexedMatrixBlock(out);
+			return SparkUtils.fromIndexedMatrixBlock(out).iterator();
 		}
 	}
 	
@@ -619,7 +620,7 @@ public class ParameterizedBuiltinSPInstruction  extends ComputationSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0)
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0)
 			throws Exception 
 		{
 			//prepare inputs (for internal api compatibility)
@@ -630,7 +631,7 @@ public class ParameterizedBuiltinSPInstruction  extends ComputationSPInstruction
 			LibMatrixReorg.rexpand(data, _maxVal, _dirRows, _cast, _ignore, _brlen, _bclen, out);
 			
 			//prepare and return outputs
-			return SparkUtils.fromIndexedMatrixBlock(out);
+			return SparkUtils.fromIndexedMatrixBlock(out).iterator();
 		}
 	}
 	
@@ -654,7 +655,7 @@ public class ParameterizedBuiltinSPInstruction  extends ComputationSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0)
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0)
 			throws Exception 
 		{
 			//get all inputs
@@ -668,7 +669,7 @@ public class ParameterizedBuiltinSPInstruction  extends ComputationSPInstruction
 			OperationsOnMatrixValues.performMapGroupedAggregate(_op, in1, groups, _ngroups, _brlen, _bclen, outlist);
 			
 			//output all result blocks
-			return SparkUtils.fromIndexedMatrixBlock(outlist);
+			return SparkUtils.fromIndexedMatrixBlock(outlist).iterator();
 		}
 	}
 	

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/PmmSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/PmmSPInstruction.java
@@ -21,6 +21,7 @@ package org.apache.sysml.runtime.instructions.spark;
 
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
@@ -143,7 +144,7 @@ public class PmmSPInstruction extends BinarySPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
 			throws Exception 
 		{
 			ArrayList<Tuple2<MatrixIndexes,MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes,MatrixBlock>>();
@@ -183,7 +184,7 @@ public class PmmSPInstruction extends BinarySPInstruction
 					ret.add(new Tuple2<MatrixIndexes, MatrixBlock>(new MatrixIndexes(rowIX2, ixIn.getColumnIndex()), out2));
 			}
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 	

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/QuaternarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/QuaternarySPInstruction.java
@@ -395,7 +395,7 @@ public class QuaternarySPInstruction extends ComputationSPInstruction
 		}
 	
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg)
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg)
 			throws Exception 
 		{
 			return new RDDQuaternaryPartitionIterator(arg);
@@ -575,7 +575,7 @@ public class QuaternarySPInstruction extends ComputationSPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
 			throws Exception 
 		{
 			LinkedList<Tuple2<MatrixIndexes, MatrixBlock>> ret = new LinkedList<Tuple2<MatrixIndexes, MatrixBlock>>();
@@ -606,7 +606,7 @@ public class QuaternarySPInstruction extends ComputationSPInstruction
 			}
 			
 			//output list of new tuples
-			return ret;
+			return ret.iterator();
 		}
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/RandSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/RandSPInstruction.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.Random;
 
 import org.apache.commons.math3.distribution.PoissonDistribution;
@@ -646,7 +647,7 @@ public class RandSPInstruction extends UnarySPInstruction
 		}
 		
 		@Override
-		public Iterable<Double> call(SampleTask t)
+		public Iterator<Double> call(SampleTask t)
 				throws Exception {
 
 			long st = t.range_start;
@@ -680,7 +681,7 @@ public class RandSPInstruction extends UnarySPInstruction
 							retList.add((double) i);
 				}
 			}
-			return retList;
+			return retList.iterator();
 		}
 	}
 	

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/ReorgSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/ReorgSPInstruction.java
@@ -20,6 +20,7 @@
 package org.apache.sysml.runtime.instructions.spark;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.function.Function;
@@ -247,7 +248,7 @@ public class ReorgSPInstruction extends UnarySPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
 			throws Exception 
 		{
 			ArrayList<Tuple2<MatrixIndexes, MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes,MatrixBlock>>();
@@ -272,7 +273,7 @@ public class ReorgSPInstruction extends UnarySPInstruction
 				}
 			}
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 	
@@ -292,7 +293,7 @@ public class ReorgSPInstruction extends UnarySPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
 			throws Exception 
 		{
 			//construct input
@@ -303,7 +304,7 @@ public class ReorgSPInstruction extends UnarySPInstruction
 			LibMatrixReorg.rev(in, _mcIn.getRows(), _mcIn.getRowsPerBlock(), out);
 			
 			//construct output
-			return SparkUtils.fromIndexedMatrixBlock(out);
+			return SparkUtils.fromIndexedMatrixBlock(out).iterator();
 		}
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/RmmSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/RmmSPInstruction.java
@@ -20,6 +20,7 @@
 package org.apache.sysml.runtime.instructions.spark;
 
 
+import java.util.Iterator;
 import java.util.LinkedList;
 
 import org.apache.spark.api.java.JavaPairRDD;
@@ -132,7 +133,7 @@ public class RmmSPInstruction extends BinarySPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<TripleIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
+		public Iterator<Tuple2<TripleIndexes, MatrixBlock>> call( Tuple2<MatrixIndexes, MatrixBlock> arg0 ) 
 			throws Exception 
 		{
 			LinkedList<Tuple2<TripleIndexes, MatrixBlock>> ret = new LinkedList<Tuple2<TripleIndexes, MatrixBlock>>();
@@ -165,7 +166,7 @@ public class RmmSPInstruction extends BinarySPInstruction
 			}
 			
 			//output list of new tuples
-			return ret;
+			return ret.iterator();
 		}
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/TernarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/TernarySPInstruction.java
@@ -20,6 +20,7 @@
 package org.apache.sysml.runtime.instructions.spark;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.function.Function;
@@ -267,7 +268,7 @@ public class TernarySPInstruction extends ComputationSPInstruction
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, Double>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) 
+		public Iterator<Tuple2<MatrixIndexes, Double>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) 
 			throws Exception 
 		{
 			MatrixIndexes ix = arg0._1();
@@ -288,7 +289,7 @@ public class TernarySPInstruction extends ComputationSPInstruction
 					retVal.add(new Tuple2<MatrixIndexes,Double>(p.getKey(), p.getValue()));
 			}
 			
-			return retVal;
+			return retVal.iterator();
 		}
 	}
 	
@@ -469,7 +470,7 @@ public class TernarySPInstruction extends ComputationSPInstruction
 		
 		@SuppressWarnings("deprecation")
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, Double>> call(CTableMap ctableMap)
+		public Iterator<Tuple2<MatrixIndexes, Double>> call(CTableMap ctableMap)
 				throws Exception {
 			ArrayList<Tuple2<MatrixIndexes, Double>> retVal = new ArrayList<Tuple2<MatrixIndexes, Double>>();
 			
@@ -481,7 +482,7 @@ public class TernarySPInstruction extends ComputationSPInstruction
 				// retVal.add(new Tuple2<MatrixIndexes, MatrixCell>(blockIndexes, cell));
 				retVal.add(new Tuple2<MatrixIndexes, Double>(new MatrixIndexes(i, j), v));
 			}
-			return retVal;
+			return retVal.iterator();
 		}
 		
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/UaggOuterChainSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/UaggOuterChainSPInstruction.java
@@ -271,7 +271,7 @@ public class UaggOuterChainSPInstruction extends BinarySPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0)
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0)
 			throws Exception 
 		{
 			return new RDDMapUAggOuterChainIterator(arg0);	
@@ -346,7 +346,7 @@ public class UaggOuterChainSPInstruction extends BinarySPInstruction
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg)
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg)
 			throws Exception 
 		{
 			return new RDDMapGenUAggOuterChainIterator(arg);

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/ConvertFrameBlockToIJVLines.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/ConvertFrameBlockToIJVLines.java
@@ -32,7 +32,7 @@ public class ConvertFrameBlockToIJVLines implements FlatMapFunction<Tuple2<Long,
 	private static final long serialVersionUID = 1803516615963340115L;
 
 	@Override
-	public Iterable<String> call(Tuple2<Long, FrameBlock> kv) 
+	public Iterator<String> call(Tuple2<Long, FrameBlock> kv) 
 		throws Exception 
 	{
 		long rowoffset = kv._1;
@@ -68,6 +68,6 @@ public class ConvertFrameBlockToIJVLines implements FlatMapFunction<Tuple2<Long,
 			}
 		}
 		
-		return cells;
+		return cells.iterator();
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/ConvertMatrixBlockToIJVLines.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/ConvertMatrixBlockToIJVLines.java
@@ -39,12 +39,12 @@ public class ConvertMatrixBlockToIJVLines implements FlatMapFunction<Tuple2<Matr
 	}
 	
 	@Override
-	public Iterable<String> call(Tuple2<MatrixIndexes, MatrixBlock> kv) throws Exception {
+	public Iterator<String> call(Tuple2<MatrixIndexes, MatrixBlock> kv) throws Exception {
 		final BinaryBlockToTextCellConverter converter = new BinaryBlockToTextCellConverter();
 		converter.setBlockSize(brlen, bclen);
 		converter.convert(kv._1, kv._2);
 		
-		return new Iterable<String>() {
+		Iterable<String> ret = new Iterable<String>() {
 			@Override
 			public Iterator<String> iterator() {
 				return new Iterator<String>() {
@@ -64,6 +64,8 @@ public class ConvertMatrixBlockToIJVLines implements FlatMapFunction<Tuple2<Matr
 				};
 			}
 		};
+		
+		return ret.iterator();
 	}
 
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/ExtractBlockForBinaryReblock.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/ExtractBlockForBinaryReblock.java
@@ -20,6 +20,7 @@
 package org.apache.sysml.runtime.instructions.spark.functions;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 
@@ -60,7 +61,7 @@ public class ExtractBlockForBinaryReblock implements PairFlatMapFunction<Tuple2<
 	}
 	
 	@Override
-	public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) 
+	public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) 
 		throws Exception 
 	{
 		MatrixIndexes ixIn = arg0._1();
@@ -107,7 +108,7 @@ public class ExtractBlockForBinaryReblock implements PairFlatMapFunction<Tuple2<
 				retVal.add(new Tuple2<MatrixIndexes, MatrixBlock>(indx, blk));
 			}
 		}
-		return retVal;
+		return retVal.iterator();
 	}
 	
 	/**

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/ExtractGroup.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/ExtractGroup.java
@@ -21,6 +21,7 @@ package org.apache.sysml.runtime.instructions.spark.functions;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 
@@ -57,7 +58,7 @@ public abstract class ExtractGroup implements Serializable
 	 * @return
 	 * @throws Exception 
 	 */
-	protected Iterable<Tuple2<MatrixIndexes, WeightedCell>> execute(MatrixIndexes ix, MatrixBlock group, MatrixBlock target) throws Exception
+	protected Iterator<Tuple2<MatrixIndexes, WeightedCell>> execute(MatrixIndexes ix, MatrixBlock group, MatrixBlock target) throws Exception
 	{
 		//sanity check matching block dimensions
 		if(group.getNumRows() != target.getNumRows()) {
@@ -105,7 +106,7 @@ public abstract class ExtractGroup implements Serializable
 			}
 		}
 		
-		return groupValuePairs;	
+		return groupValuePairs.iterator();	
 	}
 	
 	/**
@@ -120,7 +121,7 @@ public abstract class ExtractGroup implements Serializable
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, WeightedCell>> call(
+		public Iterator<Tuple2<MatrixIndexes, WeightedCell>> call(
 				Tuple2<MatrixIndexes, Tuple2<MatrixBlock, MatrixBlock>> arg)
 				throws Exception 
 		{
@@ -147,7 +148,7 @@ public abstract class ExtractGroup implements Serializable
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, WeightedCell>> call(
+		public Iterator<Tuple2<MatrixIndexes, WeightedCell>> call(
 				Tuple2<MatrixIndexes, MatrixBlock> arg)
 				throws Exception 
 		{

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/ExtractGroupNWeights.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/ExtractGroupNWeights.java
@@ -20,6 +20,7 @@
 package org.apache.sysml.runtime.instructions.spark.functions;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 
@@ -35,7 +36,7 @@ public class ExtractGroupNWeights implements PairFlatMapFunction<Tuple2<MatrixIn
 	private static final long serialVersionUID = -188180042997588072L;
 
 	@Override
-	public Iterable<Tuple2<MatrixIndexes, WeightedCell>> call(
+	public Iterator<Tuple2<MatrixIndexes, WeightedCell>> call(
 			Tuple2<MatrixIndexes, Tuple2<Tuple2<MatrixBlock, MatrixBlock>, MatrixBlock>> arg)
 		throws Exception 
 	{
@@ -62,6 +63,6 @@ public class ExtractGroupNWeights implements PairFlatMapFunction<Tuple2<MatrixIn
 			groupValuePairs.add(new Tuple2<MatrixIndexes, WeightedCell>(ix, weightedCell));
 		}
 		
-		return groupValuePairs;
+		return groupValuePairs.iterator();
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/MatrixVectorBinaryOpPartitionFunction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/MatrixVectorBinaryOpPartitionFunction.java
@@ -48,7 +48,7 @@ public class MatrixVectorBinaryOpPartitionFunction implements PairFlatMapFunctio
 	}
 
 	@Override
-	public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0) 
+	public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0) 
 		throws Exception 
 	{
 		return new MapBinaryPartitionIterator( arg0 );

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/OuterVectorBinaryOpFunction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/OuterVectorBinaryOpFunction.java
@@ -44,7 +44,7 @@ public class OuterVectorBinaryOpFunction implements PairFlatMapFunction<Tuple2<M
 	}
 
 	@Override
-	public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) 
+	public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) 
 		throws Exception 
 	{
 		return new OuterVectorBinaryOpIterator(arg0);

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/ReplicateVectorFunction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/ReplicateVectorFunction.java
@@ -20,6 +20,7 @@
 package org.apache.sysml.runtime.instructions.spark.functions;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 
@@ -44,7 +45,7 @@ public class ReplicateVectorFunction implements PairFlatMapFunction<Tuple2<Matri
 	}
 	
 	@Override
-	public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) 
+	public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) 
 		throws Exception 
 	{
 		MatrixIndexes ix = arg0._1();
@@ -66,6 +67,6 @@ public class ReplicateVectorFunction implements PairFlatMapFunction<Tuple2<Matri
 				retVal.add(new Tuple2<MatrixIndexes, MatrixBlock>(new MatrixIndexes(ix.getRowIndex(), i), mb));
 		}
 		
-		return retVal;
+		return retVal.iterator();
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/SparkListener.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/SparkListener.java
@@ -172,8 +172,9 @@ public class SparkListener extends RDDOperationGraphListener {
 		
 		synchronized(currentInstructions) {
 			if(stageTaskMapping.containsKey(stageID)) {
-				Option<String> errorMessage = Option.apply(null); // TODO
-				TaskUIData taskData = new TaskUIData(taskEnd.taskInfo(), Option.apply(taskEnd.taskMetrics()), errorMessage);
+				//<String> errorMessage = Option.apply(null); // TODO
+				//TaskUIData taskData = new TaskUIData(taskEnd.taskInfo(), Option.apply(taskEnd.taskMetrics()), errorMessage);
+				TaskUIData taskData = new TaskUIData(taskEnd.taskInfo(), null);
 				stageTaskMapping.get(stageID).add(taskData);
 			}
 			else {

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtils.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtils.java
@@ -266,7 +266,7 @@ public class RDDConverterUtils
 		private static final long serialVersionUID = -6590259914203201585L;
 
 		@Override
-		public Iterable<LabeledPoint> call(MatrixBlock arg0) 
+		public Iterator<LabeledPoint> call(MatrixBlock arg0) 
 			throws Exception 
 		{
 			ArrayList<LabeledPoint> ret = new ArrayList<LabeledPoint>();
@@ -290,7 +290,7 @@ public class RDDConverterUtils
 				}
 			}
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 	
@@ -351,7 +351,7 @@ public class RDDConverterUtils
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Text> arg0) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Text> arg0) 
 			throws Exception 
 		{
 			ArrayList<Tuple2<MatrixIndexes,MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes,MatrixBlock>>();
@@ -382,7 +382,7 @@ public class RDDConverterUtils
 			//final flush buffer
 			flushBufferToList(rbuff, ret);
 		
-			return ret;
+			return ret.iterator();
 		}
 	}
 	
@@ -432,7 +432,7 @@ public class RDDConverterUtils
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes,MatrixCell>> arg0) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<MatrixIndexes,MatrixCell>> arg0) 
 			throws Exception 
 		{
 			ArrayList<Tuple2<MatrixIndexes,MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes,MatrixBlock>>();
@@ -459,7 +459,7 @@ public class RDDConverterUtils
 			//final flush buffer
 			flushBufferToList(rbuff, ret);
 		
-			return ret;
+			return ret.iterator();
 		}
 	}
 	
@@ -538,7 +538,7 @@ public class RDDConverterUtils
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<Text,Long>> arg0) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<Text,Long>> arg0) 
 			throws Exception 
 		{
 			ArrayList<Tuple2<MatrixIndexes,MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes,MatrixBlock>>();
@@ -586,7 +586,7 @@ public class RDDConverterUtils
 			//flush last blocks
 			flushBlocksToList(ix, mb, ret);
 		
-			return ret;
+			return ret.iterator();
 		}
 		
 		// Creates new state of empty column blocks for current global row index.
@@ -631,7 +631,7 @@ public class RDDConverterUtils
 		}
 
 		@Override
-		public Iterable<String> call(Tuple2<MatrixIndexes, MatrixBlock> arg0)
+		public Iterator<String> call(Tuple2<MatrixIndexes, MatrixBlock> arg0)
 			throws Exception 
 		{
 			MatrixIndexes ix = arg0._1();
@@ -664,7 +664,7 @@ public class RDDConverterUtils
 	    		sb.setLength(0); //reset
     		}
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 	
@@ -682,7 +682,7 @@ public class RDDConverterUtils
 		}
 		
 		@Override
-		public Iterable<Tuple2<Long,Tuple2<Long,MatrixBlock>>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) 
+		public Iterator<Tuple2<Long, Tuple2<Long, MatrixBlock>>> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) 
 			throws Exception 
 		{
 			ArrayList<Tuple2<Long,Tuple2<Long,MatrixBlock>>> ret = 
@@ -698,7 +698,7 @@ public class RDDConverterUtils
 						new Tuple2<Long,MatrixBlock>(ix.getColumnIndex(),tmpBlk)));
 			}
 			
-			return ret;
+			return ret.iterator();
 		}
 		
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
@@ -39,7 +39,8 @@ import org.apache.spark.mllib.linalg.Vector;
 import org.apache.spark.mllib.linalg.VectorUDT;
 import org.apache.spark.mllib.linalg.distributed.CoordinateMatrix;
 import org.apache.spark.mllib.linalg.distributed.MatrixEntry;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SQLContext;
@@ -141,19 +142,19 @@ public class RDDConverterUtilsExt
 	}
 	
 	public static JavaPairRDD<MatrixIndexes, MatrixBlock> vectorDataFrameToBinaryBlock(SparkContext sc,
-			DataFrame inputDF, MatrixCharacteristics mcOut, boolean containsID, String vectorColumnName) throws DMLRuntimeException {
+			Dataset<Row> inputDF, MatrixCharacteristics mcOut, boolean containsID, String vectorColumnName) throws DMLRuntimeException {
 		return vectorDataFrameToBinaryBlock(new JavaSparkContext(sc), inputDF, mcOut, containsID, vectorColumnName);
 	}
 	
 	public static JavaPairRDD<MatrixIndexes, MatrixBlock> vectorDataFrameToBinaryBlock(JavaSparkContext sc,
-			DataFrame inputDF, MatrixCharacteristics mcOut, boolean containsID, String vectorColumnName)
+			Dataset<Row> inputDF, MatrixCharacteristics mcOut, boolean containsID, String vectorColumnName)
 			throws DMLRuntimeException {
 		
 		if(containsID) {
 			inputDF = dropColumn(inputDF.sort("ID"), "ID");
 		}
 		
-		DataFrame df = inputDF.select(vectorColumnName);
+		Dataset<Row> df = inputDF.select(vectorColumnName);
 			
 		//determine unknown dimensions and sparsity if required
 		if( !mcOut.dimsKnown(true) ) {
@@ -186,7 +187,7 @@ public class RDDConverterUtilsExt
 	 * @return
 	 * @throws DMLRuntimeException
 	 */
-	public static DataFrame dropColumn(DataFrame df, String column) throws DMLRuntimeException {
+	public static Dataset<Row> dropColumn(Dataset<Row> df, String column) throws DMLRuntimeException {
 		ArrayList<String> columnToSelect = new ArrayList<String>();
 		String firstCol = null;
 		boolean colPresent = false;
@@ -213,7 +214,7 @@ public class RDDConverterUtilsExt
 		return df.select(firstCol, scala.collection.JavaConversions.asScalaBuffer(columnToSelect).toList());
 	}
 	
-	public static DataFrame projectColumns(DataFrame df, ArrayList<String> columns) throws DMLRuntimeException {
+	public static Dataset<Row> projectColumns(Dataset<Row> df, ArrayList<String> columns) throws DMLRuntimeException {
 		ArrayList<String> columnToSelect = new ArrayList<String>();
 		for(int i = 1; i < columns.size(); i++) {
 			columnToSelect.add(columns.get(i));
@@ -222,41 +223,41 @@ public class RDDConverterUtilsExt
 	}
 	
 	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlock(SparkContext sc,
-			DataFrame df, MatrixCharacteristics mcOut, boolean containsID) throws DMLRuntimeException {
+			Dataset<Row> df, MatrixCharacteristics mcOut, boolean containsID) throws DMLRuntimeException {
 		return dataFrameToBinaryBlock(new JavaSparkContext(sc), df, mcOut, containsID, null);
 	}
 	
 	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlock(SparkContext sc,
-			DataFrame df, MatrixCharacteristics mcOut, String [] columns) throws DMLRuntimeException {
+			Dataset<Row> df, MatrixCharacteristics mcOut, String [] columns) throws DMLRuntimeException {
 		ArrayList<String> columns1 = new ArrayList<String>(Arrays.asList(columns));
 		return dataFrameToBinaryBlock(new JavaSparkContext(sc), df, mcOut, false, columns1);
 	}
 	
 	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlock(SparkContext sc,
-			DataFrame df, MatrixCharacteristics mcOut, ArrayList<String> columns) throws DMLRuntimeException {
+			Dataset<Row> df, MatrixCharacteristics mcOut, ArrayList<String> columns) throws DMLRuntimeException {
 		return dataFrameToBinaryBlock(new JavaSparkContext(sc), df, mcOut, false, columns);
 	}
 	
 	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlock(SparkContext sc,
-			DataFrame df, MatrixCharacteristics mcOut, boolean containsID, String [] columns) 
+			Dataset<Row> df, MatrixCharacteristics mcOut, boolean containsID, String [] columns) 
 			throws DMLRuntimeException {
 		ArrayList<String> columns1 = new ArrayList<String>(Arrays.asList(columns));
 		return dataFrameToBinaryBlock(new JavaSparkContext(sc), df, mcOut, containsID, columns1);
 	}
 	
 	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlock(SparkContext sc,
-			DataFrame df, MatrixCharacteristics mcOut, boolean containsID, ArrayList<String> columns) 
+			Dataset<Row> df, MatrixCharacteristics mcOut, boolean containsID, ArrayList<String> columns) 
 			throws DMLRuntimeException {
 		return dataFrameToBinaryBlock(new JavaSparkContext(sc), df, mcOut, containsID, columns);
 	}
 	
 	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlock(JavaSparkContext sc,
-			DataFrame df, MatrixCharacteristics mcOut, boolean containsID) throws DMLRuntimeException {
+			Dataset<Row> df, MatrixCharacteristics mcOut, boolean containsID) throws DMLRuntimeException {
 		return dataFrameToBinaryBlock(sc, df, mcOut, containsID, null);
 	}
 	
 	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlock(JavaSparkContext sc,
-			DataFrame df, MatrixCharacteristics mcOut, ArrayList<String> columns) throws DMLRuntimeException {
+			Dataset<Row> df, MatrixCharacteristics mcOut, ArrayList<String> columns) throws DMLRuntimeException {
 		return dataFrameToBinaryBlock(sc, df, mcOut, false, columns);
 	}
 	
@@ -272,7 +273,7 @@ public class RDDConverterUtilsExt
 	 * @throws DMLRuntimeException
 	 */
 	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlock(JavaSparkContext sc,
-			DataFrame df, MatrixCharacteristics mcOut, boolean containsID, ArrayList<String> columns) 
+			Dataset<Row> df, MatrixCharacteristics mcOut, boolean containsID, ArrayList<String> columns) 
 			throws DMLRuntimeException {
 		if(columns != null) {
 			df = projectColumns(df, columns);
@@ -306,7 +307,7 @@ public class RDDConverterUtilsExt
 		return out;
 	}
 	
-	public static DataFrame binaryBlockToVectorDataFrame(JavaPairRDD<MatrixIndexes, MatrixBlock> binaryBlockRDD, 
+	public static Dataset<Row> binaryBlockToVectorDataFrame(JavaPairRDD<MatrixIndexes, MatrixBlock> binaryBlockRDD, 
 			MatrixCharacteristics mc, SQLContext sqlContext) throws DMLRuntimeException {
 		long rlen = mc.getRows(); long clen = mc.getCols();
 		int brlen = mc.getRowsPerBlock(); int bclen = mc.getColsPerBlock();
@@ -328,7 +329,7 @@ public class RDDConverterUtilsExt
 		// This will cause infinite recursion due to bug in Spark
 		// https://issues.apache.org/jira/browse/SPARK-6999
 		// return sqlContext.createDataFrame(rowsRDD, colNames); // where ArrayList<String> colNames
-		return sqlContext.createDataFrame(rowsRDD.rdd(), DataTypes.createStructType(fields));
+		return RDDConverterUtilsExt.createDataFrame(sqlContext, rowsRDD.rdd(), DataTypes.createStructType(fields));
 	}
 	
 	public static class AddRowID implements Function<Tuple2<Row,Long>, Row> {
@@ -354,7 +355,7 @@ public class RDDConverterUtilsExt
 	 * @param nameOfCol name of index column
 	 * @return new data frame
 	 */
-	public static DataFrame addIDToDataFrame(DataFrame df, SQLContext sqlContext, String nameOfCol) {
+	public static Dataset<Row> addIDToDataFrame(Dataset<Row> df, SQLContext sqlContext, String nameOfCol) {
 		StructField[] oldSchema = df.schema().fields();
 		StructField[] newSchema = new StructField[oldSchema.length + 1];
 		for(int i = 0; i < oldSchema.length; i++) {
@@ -363,10 +364,11 @@ public class RDDConverterUtilsExt
 		newSchema[oldSchema.length] = DataTypes.createStructField(nameOfCol, DataTypes.DoubleType, false);
 		// JavaRDD<Row> newRows = df.rdd().toJavaRDD().map(new AddRowID());
 		JavaRDD<Row> newRows = df.rdd().toJavaRDD().zipWithIndex().map(new AddRowID());
-		return sqlContext.createDataFrame(newRows, new StructType(newSchema));
+		//return sqlContext.createDataFrame(newRows, new StructType(newSchema));
+		return RDDConverterUtilsExt.createDataFrame(sqlContext, newRows, new StructType(newSchema));
 	}
 	
-	public static DataFrame binaryBlockToDataFrame(JavaPairRDD<MatrixIndexes, MatrixBlock> binaryBlockRDD, 
+	public static Dataset<Row> binaryBlockToDataFrame(JavaPairRDD<MatrixIndexes, MatrixBlock> binaryBlockRDD, 
 			MatrixCharacteristics mc, SQLContext sqlContext) throws DMLRuntimeException {
 		long rlen = mc.getRows(); long clen = mc.getCols();
 		int brlen = mc.getRowsPerBlock(); int bclen = mc.getColsPerBlock();
@@ -391,7 +393,72 @@ public class RDDConverterUtilsExt
 		// This will cause infinite recursion due to bug in Spark
 		// https://issues.apache.org/jira/browse/SPARK-6999
 		// return sqlContext.createDataFrame(rowsRDD, colNames); // where ArrayList<String> colNames
-		return sqlContext.createDataFrame(rowsRDD.rdd(), DataTypes.createStructType(fields));
+		return RDDConverterUtilsExt.createDataFrame(sqlContext, rowsRDD.rdd(), DataTypes.createStructType(fields));
+	}
+	
+	/**
+	 * Wrapper for org.apache.spark.sql.SQLContext.createDataFrame
+	 * 
+	 * *** HACK ALERT *** HACK ALERT *** HACK ALERT ***
+	 * Work-around for Spark 2.0.0 uri syntax issue on Windows [SPARK-15893] [SPARK-15899]
+	 * 
+	 * @param sqlContext SQLContext
+	 * @param rowRDD RDD<Row>
+	 * @param schema org.apache.spark.sql.types.StructType
+	 * @return
+	 */
+	public static Dataset<Row> createDataFrame(SQLContext sqlContext, RDD<Row> rowRDD, StructType schema) {
+		String userDir = System.getProperty("user.dir");
+		boolean windows = System.getProperty("os.name").toLowerCase().contains("win");
+		if (windows) {
+			// Prevent java.net.URISyntaxException: Relative path in absolute URI
+			String uriDir = userDir.replace('\\', '/');
+			if (!uriDir.startsWith("/")) {
+				uriDir = "/" + uriDir;
+			}
+			System.setProperty("user.dir", uriDir);
+		}
+
+		Dataset<Row> df = sqlContext.createDataFrame(rowRDD, schema);
+		
+		if (windows) {
+			// Restore original value
+			System.setProperty("user.dir", userDir);
+		}
+
+		return df;
+	}
+	/**
+	 * Wrapper for org.apache.spark.sql.SQLContext.createDataFrame
+	 * 
+	 * *** HACK ALERT *** HACK ALERT *** HACK ALERT ***
+	 * Work-around for Spark 2.0.0 uri syntax issue on Windows [SPARK-15893] [SPARK-15899]
+	 * 
+	 * @param sqlContext SQLContext
+	 * @param rowRDD JavaRDD<Row>
+	 * @param schema org.apache.spark.sql.types.StructType
+	 * @return
+	 */
+	public static Dataset<Row> createDataFrame(SQLContext sqlContext, JavaRDD<Row> rowRDD, StructType schema) {
+		String userDir = System.getProperty("user.dir");
+		boolean windows = System.getProperty("os.name").toLowerCase().contains("win");
+		if (windows) {
+			// Prevent java.net.URISyntaxException: Relative path in absolute URI
+			String uriDir = userDir.replace('\\', '/');
+			if (!uriDir.startsWith("/")) {
+				uriDir = "/" + uriDir;
+			}
+			System.setProperty("user.dir", uriDir);
+		}
+
+		Dataset<Row> df = sqlContext.createDataFrame(rowRDD, schema);
+		
+		if (windows) {
+			// Restore original value
+			System.setProperty("user.dir", userDir);
+		}
+
+		return df;
 	}
 	
 	private static class MatrixEntryToBinaryBlockFunction implements PairFlatMapFunction<Iterator<MatrixEntry>,MatrixIndexes,MatrixBlock> 
@@ -404,7 +471,7 @@ public class RDDConverterUtilsExt
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<MatrixEntry> arg0) throws Exception {
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<MatrixEntry> arg0) throws Exception {
 			return helper.convertToBinaryBlock(arg0, RDDConverterTypes.MATRIXENTRY_TO_MATRIXCELL);
 		}
 
@@ -439,7 +506,7 @@ public class RDDConverterUtilsExt
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<Text, Long>> arg0) throws Exception {
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<Text, Long>> arg0) throws Exception {
 			return helper.convertToBinaryBlock(arg0, RDDConverterTypes.TEXT_TO_DOUBLEARR);
 		}
 		
@@ -456,7 +523,7 @@ public class RDDConverterUtilsExt
 		}
 		
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<Row, Long>> arg0) throws Exception {
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<Row, Long>> arg0) throws Exception {
 			if(isVectorBasedDF)
 				return helper.convertToBinaryBlock(arg0, RDDConverterTypes.VECTOR_TO_DOUBLEARR);
 			else
@@ -588,7 +655,7 @@ public class RDDConverterUtilsExt
 		
 		// ----------------------------------------------------
 		
-		Iterable<Tuple2<MatrixIndexes, MatrixBlock>> convertToBinaryBlock(Object arg0, RDDConverterTypes converter)  throws Exception {
+		Iterator<Tuple2<MatrixIndexes, MatrixBlock>> convertToBinaryBlock(Object arg0, RDDConverterTypes converter)  throws Exception {
 			ArrayList<Tuple2<MatrixIndexes,MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes,MatrixBlock>>();
 			ReblockBuffer rbuff = new ReblockBuffer(_bufflen, _rlen, _clen, _brlen, _bclen);
 		
@@ -623,7 +690,7 @@ public class RDDConverterUtilsExt
 			//final flush buffer
 			flushBufferToList(rbuff, ret);
 		
-			return ret;
+			return ret.iterator();
 		}
 		
 		/**
@@ -710,7 +777,7 @@ public class RDDConverterUtilsExt
 		}
 		// ----------------------------------------------------
 
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> convertToBinaryBlock(Object arg0, RDDConverterTypes converter) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> convertToBinaryBlock(Object arg0, RDDConverterTypes converter) 
 			throws Exception 
 		{
 			ArrayList<Tuple2<MatrixIndexes,MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes,MatrixBlock>>();
@@ -772,7 +839,7 @@ public class RDDConverterUtilsExt
 			//flush last blocks
 			flushBlocksToList(ix, mb, ret);
 		
-			return ret;
+			return ret.iterator();
 		}
 			
 		// Creates new state of empty column blocks for current global row index.

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDSortUtils.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDSortUtils.java
@@ -235,10 +235,10 @@ public class RDDSortUtils
 		private static final long serialVersionUID = 6888003502286282876L;
 
 		@Override
-		public Iterable<Double> call(MatrixBlock arg0) 
+		public Iterator<Double> call(MatrixBlock arg0) 
 			throws Exception 
 		{
-			return DataConverter.convertToDoubleList(arg0);
+			return DataConverter.convertToDoubleList(arg0).iterator();
 		}		
 	}
 
@@ -250,7 +250,7 @@ public class RDDSortUtils
 		private static final long serialVersionUID = 2132672563825289022L;
 
 		@Override
-		public Iterable<DoublePair> call(Tuple2<MatrixBlock,MatrixBlock> arg0) 
+		public Iterator<DoublePair> call(Tuple2<MatrixBlock,MatrixBlock> arg0) 
 			throws Exception 
 		{
 			ArrayList<DoublePair> ret = new ArrayList<DoublePair>(); 
@@ -263,7 +263,7 @@ public class RDDSortUtils
 						mb2.quickGetValue(i, 0)));
 			}
 			
-			return ret;
+			return ret.iterator();
 		}		
 	}
 	
@@ -279,7 +279,7 @@ public class RDDSortUtils
 		}
 		
 		@Override
-		public Iterable<Tuple2<ValueIndexPair,Double>> call(Tuple2<MatrixIndexes,MatrixBlock> arg0) 
+		public Iterator<Tuple2<ValueIndexPair, Double>> call(Tuple2<MatrixIndexes,MatrixBlock> arg0) 
 			throws Exception 
 		{
 			ArrayList<Tuple2<ValueIndexPair,Double>> ret = new ArrayList<Tuple2<ValueIndexPair,Double>>(); 
@@ -293,7 +293,7 @@ public class RDDSortUtils
 						new ValueIndexPair(val,ixoffset+i+1), val));
 			}
 			
-			return ret;
+			return ret.iterator();
 		}		
 	}
 	
@@ -359,7 +359,7 @@ public class RDDSortUtils
 			_brlen = brlen;
 		}
 		
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<Double,Long>> arg0) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<Double,Long>> arg0) 
 			throws Exception 
 		{
 			ArrayList<Tuple2<MatrixIndexes,MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes,MatrixBlock>>();
@@ -390,7 +390,7 @@ public class RDDSortUtils
 			if( mb!=null && mb.getNonZeros() != 0 )
 				ret.add(new Tuple2<MatrixIndexes,MatrixBlock>(ix,mb));
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 
@@ -410,7 +410,7 @@ public class RDDSortUtils
 			_brlen = brlen;
 		}
 		
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<DoublePair,Long>> arg0) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<DoublePair,Long>> arg0) 
 			throws Exception
 		{
 			ArrayList<Tuple2<MatrixIndexes,MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes,MatrixBlock>>();
@@ -442,7 +442,7 @@ public class RDDSortUtils
 			if( mb!=null && mb.getNonZeros() != 0 )
 				ret.add(new Tuple2<MatrixIndexes,MatrixBlock>(ix,mb));
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 	
@@ -462,7 +462,7 @@ public class RDDSortUtils
 			_brlen = brlen;
 		}
 		
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<ValueIndexPair,Long>> arg0) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<ValueIndexPair,Long>> arg0) 
 			throws Exception
 		{
 			ArrayList<Tuple2<MatrixIndexes,MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes,MatrixBlock>>();
@@ -493,7 +493,7 @@ public class RDDSortUtils
 			if( mb!=null && mb.getNonZeros() != 0 )
 				ret.add(new Tuple2<MatrixIndexes,MatrixBlock>(ix,mb));
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 	
@@ -513,7 +513,7 @@ public class RDDSortUtils
 			_brlen = brlen;
 		}
 		
-		public Iterable<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<Long,Long>> arg0) 
+		public Iterator<Tuple2<MatrixIndexes, MatrixBlock>> call(Iterator<Tuple2<Long,Long>> arg0) 
 			throws Exception
 		{
 			ArrayList<Tuple2<MatrixIndexes,MatrixBlock>> ret = new ArrayList<Tuple2<MatrixIndexes,MatrixBlock>>();
@@ -544,7 +544,7 @@ public class RDDSortUtils
 			if( mb!=null && mb.getNonZeros() != 0 )
 				ret.add(new Tuple2<MatrixIndexes,MatrixBlock>(ix,mb));
 			
-			return ret;
+			return ret.iterator();
 		}
 	}
 	
@@ -562,7 +562,7 @@ public class RDDSortUtils
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, RowMatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, Tuple2<MatrixBlock, MatrixBlock>>> arg0)
+		public Iterator<Tuple2<MatrixIndexes, RowMatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, Tuple2<MatrixBlock, MatrixBlock>>> arg0)
 			throws Exception 
 		{
 			return new ShuffleMatrixIterator(arg0);
@@ -651,7 +651,7 @@ public class RDDSortUtils
 		}
 
 		@Override
-		public Iterable<Tuple2<MatrixIndexes, RowMatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0)
+		public Iterator<Tuple2<MatrixIndexes, RowMatrixBlock>> call(Iterator<Tuple2<MatrixIndexes, MatrixBlock>> arg0)
 			throws Exception 
 		{
 			return new ShuffleMatrixIterator(arg0);

--- a/src/main/java/org/apache/sysml/runtime/transform/GenTfMtdSPARK.java
+++ b/src/main/java/org/apache/sysml/runtime/transform/GenTfMtdSPARK.java
@@ -161,7 +161,7 @@ public class GenTfMtdSPARK
 
 		@SuppressWarnings("unchecked")
 		@Override
-		public Iterable<Long> call(Tuple2<Integer, Iterable<DistinctValue>> t)
+		public Iterator<Long> call(Tuple2<Integer, Iterable<DistinctValue>> t)
 				throws Exception {
 			
 			int colID = t._1();
@@ -210,7 +210,7 @@ public class GenTfMtdSPARK
 				numRows.add(0L);
 			}
 			
-			return numRows;
+			return numRows.iterator();
 		}
 	}
 	

--- a/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
@@ -47,7 +47,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.rdd.RDD;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SQLContext;
@@ -64,6 +64,7 @@ import org.apache.sysml.api.mlcontext.MatrixMetadata;
 import org.apache.sysml.api.mlcontext.Script;
 import org.apache.sysml.api.mlcontext.ScriptExecutor;
 import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
+import org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt;
 import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.junit.After;
 import org.junit.Assert;
@@ -511,7 +512,7 @@ public class MLContextTest extends AutomatedTestBase {
 		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
 		StructType schema = DataTypes.createStructType(fields);
-		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
+		Dataset<Row> dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
 		Script script = dml("print('sum: ' + sum(M));").in("M", dataFrame);
 		setExpectedStdOut("sum: 450.0");
@@ -535,7 +536,7 @@ public class MLContextTest extends AutomatedTestBase {
 		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
 		StructType schema = DataTypes.createStructType(fields);
-		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
+		Dataset<Row> dataFrame = RDDConverterUtilsExt.createDataFrame(sqlContext, javaRddRow, schema);
 
 		Script script = pydml("print('sum: ' + sum(M))").in("M", dataFrame);
 		setExpectedStdOut("sum: 450.0");
@@ -996,7 +997,7 @@ public class MLContextTest extends AutomatedTestBase {
 		String s = "M = matrix('1 2 3 4', rows=2, cols=2);";
 		Script script = dml(s).out("M");
 		MLResults results = ml.execute(script);
-		DataFrame dataFrame = results.getDataFrame("M");
+		Dataset<Row> dataFrame = results.getDataFrame("M");
 		List<Row> list = dataFrame.collectAsList();
 		Row row1 = list.get(0);
 		Assert.assertEquals(0.0, row1.getDouble(0), 0.0);
@@ -1016,7 +1017,7 @@ public class MLContextTest extends AutomatedTestBase {
 		String s = "M = full('1 2 3 4', rows=2, cols=2)";
 		Script script = pydml(s).out("M");
 		MLResults results = ml.execute(script);
-		DataFrame dataFrame = results.getDataFrame("M");
+		Dataset<Row> dataFrame = results.getDataFrame("M");
 		List<Row> list = dataFrame.collectAsList();
 		Row row1 = list.get(0);
 		Assert.assertEquals(0.0, row1.getDouble(0), 0.0);
@@ -1188,7 +1189,7 @@ public class MLContextTest extends AutomatedTestBase {
 		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
 		StructType schema = DataTypes.createStructType(fields);
-		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
+		Dataset<Row> dataFrame = RDDConverterUtilsExt.createDataFrame(sqlContext, javaRddRow, schema);
 
 		BinaryBlockMatrix binaryBlockMatrix = new BinaryBlockMatrix(dataFrame);
 		Script script = dml("avg = avg(M);").in("M", binaryBlockMatrix).out("avg");
@@ -1213,7 +1214,7 @@ public class MLContextTest extends AutomatedTestBase {
 		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
 		StructType schema = DataTypes.createStructType(fields);
-		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
+		Dataset<Row> dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
 		BinaryBlockMatrix binaryBlockMatrix = new BinaryBlockMatrix(dataFrame);
 		Script script = pydml("avg = avg(M)").in("M", binaryBlockMatrix).out("avg");
@@ -1482,7 +1483,7 @@ public class MLContextTest extends AutomatedTestBase {
 		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
 		StructType schema = DataTypes.createStructType(fields);
-		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
+		Dataset<Row> dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
 		MatrixMetadata mm = new MatrixMetadata(3, 3, 9);
 
@@ -1508,7 +1509,7 @@ public class MLContextTest extends AutomatedTestBase {
 		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
 		StructType schema = DataTypes.createStructType(fields);
-		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
+		Dataset<Row> dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
 		MatrixMetadata mm = new MatrixMetadata(3, 3, 9);
 

--- a/src/test/scala/org/apache/sysml/api/ml/LogisticRegressionSuite.scala
+++ b/src/test/scala/org/apache/sysml/api/ml/LogisticRegressionSuite.scala
@@ -21,7 +21,7 @@ package org.apache.sysml.api.ml
 
 import org.scalatest.FunSuite
 import org.scalatest.Matchers
-import org.apache.spark.Logging
+
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.ml.Pipeline
@@ -34,7 +34,7 @@ import scala.reflect.runtime.universe._
 case class LabeledDocument[T:TypeTag](id: Long, text: String, label: Double)
 case class Document[T:TypeTag](id: Long, text: String)
 
-class LogisticRegressionSuite extends FunSuite with WrapperSparkContext with Matchers with Logging {
+class LogisticRegressionSuite extends FunSuite with WrapperSparkContext with Matchers {
 
   // Note: This is required by every test to ensure that it runs successfully on windows laptop !!!
   val loadConfig = ScalaAutomatedTestBase


### PR DESCRIPTION
Updated Runtime, API, and Test components to be compatible with Spark 2.0.0.  The primary code changes and related Spark JIRAs are as follows.

1) DataFrame -> Dataset<Row>
[SPARK-13244 Unify DataFrame and Dataset API](https://issues.apache.org/jira/browse/SPARK-13244)

2) Iterable -> Iterator
[SPARK-3369 Java mapPartitions Iterator->Iterable is inconsistent with Scala's Iterator->Iterator](https://issues.apache.org/jira/browse/SPARK-3369)

3) DataFrame -> Dataset[_]
[SPARK-14500](https://issues.apache.org/jira/browse/SPARK-14500) Accept Dataset[_] instead of DataFrame in MLlib APIs

4) spark.mllib.linalg -> spark.ml.linalg
[SPARK-13944 Separate out local linear algebra as a standalone module without Spark dependency](https://issues.apache.org/jira/browse/SPARK-13944)

Additional changes were also required due to following JIRAs:
[SPARK-12600 Remove deprecated methods in SQL / DataFrames](https://issues.apache.org/jira/browse/SPARK-12600)
[SPARK-14625 TaskUIData and ExecutorUIData shouldn't be case classes](https://issues.apache.org/jira/browse/SPARK-14625)
[SPARK-13928 Move org.apache.spark.Logging into org.apache.spark.internal.Logging](https://issues.apache.org/jira/browse/SPARK-13928)

Note a work-around was also implemented where Spark 2.0.0 introduced a defect when run on Windows:
[SPARK-15893 spark.createDataFrame raises an exception in Spark 2.0 tests on Windows](https://issues.apache.org/jira/browse/SPARK-15893)
[SPARK-15899 file scheme should be used correctly](https://issues.apache.org/jira/browse/SPARK-15899)

Additional information on Spark 2.0.0 including removals and behavior changes can be found in [release notes](http://spark.apache.org/releases/spark-release-2-0-0.html#removals).
