### PR TITLE
[SYSTEMML-234] [SYSTEMML-208] Added mllearn library to support scikit-learn and MLPipeline

### DIFF
--- a/docs/algorithms-classification.md
+++ b/docs/algorithms-classification.md
@@ -128,6 +128,7 @@ Eqs. (1) and (2).
 
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
+{% highlight python %}
 import SystemML as sml
 # C = 1/reg
 logistic = sml.mllearn.LogisticRegression(sqlCtx, fit_intercept=True, max_iter=100, max_inner_iter=0, tol=0.000001, C=1.0)
@@ -135,6 +136,7 @@ logistic = sml.mllearn.LogisticRegression(sqlCtx, fit_intercept=True, max_iter=1
 y_test = logistic.fit(X_train, y_train).predict(X_test)
 # df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
 y_test = logistic.fit(df_train).transform(df_test)
+{% endhighlight %}
 </div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f MultiLogReg.dml
@@ -224,6 +226,7 @@ SystemML Language Reference for details.
 
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
+{% highlight python %}
 # Scikit-learn way
 from sklearn import datasets, neighbors
 import SystemML as sml
@@ -272,6 +275,7 @@ test = sqlCtx.createDataFrame([
     (15L, "apache hadoop")], ["id", "text"])
 prediction = model.transform(test)
 prediction.show()
+{% endhighlight %}
 </div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f MultiLogReg.dml
@@ -453,6 +457,7 @@ support vector machine (`y` with domain size `2`).
 
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
+{% highlight python %}
 import SystemML as sml
 # C = 1/reg
 svm = sml.mllearn.SVM(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, is_multi_class=False)
@@ -460,6 +465,7 @@ svm = sml.mllearn.SVM(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=
 y_test = svm.fit(X_train, y_train)
 # df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
 y_test = svm.fit(df_train)
+{% endhighlight %}
 </div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f l2-svm.dml
@@ -497,10 +503,12 @@ y_test = svm.fit(df_train)
 
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
+{% highlight python %}
 # X_test can be NumPy matrices or Pandas DataFrame
 y_test = svm.predict(X_test)
 # df_test is a DataFrame that contains the column "features" of type Vector
 y_test = svm.transform(df_test)
+{% endhighlight %}
 </div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f l2-svm-predict.dml
@@ -705,6 +713,7 @@ class labels.
 
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
+{% highlight python %}
 import SystemML as sml
 # C = 1/reg
 svm = sml.mllearn.SVM(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, is_multi_class=True)
@@ -712,6 +721,7 @@ svm = sml.mllearn.SVM(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=
 y_test = svm.fit(X_train, y_train)
 # df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
 y_test = svm.fit(df_train)
+{% endhighlight %}
 </div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f m-svm.dml
@@ -749,10 +759,12 @@ y_test = svm.fit(df_train)
 
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
+{% highlight python %}
 # X_test can be NumPy matrices or Pandas DataFrame
 y_test = svm.predict(X_test)
 # df_test is a DataFrame that contains the column "features" of type Vector
 y_test = svm.transform(df_test)
+{% endhighlight %}
 </div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f m-svm-predict.dml
@@ -837,6 +849,7 @@ SystemML Language Reference for details.
 
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
+{% highlight python %}
 # Scikit-learn way
 from sklearn import datasets, neighbors
 import SystemML as sml
@@ -885,6 +898,7 @@ test = sqlCtx.createDataFrame([
     (15L, "apache hadoop")], ["id", "text"])
 prediction = model.transform(test)
 prediction.show()
+{% endhighlight %}
 </div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f m-svm.dml

--- a/docs/algorithms-classification.md
+++ b/docs/algorithms-classification.md
@@ -127,6 +127,15 @@ Eqs. (1) and (2).
 ### Usage
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+import SystemML as sml
+# C = 1/reg
+logistic = sml.mllearn.LogisticRegression(sqlCtx, fit_intercept=True, max_iter=100, max_inner_iter=0, tol=0.000001, C=1.0)
+# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame
+y_test = logistic.fit(X_train, y_train).predict(X_test)
+# df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
+y_test = logistic.fit(df_train).transform(df_test)
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f MultiLogReg.dml
                             -nvargs X=<file>
@@ -214,6 +223,56 @@ SystemML Language Reference for details.
 ### Examples
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+# Scikit-learn way
+from sklearn import datasets, neighbors
+import SystemML as sml
+from pyspark.sql import SQLContext
+sqlCtx = SQLContext(sc)
+digits = datasets.load_digits()
+X_digits = digits.data
+y_digits = digits.target + 1
+n_samples = len(X_digits)
+X_train = X_digits[:.9 * n_samples]
+y_train = y_digits[:.9 * n_samples]
+X_test = X_digits[.9 * n_samples:]
+y_test = y_digits[.9 * n_samples:]
+logistic = sml.mllearn.LogisticRegression(sqlCtx)
+print('LogisticRegression score: %f' % logistic.fit(X_train, y_train).score(X_test, y_test))
+
+# MLPipeline way
+from pyspark.ml import Pipeline
+import SystemML as sml
+from pyspark.ml.feature import HashingTF, Tokenizer
+from pyspark.sql import SQLContext
+sqlCtx = SQLContext(sc)
+training = sqlCtx.createDataFrame([
+    (0L, "a b c d e spark", 1.0),
+    (1L, "b d", 2.0),
+    (2L, "spark f g h", 1.0),
+    (3L, "hadoop mapreduce", 2.0),
+    (4L, "b spark who", 1.0),
+    (5L, "g d a y", 2.0),
+    (6L, "spark fly", 1.0),
+    (7L, "was mapreduce", 2.0),
+    (8L, "e spark program", 1.0),
+    (9L, "a e c l", 2.0),
+    (10L, "spark compile", 1.0),
+    (11L, "hadoop software", 2.0)
+], ["id", "text", "label"])
+tokenizer = Tokenizer(inputCol="text", outputCol="words")
+hashingTF = HashingTF(inputCol="words", outputCol="features", numFeatures=20)
+lr = sml.mllearn.LogisticRegression(sqlCtx)
+pipeline = Pipeline(stages=[tokenizer, hashingTF, lr])
+model = pipeline.fit(training)
+test = sqlCtx.createDataFrame([
+    (12L, "spark i j k"),
+    (13L, "l m n"),
+    (14L, "mapreduce spark"),
+    (15L, "apache hadoop")], ["id", "text"])
+prediction = model.transform(test)
+prediction.show()
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f MultiLogReg.dml
                             -nvargs X=/user/ml/X.mtx
@@ -393,6 +452,15 @@ support vector machine (`y` with domain size `2`).
 **Binary-Class Support Vector Machines**:
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+import SystemML as sml
+# C = 1/reg
+svm = sml.mllearn.SVM(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, is_multi_class=False)
+# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame
+y_test = svm.fit(X_train, y_train)
+# df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
+y_test = svm.fit(df_train)
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f l2-svm.dml
                             -nvargs X=<file>
@@ -428,6 +496,12 @@ support vector machine (`y` with domain size `2`).
 **Binary-Class Support Vector Machines Prediction**:
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+# X_test can be NumPy matrices or Pandas DataFrame
+y_test = svm.predict(X_test)
+# df_test is a DataFrame that contains the column "features" of type Vector
+y_test = svm.transform(df_test)
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f l2-svm-predict.dml
                             -nvargs X=<file>
@@ -630,6 +704,15 @@ class labels.
 **Multi-Class Support Vector Machines**:
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+import SystemML as sml
+# C = 1/reg
+svm = sml.mllearn.SVM(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, is_multi_class=True)
+# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame
+y_test = svm.fit(X_train, y_train)
+# df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
+y_test = svm.fit(df_train)
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f m-svm.dml
                             -nvargs X=<file>
@@ -665,6 +748,12 @@ class labels.
 **Multi-Class Support Vector Machines Prediction**:
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+# X_test can be NumPy matrices or Pandas DataFrame
+y_test = svm.predict(X_test)
+# df_test is a DataFrame that contains the column "features" of type Vector
+y_test = svm.transform(df_test)
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f m-svm-predict.dml
                             -nvargs X=<file>
@@ -747,6 +836,56 @@ SystemML Language Reference for details.
 **Multi-Class Support Vector Machines**:
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+# Scikit-learn way
+from sklearn import datasets, neighbors
+import SystemML as sml
+from pyspark.sql import SQLContext
+sqlCtx = SQLContext(sc)
+digits = datasets.load_digits()
+X_digits = digits.data
+y_digits = digits.target 
+n_samples = len(X_digits)
+X_train = X_digits[:.9 * n_samples]
+y_train = y_digits[:.9 * n_samples]
+X_test = X_digits[.9 * n_samples:]
+y_test = y_digits[.9 * n_samples:]
+svm = sml.mllearn.SVM(sqlCtx, is_multi_class=True)
+print('LogisticRegression score: %f' % svm.fit(X_train, y_train).score(X_test, y_test))
+
+# MLPipeline way
+from pyspark.ml import Pipeline
+import SystemML as sml
+from pyspark.ml.feature import HashingTF, Tokenizer
+from pyspark.sql import SQLContext
+sqlCtx = SQLContext(sc)
+training = sqlCtx.createDataFrame([
+    (0L, "a b c d e spark", 1.0),
+    (1L, "b d", 2.0),
+    (2L, "spark f g h", 1.0),
+    (3L, "hadoop mapreduce", 2.0),
+    (4L, "b spark who", 1.0),
+    (5L, "g d a y", 2.0),
+    (6L, "spark fly", 1.0),
+    (7L, "was mapreduce", 2.0),
+    (8L, "e spark program", 1.0),
+    (9L, "a e c l", 2.0),
+    (10L, "spark compile", 1.0),
+    (11L, "hadoop software", 2.0)
+], ["id", "text", "label"])
+tokenizer = Tokenizer(inputCol="text", outputCol="words")
+hashingTF = HashingTF(inputCol="words", outputCol="features", numFeatures=20)
+svm = sml.mllearn.SVM(sqlCtx, is_multi_class=True)
+pipeline = Pipeline(stages=[tokenizer, hashingTF, svm])
+model = pipeline.fit(training)
+test = sqlCtx.createDataFrame([
+    (12L, "spark i j k"),
+    (13L, "l m n"),
+    (14L, "mapreduce spark"),
+    (15L, "apache hadoop")], ["id", "text"])
+prediction = model.transform(test)
+prediction.show()
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f m-svm.dml
                             -nvargs X=/user/ml/X.mtx

--- a/docs/algorithms-classification.md
+++ b/docs/algorithms-classification.md
@@ -132,7 +132,7 @@ Eqs. (1) and (2).
 import SystemML as sml
 # C = 1/reg
 logistic = sml.mllearn.LogisticRegression(sqlCtx, fit_intercept=True, max_iter=100, max_inner_iter=0, tol=0.000001, C=1.0)
-# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame
+# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame or SciPy Sparse Matrix
 y_test = logistic.fit(X_train, y_train).predict(X_test)
 # df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
 y_test = logistic.fit(df_train).transform(df_test)
@@ -461,7 +461,7 @@ support vector machine (`y` with domain size `2`).
 import SystemML as sml
 # C = 1/reg
 svm = sml.mllearn.SVM(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, is_multi_class=False)
-# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame
+# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame or SciPy Sparse Matrix
 y_test = svm.fit(X_train, y_train)
 # df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
 y_test = svm.fit(df_train)
@@ -504,7 +504,7 @@ y_test = svm.fit(df_train)
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
 {% highlight python %}
-# X_test can be NumPy matrices or Pandas DataFrame
+# X_test can be NumPy matrices or Pandas DataFrame or SciPy Sparse Matrix
 y_test = svm.predict(X_test)
 # df_test is a DataFrame that contains the column "features" of type Vector
 y_test = svm.transform(df_test)
@@ -717,7 +717,7 @@ class labels.
 import SystemML as sml
 # C = 1/reg
 svm = sml.mllearn.SVM(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, is_multi_class=True)
-# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame
+# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame or SciPy Sparse Matrix
 y_test = svm.fit(X_train, y_train)
 # df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
 y_test = svm.fit(df_train)
@@ -760,7 +760,7 @@ y_test = svm.fit(df_train)
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
 {% highlight python %}
-# X_test can be NumPy matrices or Pandas DataFrame
+# X_test can be NumPy matrices or Pandas DataFrame or SciPy Sparse Matrix
 y_test = svm.predict(X_test)
 # df_test is a DataFrame that contains the column "features" of type Vector
 y_test = svm.transform(df_test)
@@ -1024,6 +1024,16 @@ applicable when all features are counts of categorical values.
 **Naive Bayes**:
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+import SystemML as sml
+nb = sml.mllearn.NaiveBayes(sqlCtx, laplace=1.0)
+# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame or SciPy Sparse Matrix
+y_test = nb.fit(X_train, y_train)
+# df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
+y_test = nb.fit(df_train)
+{% endhighlight %}
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f naive-bayes.dml
                             -nvargs X=<file>
@@ -1055,6 +1065,14 @@ applicable when all features are counts of categorical values.
 **Naive Bayes Prediction**:
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+# X_test can be NumPy matrices or Pandas DataFrame or SciPy Sparse Matrix
+y_test = nb.predict(X_test)
+# df_test is a DataFrame that contains the column "features" of type Vector
+y_test = nb.transform(df_test)
+{% endhighlight %}
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f naive-bayes-predict.dml
                             -nvargs X=<file>
@@ -1127,6 +1145,27 @@ SystemML Language Reference for details.
 **Naive Bayes**:
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+from sklearn.datasets import fetch_20newsgroups
+from sklearn.feature_extraction.text import TfidfVectorizer
+import SystemML as sml
+from sklearn import metrics
+from pyspark.sql import SQLContext
+sqlCtx = SQLContext(sc)
+categories = ['alt.atheism', 'talk.religion.misc', 'comp.graphics', 'sci.space']
+newsgroups_train = fetch_20newsgroups(subset='train', categories=categories)
+newsgroups_test = fetch_20newsgroups(subset='test', categories=categories)
+vectorizer = TfidfVectorizer()
+# Both vectors and vectors_test are SciPy CSR matrix
+vectors = vectorizer.fit_transform(newsgroups_train.data)
+vectors_test = vectorizer.transform(newsgroups_test.data)
+nb = sml.mllearn.NaiveBayes(sqlCtx)
+nb.fit(vectors, newsgroups_train.target)
+pred = nb.predict(vectors_test)
+metrics.f1_score(newsgroups_test.target, pred, average='weighted')
+{% endhighlight %}
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f naive-bayes.dml
                             -nvargs X=/user/ml/X.mtx

--- a/docs/algorithms-regression.md
+++ b/docs/algorithms-regression.md
@@ -80,6 +80,15 @@ efficient when the number of features $m$ is relatively small
 **Linear Regression - Direct Solve**:
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+import SystemML as sml
+# C = 1/reg
+lr = sml.mllearn.LinearRegression(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, solver='direct-solve')
+# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame
+y_test = lr.fit(X_train, y_train)
+# df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
+y_test = lr.fit(df_train)
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f LinearRegDS.dml
                             -nvargs X=<file>
@@ -111,6 +120,15 @@ efficient when the number of features $m$ is relatively small
 **Linear Regression - Conjugate Gradient**:
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+import SystemML as sml
+# C = 1/reg
+lr = sml.mllearn.LinearRegression(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, solver='newton-cg')
+# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame
+y_test = lr.fit(X_train, y_train)
+# df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
+y_test = lr.fit(df_train)
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f LinearRegCG.dml
                             -nvargs X=<file>
@@ -196,6 +214,28 @@ SystemML Language Reference for details.
 **Linear Regression - Direct Solve**:
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+import numpy as np
+from sklearn import datasets
+import SystemML as sml
+from pyspark.sql import SQLContext
+# Load the diabetes dataset
+diabetes = datasets.load_diabetes()
+# Use only one feature
+diabetes_X = diabetes.data[:, np.newaxis, 2]
+# Split the data into training/testing sets
+diabetes_X_train = diabetes_X[:-20]
+diabetes_X_test = diabetes_X[-20:]
+# Split the targets into training/testing sets
+diabetes_y_train = diabetes.target[:-20]
+diabetes_y_test = diabetes.target[-20:]
+# Create linear regression object
+regr = sml.mllearn.LinearRegression(sqlCtx, solver='direct-solve')
+# Train the model using the training sets
+regr.fit(diabetes_X_train, diabetes_y_train)
+# The mean square error
+print("Residual sum of squares: %.2f" % np.mean((regr.predict(diabetes_X_test) - diabetes_y_test) ** 2))
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f LinearRegDS.dml
                             -nvargs X=/user/ml/X.mtx
@@ -227,6 +267,28 @@ SystemML Language Reference for details.
 **Linear Regression - Conjugate Gradient**:
 
 <div class="codetabs">
+<div data-lang="Python" markdown="1">
+import numpy as np
+from sklearn import datasets
+import SystemML as sml
+from pyspark.sql import SQLContext
+# Load the diabetes dataset
+diabetes = datasets.load_diabetes()
+# Use only one feature
+diabetes_X = diabetes.data[:, np.newaxis, 2]
+# Split the data into training/testing sets
+diabetes_X_train = diabetes_X[:-20]
+diabetes_X_test = diabetes_X[-20:]
+# Split the targets into training/testing sets
+diabetes_y_train = diabetes.target[:-20]
+diabetes_y_test = diabetes.target[-20:]
+# Create linear regression object
+regr = sml.mllearn.LinearRegression(sqlCtx, solver='newton-cg')
+# Train the model using the training sets
+regr.fit(diabetes_X_train, diabetes_y_train)
+# The mean square error
+print("Residual sum of squares: %.2f" % np.mean((regr.predict(diabetes_X_test) - diabetes_y_test) ** 2))
+</div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f LinearRegCG.dml
                             -nvargs X=/user/ml/X.mtx

--- a/docs/algorithms-regression.md
+++ b/docs/algorithms-regression.md
@@ -81,6 +81,7 @@ efficient when the number of features $m$ is relatively small
 
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
+{% highlight python %}
 import SystemML as sml
 # C = 1/reg
 lr = sml.mllearn.LinearRegression(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, solver='direct-solve')
@@ -88,6 +89,7 @@ lr = sml.mllearn.LinearRegression(sqlCtx, fit_intercept=True, max_iter=100, tol=
 y_test = lr.fit(X_train, y_train)
 # df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
 y_test = lr.fit(df_train)
+{% endhighlight %}
 </div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f LinearRegDS.dml
@@ -121,6 +123,7 @@ y_test = lr.fit(df_train)
 
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
+{% highlight python %}
 import SystemML as sml
 # C = 1/reg
 lr = sml.mllearn.LinearRegression(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, solver='newton-cg')
@@ -128,6 +131,7 @@ lr = sml.mllearn.LinearRegression(sqlCtx, fit_intercept=True, max_iter=100, tol=
 y_test = lr.fit(X_train, y_train)
 # df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
 y_test = lr.fit(df_train)
+{% endhighlight %}
 </div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f LinearRegCG.dml
@@ -215,6 +219,7 @@ SystemML Language Reference for details.
 
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
+{% highlight python %}
 import numpy as np
 from sklearn import datasets
 import SystemML as sml
@@ -235,6 +240,7 @@ regr = sml.mllearn.LinearRegression(sqlCtx, solver='direct-solve')
 regr.fit(diabetes_X_train, diabetes_y_train)
 # The mean square error
 print("Residual sum of squares: %.2f" % np.mean((regr.predict(diabetes_X_test) - diabetes_y_test) ** 2))
+{% endhighlight %}
 </div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f LinearRegDS.dml
@@ -268,6 +274,7 @@ print("Residual sum of squares: %.2f" % np.mean((regr.predict(diabetes_X_test) -
 
 <div class="codetabs">
 <div data-lang="Python" markdown="1">
+{% highlight python %}
 import numpy as np
 from sklearn import datasets
 import SystemML as sml
@@ -288,6 +295,7 @@ regr = sml.mllearn.LinearRegression(sqlCtx, solver='newton-cg')
 regr.fit(diabetes_X_train, diabetes_y_train)
 # The mean square error
 print("Residual sum of squares: %.2f" % np.mean((regr.predict(diabetes_X_test) - diabetes_y_test) ** 2))
+{% endhighlight %}
 </div>
 <div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f LinearRegCG.dml

--- a/docs/algorithms-regression.md
+++ b/docs/algorithms-regression.md
@@ -85,7 +85,7 @@ efficient when the number of features $m$ is relatively small
 import SystemML as sml
 # C = 1/reg
 lr = sml.mllearn.LinearRegression(sqlCtx, fit_intercept=True, C=1.0, solver='direct-solve')
-# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame
+# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame or SciPy Sparse Matrix
 y_test = lr.fit(X_train, y_train)
 # df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
 y_test = lr.fit(df_train)
@@ -127,7 +127,7 @@ y_test = lr.fit(df_train)
 import SystemML as sml
 # C = 1/reg
 lr = sml.mllearn.LinearRegression(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, solver='newton-cg')
-# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame
+# X_train, y_train and X_test can be NumPy matrices or Pandas DataFrames or SciPy Sparse matrices
 y_test = lr.fit(X_train, y_train)
 # df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"
 y_test = lr.fit(df_train)

--- a/docs/algorithms-regression.md
+++ b/docs/algorithms-regression.md
@@ -84,7 +84,7 @@ efficient when the number of features $m$ is relatively small
 {% highlight python %}
 import SystemML as sml
 # C = 1/reg
-lr = sml.mllearn.LinearRegression(sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, solver='direct-solve')
+lr = sml.mllearn.LinearRegression(sqlCtx, fit_intercept=True, C=1.0, solver='direct-solve')
 # X_train, y_train and X_test can be NumPy matrices or Pandas DataFrame
 y_test = lr.fit(X_train, y_train)
 # df_train is DataFrame that contains two columns: "features" (of type Vector) and "label". df_test is a DataFrame that contains the column "features"

--- a/scripts/algorithms/l2-svm.dml
+++ b/scripts/algorithms/l2-svm.dml
@@ -160,4 +160,7 @@ extra_model_params[4,1] = dimensions
 w = t(append(t(w), t(extra_model_params)))
 write(w, $model, format=cmdLine_fmt)
 
-write(debug_str, $Log)
+logFile = $Log
+if(logFile != " ") {
+	write(debug_str, logFile)
+}

--- a/scripts/algorithms/m-svm.dml
+++ b/scripts/algorithms/m-svm.dml
@@ -175,4 +175,7 @@ for(iter_class in 1:ncol(debug_mat)){
 			debug_str = append(debug_str, iter_class + "," + iter + "," + obj)
 	}
 }
-write(debug_str, $Log)
+logFile = $Log
+if(logFile != " ") {
+	write(debug_str, logFile)
+}

--- a/scripts/algorithms/naive-bayes-predict.dml
+++ b/scripts/algorithms/naive-bayes-predict.dml
@@ -28,7 +28,6 @@
 cmdLine_Y = ifdef($Y, " ")
 cmdLine_accuracy = ifdef($accuracy, " ")
 cmdLine_confusion = ifdef($confusion, " ")
-cmdLine_probabilities = ifdef($probabilities, " ")
 cmdLine_fmt = ifdef($fmt, "text")
 
 D = read($X)
@@ -51,13 +50,13 @@ model = append(conditionals, prior)
 
 log_probs = D_w_ones %*% t(log(model))
 
-if(cmdLine_probabilities != " "){
-	mx = rowMaxs(log_probs)
-	ones = matrix(1, rows=1, cols=nrow(prior))
-	probs = log_probs - mx %*% ones
-	probs = exp(probs)/(rowSums(exp(probs)) %*% ones)
-	write(probs, cmdLine_probabilities, format=cmdLine_fmt)
-}
+
+mx = rowMaxs(log_probs)
+ones = matrix(1, rows=1, cols=nrow(prior))
+probs = log_probs - mx %*% ones
+probs = exp(probs)/(rowSums(exp(probs)) %*% ones)
+write(probs, $probabilities, format=cmdLine_fmt)
+
 
 if(cmdLine_Y != " "){
 	C = read(cmdLine_Y)

--- a/scripts/algorithms/naive-bayes.dml
+++ b/scripts/algorithms/naive-bayes.dml
@@ -74,7 +74,10 @@ acc = sum(rowIndexMax(logProbs) == C) / numRows * 100
 
 acc_str = "Training Accuracy (%): " + acc
 print(acc_str)
-write(acc, $accuracy)
+accuracyFile = $accuracy
+if(accuracyFile != " ") {
+	write(acc, accuracyFile)
+}
 
 extraModelParams = as.matrix(numFeatures)
 classPrior = rbind(classPrior, extraModelParams)

--- a/src/main/java/org/apache/sysml/api/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/MLContext.java
@@ -65,7 +65,6 @@ import org.apache.sysml.runtime.controlprogram.caching.CacheableData;
 import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.controlprogram.context.ExecutionContextFactory;
-import org.apache.sysml.runtime.controlprogram.context.SparkExecutionContext;
 import org.apache.sysml.runtime.instructions.Instruction;
 import org.apache.sysml.runtime.instructions.cp.Data;
 import org.apache.sysml.runtime.instructions.spark.data.RDDObject;

--- a/src/main/java/org/apache/sysml/api/mlcontext/BinaryBlockMatrix.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/BinaryBlockMatrix.java
@@ -21,6 +21,8 @@ package org.apache.sysml.api.mlcontext;
 
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.sql.DataFrame;
+import org.apache.sysml.runtime.DMLRuntimeException;
+import org.apache.sysml.runtime.controlprogram.context.SparkExecutionContext;
 import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
@@ -96,6 +98,13 @@ public class BinaryBlockMatrix {
 	 */
 	public JavaPairRDD<MatrixIndexes, MatrixBlock> getBinaryBlocks() {
 		return binaryBlocks;
+	}
+	
+	public MatrixBlock getMatrixBlock() throws DMLRuntimeException {
+		MatrixCharacteristics mc = getMatrixCharacteristics();
+		MatrixBlock mb = SparkExecutionContext.toMatrixBlock(binaryBlocks, (int) mc.getRows(), (int) mc.getCols(), 
+				mc.getRowsPerBlock(), mc.getColsPerBlock(), mc.getNonZeros());
+		return mb;
 	}
 
 	/**

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextConversionUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextConversionUtil.java
@@ -676,7 +676,7 @@ public class MLContextConversionUtil {
 	 * @return the {@code MatrixObject} converted to a {@code DataFrame}
 	 */
 	public static DataFrame matrixObjectToDataFrame(MatrixObject matrixObject,
-			SparkExecutionContext sparkExecutionContext) {
+			SparkExecutionContext sparkExecutionContext, boolean isVectorDF) {
 		try {
 			@SuppressWarnings("unchecked")
 			JavaPairRDD<MatrixIndexes, MatrixBlock> binaryBlockMatrix = (JavaPairRDD<MatrixIndexes, MatrixBlock>) sparkExecutionContext
@@ -686,8 +686,17 @@ public class MLContextConversionUtil {
 			MLContext activeMLContext = (MLContext) MLContextProxy.getActiveMLContext();
 			SparkContext sc = activeMLContext.getSparkContext();
 			SQLContext sqlContext = new SQLContext(sc);
-			DataFrame df = RDDConverterUtilsExt.binaryBlockToDataFrame(binaryBlockMatrix, matrixCharacteristics,
+			DataFrame df = null;
+			if(isVectorDF) {
+				df = RDDConverterUtilsExt.binaryBlockToVectorDataFrame(binaryBlockMatrix, matrixCharacteristics,
+						sqlContext);
+			}
+			else {
+				df = RDDConverterUtilsExt.binaryBlockToDataFrame(binaryBlockMatrix, matrixCharacteristics,
 					sqlContext);
+			}
+			
+			
 			return df;
 		} catch (DMLRuntimeException e) {
 			throw new MLContextException("DMLRuntimeException while converting matrix object to DataFrame", e);

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
@@ -255,7 +255,13 @@ public class MLResults {
 	 */
 	public DataFrame getDataFrame(String outputName) {
 		MatrixObject mo = getMatrixObject(outputName);
-		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext);
+		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext, false);
+		return df;
+	}
+	
+	public DataFrame getDataFrame(String outputName, boolean isVectorDF) {
+		MatrixObject mo = getMatrixObject(outputName);
+		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext, isVectorDF);
 		return df;
 	}
 
@@ -271,6 +277,7 @@ public class MLResults {
 		Matrix matrix = new Matrix(mo, sparkExecutionContext);
 		return matrix;
 	}
+	
 
 	/**
 	 * Obtain an output as a {@code BinaryBlockMatrix}.

--- a/src/main/java/org/apache/sysml/api/mlcontext/Matrix.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/Matrix.java
@@ -108,7 +108,7 @@ public class Matrix {
 	 * @return the matrix as a {@code DataFrame}
 	 */
 	public DataFrame asDataFrame() {
-		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext);
+		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext, false);
 		return df;
 	}
 

--- a/src/main/java/org/apache/sysml/api/python/SystemML.py
+++ b/src/main/java/org/apache/sysml/api/python/SystemML.py
@@ -259,24 +259,19 @@ class MLOutput(object):
         #    traceback.print_exc()
 
 def getNumCols(numPyArr):
-	if len(numPyArr.shape) == 1:
+	if numPyArr.ndim == 1:
 		return 1
 	else:
 		return numPyArr.shape[1]
        
 def convertToJavaMatrix(sc, src):
-	if isinstance(src, np.ndarray):
-		from array import array
-		numCols = getNumCols(src)
-		numRows = src.shape[0]
-		if src.dtype.type is np.float64:
-			arr = src.reshape(-1)
-		else:
-			arr = array('d', src.reshape(-1))
-		buf = bytearray(arr.tostring())
-		return sc._jvm.org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt.convertPy4JArrayToMB(buf, numRows, numCols)
-	else:
-		raise Exception('Type is not supported')
+	src = np.asarray(src)
+	numCols = getNumCols(src)
+	numRows = src.shape[0]
+	arr = src.ravel().astype(np.float64)
+	buf = bytearray(arr.tostring())
+	return sc._jvm.org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt.convertPy4JArrayToMB(buf, numRows, numCols)
+	
 
 def convertToNumpyArr(sc, mb):
 	numRows = mb.getNumRows()

--- a/src/main/java/org/apache/sysml/api/python/SystemML.py
+++ b/src/main/java/org/apache/sysml/api/python/SystemML.py
@@ -33,6 +33,7 @@ from pyspark.ml.feature import VectorAssembler
 from pyspark.mllib.linalg import Vectors
 import sys
 from pyspark.ml import Estimator, Model
+from __future__ import division
 
 class MLContext(object):
 
@@ -303,7 +304,7 @@ class mllearn:
             self.tol = tol
             if C < 0:
                 raise Exception('C has to be positive')
-            reg = 1/C
+            reg = 1.0 / C
             self.reg = reg
             self.updateLog()
             if solver != 'newton-cg':

--- a/src/main/java/org/apache/sysml/api/python/SystemML.py
+++ b/src/main/java/org/apache/sysml/api/python/SystemML.py
@@ -302,7 +302,7 @@ class mllearn:
             self.max_iter = max_iter
             self.max_inner_iter = max_inner_iter
             self.tol = tol
-            if C < 0:
+            if C <= 0:
                 raise Exception('C has to be positive')
             reg = 1.0 / C
             self.reg = reg

--- a/src/main/java/org/apache/sysml/api/python/SystemML.py
+++ b/src/main/java/org/apache/sysml/api/python/SystemML.py
@@ -30,6 +30,7 @@ from pyspark.rdd import RDD
 import numpy as np
 import pandas as pd
 import sklearn as sk
+from sklearn import metrics
 from pyspark.ml.feature import VectorAssembler
 from pyspark.mllib.linalg import Vectors
 import sys
@@ -377,7 +378,7 @@ class mllearn:
                 raise Exception('Unsupported input type')
                 
         def score(self, X, y):
-            return sk.metrics.accuracy_score(y, self.predict(X))    
+            return metrics.accuracy_score(y, self.predict(X))    
     
     # Or we can create new Python project with package structure
     class LogisticRegression(BaseSystemMLEstimator):
@@ -421,5 +422,25 @@ class mllearn:
             self.estimator.setIcpt(int(fit_intercept))
             self.transferUsingDF = transferUsingDF
             self.setOutputRawPredictionsToFalse = False
-            
+
+        def score(self, X, y):
+            return metrics.r2_score(y, self.predict(X), multioutput='variance_weighted')    
+
+
+    class SVM(BaseSystemMLEstimator):
+
+        def __init__(self, sqlCtx, fit_intercept=True, max_iter=100, tol=0.000001, C=1.0, is_multi_class=False, transferUsingDF=False):
+            self.sqlCtx = sqlCtx
+            self.sc = sqlCtx._sc
+            self.uid = "svm"
+            self.estimator = self.sc._jvm.org.apache.sysml.api.ml.SVM(self.uid, self.sc._jsc.sc(), is_multi_class)
+            self.estimator.setMaxIter(max_iter)
+            if C <= 0:
+                raise Exception('C has to be positive')
+            reg = 1.0 / C
+            self.estimator.setRegParam(reg)
+            self.estimator.setTol(tol)
+            self.estimator.setIcpt(int(fit_intercept))
+            self.transferUsingDF = transferUsingDF
+            self.setOutputRawPredictionsToFalse = False            
                 

--- a/src/main/java/org/apache/sysml/api/python/SystemML.py
+++ b/src/main/java/org/apache/sysml/api/python/SystemML.py
@@ -23,6 +23,7 @@
 from py4j.protocol import Py4JJavaError, Py4JError
 import traceback
 import os
+from pyspark.context import SparkContext 
 from pyspark.sql import DataFrame, SQLContext
 from pyspark.rdd import RDD
 import numpy as np
@@ -259,25 +260,31 @@ class MLOutput(object):
         #    traceback.print_exc()
 
 def getNumCols(numPyArr):
-	if numPyArr.ndim == 1:
-		return 1
-	else:
-		return numPyArr.shape[1]
+    if numPyArr.ndim == 1:
+        return 1
+    else:
+        return numPyArr.shape[1]
        
-def convertToJavaMatrix(sc, src):
-	src = np.asarray(src)
-	numCols = getNumCols(src)
-	numRows = src.shape[0]
-	arr = src.ravel().astype(np.float64)
-	buf = bytearray(arr.tostring())
-	return sc._jvm.org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt.convertPy4JArrayToMB(buf, numRows, numCols)
-	
+def convertToMatrixBlock(sc, src):
+    if isinstance(sc, SparkContext):
+        src = np.asarray(src)
+        numCols = getNumCols(src)
+        numRows = src.shape[0]
+        arr = src.ravel().astype(np.float64)
+        buf = bytearray(arr.tostring())
+        return sc._jvm.org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt.convertPy4JArrayToMB(buf, numRows, numCols)
+    else:
+        raise TypeError('sc needs to be of type SparkContext') # TODO: We can generalize this by creating py4j gateway ourselves
+    
 
 def convertToNumpyArr(sc, mb):
-	numRows = mb.getNumRows()
-	numCols = mb.getNumColumns()
-	buf = sc._jvm.org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt.convertMBtoPy4JDenseArr(mb)
-	return np.frombuffer(buf, count=numRows*numCols, dtype=np.float64)
+    if isinstance(sc, SparkContext):
+        numRows = mb.getNumRows()
+        numCols = mb.getNumColumns()
+        buf = sc._jvm.org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt.convertMBtoPy4JDenseArr(mb)
+        return np.frombuffer(buf, count=numRows*numCols, dtype=np.float64)
+    else:
+        raise TypeError('sc needs to be of type SparkContext') # TODO: We can generalize this by creating py4j gateway ourselves
 
 class mllearn:
     # Or we can create new Python project with package structure
@@ -290,15 +297,12 @@ class mllearn:
             self.transferUsingDF = transferUsingDF
             if penalty != 'l2':
                 raise Exception('Only l2 penalty is supported')
-            if fit_intercept:
-                self.icpt = 1
-            else:
-                self.icpt = 0
+            self.icpt = int(fit_intercept)
             self.max_iter = max_iter
             self.max_inner_iter = max_inner_iter
             self.tol = tol
-            if C == 0:
-                raise Exception('C cannot be 0')
+            if C < 0:
+                raise Exception('C has to be positive')
             reg = 1/C
             self.reg = reg
             self.updateLog()
@@ -312,7 +316,7 @@ class mllearn:
             self.log.setTol(self.tol)
             self.log.setIcpt(self.icpt)
             
-        def convertToPDF(self, X):
+        def convertToPandasDF(self, X):
             if isinstance(X, np.ndarray):
                 colNames = []
                 numCols = getNumCols(X)
@@ -354,8 +358,8 @@ class mllearn:
             elif numArgs == 2 and (isinstance(X, np.ndarray) or isinstance(X, pd.core.frame.DataFrame)):
                 y = args[0]
                 if self.transferUsingDF:
-                    pdfX = self.convertToPDF(X)
-                    pdfY = self.convertToPDF(y)
+                    pdfX = self.convertToPandasDF(X)
+                    pdfY = self.convertToPandasDF(y)
                     if getNumCols(pdfY) != 1:
                         raise Exception('y should be a column vector')
                     if pdfX.shape[0] != pdfY.shape[0]:
@@ -368,7 +372,7 @@ class mllearn:
                     numColsy = getNumCols(y)
                     if numColsy != 1:
                         raise Exception('Expected y to be a column vector')
-                    self.model = self.log.fit(convertToJavaMatrix(self.sc, X), convertToJavaMatrix(self.sc, y))
+                    self.model = self.log.fit(convertToMatrixBlock(self.sc, X), convertToMatrixBlock(self.sc, y))
                 self.model.setOutputRawPredictions(False)
                 return self
             else:
@@ -380,7 +384,7 @@ class mllearn:
         def predict(self, X):
             if isinstance(X, np.ndarray) or isinstance(X, pd.core.frame.DataFrame):
                 if self.transferUsingDF:
-                    pdfX = self.convertToPDF(X)
+                    pdfX = self.convertToPandasDF(X)
                     df = self.assemble(pdfX, pdfX.columns, 'features').select('features')
                     retjDF = self.model.transform(df._jdf)
                     retDF = DataFrame(retjDF, self.sqlCtx)
@@ -390,7 +394,7 @@ class mllearn:
                     else:
                         return retPDF
                 else:
-                    retNumPy = convertToNumpyArr(self.sc, self.model.transform(convertToJavaMatrix(self.sc, X)))
+                    retNumPy = convertToNumpyArr(self.sc, self.model.transform(convertToMatrixBlock(self.sc, X)))
                     if isinstance(X, np.ndarray):
                         return retNumPy
                     else:

--- a/src/main/java/org/apache/sysml/api/python/test.py
+++ b/src/main/java/org/apache/sysml/api/python/test.py
@@ -1,0 +1,126 @@
+from sklearn import datasets, neighbors
+import SystemML as sml
+from pyspark.sql import SQLContext
+from pyspark.context import SparkContext
+import unittest
+from pyspark.ml.evaluation import MulticlassClassificationEvaluator
+from pyspark.ml import Pipeline
+from pyspark.ml.feature import HashingTF, Tokenizer
+import numpy as np
+
+sc = SparkContext()
+sqlCtx = SQLContext(sc)
+
+# Currently not integrated with JUnit test
+# ~/spark-1.6.1-scala-2.11/bin/spark-submit --master local[*] --driver-class-path SystemML.jar test.py
+class TestMLLearn(unittest.TestCase):
+    def testLogisticSK1(self):
+        digits = datasets.load_digits()
+        X_digits = digits.data
+        y_digits = digits.target
+        n_samples = len(X_digits)
+        X_train = X_digits[:.9 * n_samples]
+        y_train = y_digits[:.9 * n_samples]
+        X_test = X_digits[.9 * n_samples:]
+        y_test = y_digits[.9 * n_samples:]
+        logistic = sml.mllearn.LogisticRegression(sqlCtx)
+        score = logistic.fit(X_train, y_train).score(X_test, y_test)
+        self.failUnless(score > 0.9)
+        
+    def testLogisticSK2(self):
+        digits = datasets.load_digits()
+        X_digits = digits.data
+        y_digits = digits.target
+        n_samples = len(X_digits)
+        X_train = X_digits[:.9 * n_samples]
+        y_train = y_digits[:.9 * n_samples]
+        X_test = X_digits[.9 * n_samples:]
+        y_test = y_digits[.9 * n_samples:]
+        # Convert to DataFrame for i/o: current way to transfer data
+        logistic = sml.mllearn.LogisticRegression(sqlCtx, transferUsingDF=True)
+        score = logistic.fit(X_train, y_train).score(X_test, y_test)
+        self.failUnless(score > 0.9)
+
+    def testLogisticMLPipeline1(self):
+        training = sqlCtx.createDataFrame([
+            (0L, "a b c d e spark", 1.0),
+            (1L, "b d", 2.0),
+            (2L, "spark f g h", 1.0),
+            (3L, "hadoop mapreduce", 2.0),
+            (4L, "b spark who", 1.0),
+            (5L, "g d a y", 2.0),
+            (6L, "spark fly", 1.0),
+            (7L, "was mapreduce", 2.0),
+            (8L, "e spark program", 1.0),
+            (9L, "a e c l", 2.0),
+            (10L, "spark compile", 1.0),
+            (11L, "hadoop software", 2.0)
+            ], ["id", "text", "label"])
+        tokenizer = Tokenizer(inputCol="text", outputCol="words")
+        hashingTF = HashingTF(inputCol="words", outputCol="features", numFeatures=20)
+        lr = sml.mllearn.LogisticRegression(sqlCtx)
+        pipeline = Pipeline(stages=[tokenizer, hashingTF, lr])
+        model = pipeline.fit(training)
+        test = sqlCtx.createDataFrame([
+            (12L, "spark i j k", 1.0),
+            (13L, "l m n", 2.0),
+            (14L, "mapreduce spark", 1.0),
+            (15L, "apache hadoop", 2.0)], ["id", "text", "label"])
+        result = model.transform(test)
+        predictionAndLabels = result.select("prediction", "label")
+        evaluator = MulticlassClassificationEvaluator()
+        score = evaluator.evaluate(predictionAndLabels)
+        self.failUnless(score == 1.0)
+
+    def testLinearRegressionSK1(self):
+        diabetes = datasets.load_diabetes()
+        diabetes_X = diabetes.data[:, np.newaxis, 2]
+        diabetes_X_train = diabetes_X[:-20]
+        diabetes_X_test = diabetes_X[-20:]
+        diabetes_y_train = diabetes.target[:-20]
+        diabetes_y_test = diabetes.target[-20:]
+        regr = sml.mllearn.LinearRegression(sqlCtx)
+        regr.fit(diabetes_X_train, diabetes_y_train)
+        score = regr.score(diabetes_X_test, diabetes_y_test)
+        self.failUnless(score > 0.4) # TODO: Improve r2-score (may be I am using it incorrectly)
+
+    def testLinearRegressionSK2(self):
+        diabetes = datasets.load_diabetes()
+        diabetes_X = diabetes.data[:, np.newaxis, 2]
+        diabetes_X_train = diabetes_X[:-20]
+        diabetes_X_test = diabetes_X[-20:]
+        diabetes_y_train = diabetes.target[:-20]
+        diabetes_y_test = diabetes.target[-20:]
+        regr = sml.mllearn.LinearRegression(sqlCtx, transferUsingDF=True)
+        regr.fit(diabetes_X_train, diabetes_y_train)
+        score = regr.score(diabetes_X_test, diabetes_y_test)
+        self.failUnless(score > 0.4) # TODO: Improve r2-score (may be I am using it incorrectly)
+
+    def testSVMSK1(self):
+        digits = datasets.load_digits()
+        X_digits = digits.data
+        y_digits = digits.target
+        n_samples = len(X_digits)
+        X_train = X_digits[:.9 * n_samples]
+        y_train = y_digits[:.9 * n_samples]
+        X_test = X_digits[.9 * n_samples:]
+        y_test = y_digits[.9 * n_samples:]
+        svm = sml.mllearn.SVM(sqlCtx, is_multi_class=True)
+        score = svm.fit(X_train, y_train).score(X_test, y_test)
+        self.failUnless(score > 0.9)
+
+    def testSVMSK2(self):
+        digits = datasets.load_digits()
+        X_digits = digits.data
+        y_digits = digits.target
+        n_samples = len(X_digits)
+        X_train = X_digits[:.9 * n_samples]
+        y_train = y_digits[:.9 * n_samples]
+        X_test = X_digits[.9 * n_samples:]
+        y_test = y_digits[.9 * n_samples:]
+        svm = sml.mllearn.SVM(sqlCtx, is_multi_class=True, transferUsingDF=True)
+        score = svm.fit(X_train, y_train).score(X_test, y_test)
+        self.failUnless(score > 0.9)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/main/java/org/apache/sysml/api/python/test.py
+++ b/src/main/java/org/apache/sysml/api/python/test.py
@@ -1,3 +1,24 @@
+#!/usr/bin/python
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
 from sklearn import datasets, neighbors
 import SystemML as sml
 from pyspark.sql import SQLContext
@@ -7,6 +28,9 @@ from pyspark.ml.evaluation import MulticlassClassificationEvaluator
 from pyspark.ml import Pipeline
 from pyspark.ml.feature import HashingTF, Tokenizer
 import numpy as np
+from sklearn.datasets import fetch_20newsgroups
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn import metrics
 
 sc = SparkContext()
 sqlCtx = SQLContext(sc)
@@ -121,6 +145,34 @@ class TestMLLearn(unittest.TestCase):
         svm = sml.mllearn.SVM(sqlCtx, is_multi_class=True, transferUsingDF=True)
         score = svm.fit(X_train, y_train).score(X_test, y_test)
         self.failUnless(score > 0.9)
+
+    def testNaiveBayesSK1(self):
+        digits = datasets.load_digits()
+        X_digits = digits.data
+        y_digits = digits.target
+        n_samples = len(X_digits)
+        X_train = X_digits[:.9 * n_samples]
+        y_train = y_digits[:.9 * n_samples]
+        X_test = X_digits[.9 * n_samples:]
+        y_test = y_digits[.9 * n_samples:]
+        nb = sml.mllearn.NaiveBayes(sqlCtx)
+        score = nb.fit(X_train, y_train).score(X_test, y_test)
+        self.failUnless(score > 0.85)
+
+    def testNaiveBayesSK2(self):
+        categories = ['alt.atheism', 'talk.religion.misc', 'comp.graphics', 'sci.space']
+        newsgroups_train = fetch_20newsgroups(subset='train', categories=categories)
+        newsgroups_test = fetch_20newsgroups(subset='test', categories=categories)
+        vectorizer = TfidfVectorizer()
+        # Both vectors and vectors_test are SciPy CSR matrix
+        vectors = vectorizer.fit_transform(newsgroups_train.data)
+        vectors_test = vectorizer.transform(newsgroups_test.data)
+        nb = sml.mllearn.NaiveBayes(sqlCtx)
+        nb.fit(vectors, newsgroups_train.target)
+        pred = nb.predict(vectors_test)
+        score = metrics.f1_score(newsgroups_test.target, pred, average='weighted')
+        self.failUnless(score > 0.8)
+        
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
@@ -46,6 +46,8 @@ import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 import scala.Tuple2;
 
@@ -258,6 +260,47 @@ public class RDDConverterUtilsExt
 	public static JavaPairRDD<MatrixIndexes, MatrixBlock> dataFrameToBinaryBlock(JavaSparkContext sc,
 			DataFrame df, MatrixCharacteristics mcOut, ArrayList<String> columns) throws DMLRuntimeException {
 		return dataFrameToBinaryBlock(sc, df, mcOut, false, columns);
+	}
+	
+	public static MatrixBlock convertPy4JArrayToMB(byte [] data, int rlen, int clen) throws DMLRuntimeException {
+		return convertPy4JArrayToMB(data, rlen, clen, false);
+	}
+	
+	public static MatrixBlock convertPy4JArrayToMB(byte [] data, int rlen, int clen, boolean isSparse) throws DMLRuntimeException {
+		MatrixBlock mb = new MatrixBlock(rlen, clen, isSparse, -1);
+		if(isSparse) {
+			throw new DMLRuntimeException("Convertion to sparse format not supported");
+		}
+		else {
+			double [] denseBlock = new double[rlen*clen];
+			ByteBuffer buf = ByteBuffer.wrap(data);
+			buf.order(ByteOrder.nativeOrder());
+			for(int i = 0; i < rlen*clen; i++) {
+				denseBlock[i] = buf.getDouble();
+			}
+			mb.init( denseBlock, rlen, clen );
+		}
+		mb.examSparsity();
+		return mb;
+	}
+	
+	public static byte [] convertMBtoPy4JDenseArr(MatrixBlock mb) throws DMLRuntimeException {
+		byte [] ret = null;
+		if(mb.isInSparseFormat()) {
+			throw new DMLRuntimeException("Sparse to dense conversion is not yet implemented");
+		}
+		else {
+			double [] denseBlock = mb.getDenseBlock();
+			if(denseBlock == null) {
+				throw new DMLRuntimeException("Sparse to dense conversion is not yet implemented");
+			}
+			int times = Double.SIZE / Byte.SIZE;
+			ret = new byte[denseBlock.length * times];
+			for(int i=0;i < denseBlock.length;i++){
+		        ByteBuffer.wrap(ret, i*times, times).order(ByteOrder.nativeOrder()).putDouble(denseBlock[i]);
+			}
+		}
+		return ret;
 	}
 	
 	/**

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
@@ -266,6 +266,24 @@ public class RDDConverterUtilsExt
 		return convertPy4JArrayToMB(data, rlen, clen, false);
 	}
 	
+	public static MatrixBlock convertSciPyCOOToMB(byte [] data, byte [] row, byte [] col, int rlen, int clen, int nnz) throws DMLRuntimeException {
+		MatrixBlock mb = new MatrixBlock(rlen, clen, true);
+		mb.allocateSparseRowsBlock(false);
+		ByteBuffer buf1 = ByteBuffer.wrap(data);
+		buf1.order(ByteOrder.nativeOrder());
+		ByteBuffer buf2 = ByteBuffer.wrap(row);
+		buf2.order(ByteOrder.nativeOrder());
+		ByteBuffer buf3 = ByteBuffer.wrap(col);
+		buf3.order(ByteOrder.nativeOrder());
+		for(int i = 0; i < nnz; i++) {
+			double val = buf1.getDouble();
+			int rowIndex = buf2.getInt();
+			int colIndex = buf3.getInt();
+			mb.setValue(rowIndex, colIndex, val); // TODO: Improve the performance
+		}
+		return mb;
+	}
+	
 	public static MatrixBlock convertPy4JArrayToMB(byte [] data, int rlen, int clen, boolean isSparse) throws DMLRuntimeException {
 		MatrixBlock mb = new MatrixBlock(rlen, clen, isSparse, -1);
 		if(isSparse) {

--- a/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLClassifier.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLClassifier.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.api.ml
+
+import org.apache.spark.rdd.RDD
+import java.io.File
+import org.apache.spark.SparkContext
+import org.apache.spark.ml.{ Model, Estimator }
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.ml.param.{ Params, Param, ParamMap, DoubleParam }
+import org.apache.sysml.runtime.matrix.MatrixCharacteristics
+import org.apache.sysml.runtime.matrix.data.MatrixBlock
+import org.apache.sysml.runtime.DMLRuntimeException
+import org.apache.sysml.runtime.instructions.spark.utils.{ RDDConverterUtilsExt => RDDConverterUtils }
+import org.apache.sysml.api.mlcontext._
+import org.apache.sysml.api.mlcontext.ScriptFactory._
+
+trait HasLaplace extends Params {
+  final val laplace: Param[Double] = new Param[Double](this, "laplace", "Laplace smoothing specified by the user to avoid creation of 0 probabilities.")
+  setDefault(laplace, 1.0)
+  final def getLaplace: Double = $(laplace)
+}
+trait HasIcpt extends Params {
+  final val icpt: Param[Int] = new Param[Int](this, "icpt", "Intercept presence, shifting and rescaling X columns")
+  setDefault(icpt, 0)
+  final def getIcpt: Int = $(icpt)
+}
+trait HasMaxOuterIter extends Params {
+  final val maxOuterIter: Param[Int] = new Param[Int](this, "maxOuterIter", "max. number of outer (Newton) iterations")
+  setDefault(maxOuterIter, 100)
+  final def getMaxOuterIte: Int = $(maxOuterIter)
+}
+trait HasMaxInnerIter extends Params {
+  final val maxInnerIter: Param[Int] = new Param[Int](this, "maxInnerIter", "max. number of inner (conjugate gradient) iterations, 0 = no max")
+  setDefault(maxInnerIter, 0)
+  final def getMaxInnerIter: Int = $(maxInnerIter)
+}
+trait HasTol extends Params {
+  final val tol: DoubleParam = new DoubleParam(this, "tol", "the convergence tolerance for iterative algorithms")
+  setDefault(tol, 0.000001)
+  final def getTol: Double = $(tol)
+}
+trait HasRegParam extends Params {
+  final val regParam: DoubleParam = new DoubleParam(this, "tol", "the convergence tolerance for iterative algorithms")
+  setDefault(regParam, 0.000001)
+  final def getRegParam: Double = $(regParam)
+}
+
+
+trait BaseSystemMLClassifier {
+  def transformSchema(schema: StructType): StructType = schema
+  
+  // Returns the script and variables for X and y
+  def getTrainingScript(isSingleNode:Boolean):(Script, String, String)
+  
+  def fit(X_mb: MatrixBlock, y_mb: MatrixBlock, sc: SparkContext): (MLResults, java.util.HashMap[Int, String]) = {
+    val isSingleNode = true
+    val ml = new org.apache.sysml.api.mlcontext.MLContext(sc)
+    val revLabelMapping = new java.util.HashMap[Int, String]
+    PredictionUtils.fillLabelMapping(y_mb, revLabelMapping)
+    val ret = getTrainingScript(isSingleNode)
+    val script = ret._1.in(ret._2, X_mb).in(ret._3, y_mb)
+    (ml.execute(script), revLabelMapping)
+  }
+  
+  def fit(df: DataFrame, sc: SparkContext): (MLResults, java.util.HashMap[Int, String]) = {
+    val isSingleNode = false
+    val ml = new MLContext(df.rdd.sparkContext)
+    val mcXin = new MatrixCharacteristics()
+    val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(sc, df, mcXin, false, "features")
+    val revLabelMapping = new java.util.HashMap[Int, String]
+    val yin = PredictionUtils.fillLabelMapping(df, revLabelMapping)
+    val ret = getTrainingScript(isSingleNode)
+    val Xbin = new BinaryBlockMatrix(Xin, mcXin)
+    val script = ret._1.in(ret._2, Xbin).in(ret._3, yin)
+    (ml.execute(script), revLabelMapping)
+  }
+  
+  def toDouble(i:Int): java.lang.Double = {
+    double2Double(i.toDouble)
+  }
+  def toDouble(d:Double): java.lang.Double = {
+    double2Double(d)
+  }
+  
+}
+
+trait BaseSystemMLClassifierModel {
+  
+  def toDouble(i:Int): java.lang.Double = {
+    double2Double(i.toDouble)
+  }
+  def toDouble(d:Double): java.lang.Double = {
+    double2Double(d)
+  }
+  
+  def transformSchema(schema: StructType): StructType = schema
+  
+  // Returns the script and variable for X
+  def getPredictionScript(mloutput: MLResults, isSingleNode:Boolean): (Script, String)
+  
+  def transform(X: MatrixBlock, mloutput: MLResults, labelMapping: java.util.HashMap[Int, String], sc: SparkContext, probVar:String): MatrixBlock = {
+    val isSingleNode = true
+    val ml = new MLContext(sc)
+    val script = getPredictionScript(mloutput, isSingleNode)
+    val modelPredict = ml.execute(script._1.in(script._2, X))
+    val ret = PredictionUtils.computePredictedClassLabelsFromProbability(modelPredict, isSingleNode, sc, probVar)
+              .getBinaryBlockMatrix("Prediction").getMatrixBlock
+              
+    if(ret.getNumColumns != 1) {
+      throw new RuntimeException("Expected predicted label to be a column vector")
+    }
+    PredictionUtils.updateLabels(isSingleNode, null, ret, null, labelMapping)
+    return ret
+  }
+
+  def transform(df: DataFrame, mloutput: MLResults, labelMapping: java.util.HashMap[Int, String], sc: SparkContext, 
+      probVar:String, outputProb:Boolean=true): DataFrame = {
+    val isSingleNode = false
+    val ml = new MLContext(sc)
+    val mcXin = new MatrixCharacteristics()
+    val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(df.rdd.sparkContext, df, mcXin, false, "features")
+    val script = getPredictionScript(mloutput, isSingleNode)
+    val Xin_bin = new BinaryBlockMatrix(Xin, mcXin)
+    val modelPredict = ml.execute(script._1.in(script._2, Xin_bin))
+    val predLabelOut = PredictionUtils.computePredictedClassLabelsFromProbability(modelPredict, isSingleNode, sc, probVar)
+    val predictedDF = PredictionUtils.updateLabels(isSingleNode, predLabelOut.getDataFrame("Prediction"), null, "C1", labelMapping).select("ID", "prediction")
+    if(outputProb) {
+      val prob = modelPredict.getDataFrame(probVar, true).withColumnRenamed("C1", "probability").select("ID", "probability")
+      val dataset = RDDConverterUtils.addIDToDataFrame(df, df.sqlContext, "ID")
+      return PredictionUtils.joinUsingID(dataset, PredictionUtils.joinUsingID(prob, predictedDF))  
+    }
+    else {
+      val dataset = RDDConverterUtils.addIDToDataFrame(df, df.sqlContext, "ID")
+      return PredictionUtils.joinUsingID(dataset, predictedDF)
+    }
+    
+  }
+}

--- a/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLRegressor.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLRegressor.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.api.ml
+
+import org.apache.spark.rdd.RDD
+import java.io.File
+import org.apache.spark.SparkContext
+import org.apache.spark.ml.{ Model, Estimator }
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.ml.param.{ Params, Param, ParamMap, DoubleParam }
+import org.apache.sysml.runtime.matrix.MatrixCharacteristics
+import org.apache.sysml.runtime.matrix.data.MatrixBlock
+import org.apache.sysml.runtime.DMLRuntimeException
+import org.apache.sysml.runtime.instructions.spark.utils.{ RDDConverterUtilsExt => RDDConverterUtils }
+import org.apache.sysml.api.mlcontext._
+import org.apache.sysml.api.mlcontext.ScriptFactory._
+
+trait BaseSystemMLRegressor extends BaseSystemMLEstimator {
+  
+  def fit(X_mb: MatrixBlock, y_mb: MatrixBlock, sc: SparkContext): MLResults = {
+    val isSingleNode = true
+    val ml = new MLContext(sc)
+    val ret = getTrainingScript(isSingleNode)
+    val script = ret._1.in(ret._2, X_mb).in(ret._3, y_mb)
+    ml.execute(script)
+  }
+  
+  def fit(df: ScriptsUtils.SparkDataType, sc: SparkContext): MLResults = {
+    val isSingleNode = false
+    val ml = new MLContext(df.rdd.sparkContext)
+    val mcXin = new MatrixCharacteristics()
+    val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(sc, df.asInstanceOf[DataFrame], mcXin, false, "features")
+    val yin = df.select("label")
+    val ret = getTrainingScript(isSingleNode)
+    val Xbin = new BinaryBlockMatrix(Xin, mcXin)
+    val script = ret._1.in(ret._2, Xbin).in(ret._3, yin)
+    ml.execute(script)
+  }
+}
+
+trait BaseSystemMLRegressorModel extends BaseSystemMLEstimatorModel {
+  
+  def transform(X: MatrixBlock, mloutput: MLResults, sc: SparkContext, predictionVar:String): MatrixBlock = {
+    val isSingleNode = true
+    val ml = new MLContext(sc)
+    val script = getPredictionScript(mloutput, isSingleNode)
+    val modelPredict = ml.execute(script._1.in(script._2, X))
+    val ret = modelPredict.getBinaryBlockMatrix(predictionVar).getMatrixBlock
+              
+    if(ret.getNumColumns != 1) {
+      throw new RuntimeException("Expected prediction to be a column vector")
+    }
+    return ret
+  }
+  
+  def transform(df: ScriptsUtils.SparkDataType, mloutput: MLResults, sc: SparkContext, predictionVar:String): DataFrame = {
+    val isSingleNode = false
+    val ml = new MLContext(sc)
+    val mcXin = new MatrixCharacteristics()
+    val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(df.rdd.sparkContext, df.asInstanceOf[DataFrame], mcXin, false, "features")
+    val script = getPredictionScript(mloutput, isSingleNode)
+    val Xin_bin = new BinaryBlockMatrix(Xin, mcXin)
+    val modelPredict = ml.execute(script._1.in(script._2, Xin_bin))
+    val predictedDF = modelPredict.getDataFrame(predictionVar).select("ID", "C1").withColumnRenamed("C1", "prediction")
+    val dataset = RDDConverterUtils.addIDToDataFrame(df.asInstanceOf[DataFrame], df.sqlContext, "ID")
+    return PredictionUtils.joinUsingID(dataset, predictedDF)
+  }
+}

--- a/src/main/scala/org/apache/sysml/api/ml/LinearRegression.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/LinearRegression.scala
@@ -51,7 +51,6 @@ class LinearRegression(override val uid: String, val sc: SparkContext, val solve
   }
   def transformSchema(schema: StructType): StructType = schema
   
-  // Note: will update the y_mb as this will be called by Python mllearn
   def fit(X_mb: MatrixBlock, y_mb: MatrixBlock): LinearRegressionModel = {
     val ml = new MLContext(sc)
     if(y_mb.getNumColumns != 1) {

--- a/src/main/scala/org/apache/sysml/api/ml/LinearRegression.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/LinearRegression.scala
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.api.ml
+
+import java.io.File
+import org.apache.spark.SparkContext
+import org.apache.spark.ml.{ Model, Estimator }
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.ml.param.ParamMap
+import org.apache.sysml.api.{ MLContext, MLOutput }
+import org.apache.sysml.runtime.matrix.MatrixCharacteristics
+import org.apache.sysml.runtime.matrix.data.MatrixBlock
+import org.apache.sysml.runtime.DMLRuntimeException
+import org.apache.sysml.runtime.instructions.spark.utils.{ RDDConverterUtilsExt => RDDConverterUtils }
+
+object LinearRegression {
+  final val scriptPathCG = "scripts" + File.separator + "algorithms" + File.separator + "LinearRegCG.dml"
+  final val scriptPathDS = "scripts" + File.separator + "algorithms" + File.separator + "LinearRegDS.dml"
+}
+
+// algorithm = "direct-solve", "conjugate-gradient"
+class LinearRegression(override val uid: String, val sc: SparkContext, val solver:String="direct-solve") extends Estimator[LinearRegressionModel] with HasIcpt
+    with HasRegParam with HasTol with HasMaxOuterIter {
+  
+  def setIcpt(value: Int) = set(icpt, value)
+  def setMaxIter(value: Int) = set(maxOuterIter, value)
+  def setRegParam(value: Double) = set(regParam, value)
+  def setTol(value: Double) = set(tol, value)
+  
+  override def copy(extra: ParamMap): Estimator[LinearRegressionModel] = {
+    val that = new LinearRegression(uid, sc, solver)
+    copyValues(that, extra)
+  }
+  def transformSchema(schema: StructType): StructType = schema
+  
+  // Note: will update the y_mb as this will be called by Python mllearn
+  def fit(X_mb: MatrixBlock, y_mb: MatrixBlock): LinearRegressionModel = {
+    val ml = new MLContext(sc)
+    if(y_mb.getNumColumns != 1) {
+      throw new RuntimeException("Expected a column vector for y")
+    }
+    val mloutput = {
+      ml.registerInput("X", X_mb);
+      ml.registerInput("y", y_mb);
+      ml.registerOutput("beta_out");
+      if(solver.compareTo("direct-solve") == 0)
+        ml.executeScript(ScriptsUtils.getDMLScript(LinearRegression.scriptPathDS), getParamMap())
+      else if(solver.compareTo("newton-cg") == 0) {
+        ml.executeScript(ScriptsUtils.getDMLScript(LinearRegression.scriptPathCG), getParamMap())
+      }
+      else {
+        throw new DMLRuntimeException("The algorithm should be direct-solve or conjugate-gradient")
+      }
+    }
+    new LinearRegressionModel("linearRegression")(mloutput, sc)
+  }
+  
+  def getParamMap(): Map[String, String] = {
+    Map(  "icpt" -> this.getIcpt.toString(),
+          "reg" -> this.getRegParam.toString(),
+          "tol" -> this.getTol.toString,
+          "maxi" -> this.getMaxOuterIte.toString,
+  
+          "X" -> " ",
+          "Y" -> " ",
+          "B" -> " ", 
+          "O" -> " ", 
+          "Log" -> " ",
+          "fmt" -> "binary")
+  }
+  
+  def fit(df: DataFrame): LinearRegressionModel = {
+    val ml = new MLContext(df.rdd.sparkContext)
+    val mcXin = new MatrixCharacteristics()
+    val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(sc, df, mcXin, false, "features")
+    val yin = df.select("label")
+    val mloutput = {
+      ml.registerInput("X", Xin, mcXin);
+      ml.registerInput("y", yin);
+      ml.registerOutput("beta_out");
+      if(solver.compareTo("direct-solve") == 0)
+        ml.executeScript(ScriptsUtils.getDMLScript(LinearRegression.scriptPathDS), getParamMap())
+      else if(solver.compareTo("newton-cg") == 0) {
+        ml.executeScript(ScriptsUtils.getDMLScript(LinearRegression.scriptPathCG), getParamMap())
+      }
+      else {
+        throw new DMLRuntimeException("The algorithm should be direct-solve or conjugate-gradient")
+      }
+    }
+    new LinearRegressionModel("linearRegression")(mloutput, sc)
+  }
+}
+
+class LinearRegressionModel(override val uid: String)(val mloutput: MLOutput, val sc: SparkContext) extends Model[LinearRegressionModel] with HasIcpt
+    with HasRegParam with HasTol with HasMaxOuterIter {
+  override def copy(extra: ParamMap): LinearRegressionModel = {
+    val that = new LinearRegressionModel(uid)(mloutput, sc)
+    copyValues(that, extra)
+  }
+  
+  override def transformSchema(schema: StructType): StructType = schema
+  
+  def transform(df: DataFrame): DataFrame = {
+    val isSingleNode = false
+    val glmPredOut = PredictionUtils.doGLMPredict(isSingleNode, df, null, sc, mloutput, "beta_out", getPredictParams())
+    val predictedDF = glmPredOut.getDF(df.sqlContext, "means").withColumnRenamed("C1", "prediction")
+    val dataset = RDDConverterUtils.addIDToDataFrame(df, df.sqlContext, "ID")
+    return PredictionUtils.joinUsingID(dataset, predictedDF)
+  }
+  
+  def transform(X: MatrixBlock): MatrixBlock =  {
+    val isSingleNode = true
+    return PredictionUtils.doGLMPredict(isSingleNode, null, X, sc, mloutput, "beta_out", getPredictParams()).getMatrixBlock("means")
+  }
+  
+  
+  def getPredictParams(): Map[String, String] = {
+    Map("X" -> " ",
+        "B" -> " ",
+        // Gaussian distribution
+        "dfam" -> "1", "vpow" -> "0.0",
+        // identity link function
+        "link" -> "1", "lpow" -> "1.0"
+//        // Dispersion value: TODO
+//        ,"disp" -> "5.0"
+        )
+  }
+}

--- a/src/main/scala/org/apache/sysml/api/ml/LogisticRegression.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/LogisticRegression.scala
@@ -159,7 +159,7 @@ class LogisticRegressionModel(
       if(ret.getNumColumns != 1) {
         throw new RuntimeException("Expected predicted label to be a column vector")
       }
-      PredictionUtils.updateLabels(true, null, ret, null, labelMapping)
+      PredictionUtils.updateLabels(isSingleNode, null, ret, null, labelMapping)
       return ret
     }
   }

--- a/src/main/scala/org/apache/sysml/api/ml/LogisticRegression.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/LogisticRegression.scala
@@ -60,7 +60,7 @@ class LogisticRegression(override val uid: String, val sc: SparkContext) extends
     new LogisticRegressionModel("log")(ret._1, ret._2, sc)
   }
   
-  def fit(df: DataFrame): LogisticRegressionModel = {
+  def fit(df: ScriptsUtils.SparkDataType): LogisticRegressionModel = {
     val ret = fit(df, sc)
     new LogisticRegressionModel("log")(ret._1, ret._2, sc)
   }
@@ -100,10 +100,10 @@ class LogisticRegressionModel(override val uid: String)(
   def setOutputRawPredictions(outRawPred:Boolean): Unit = { outputRawPredictions = outRawPred }
   
   def getPredictionScript(mloutput: MLResults, isSingleNode:Boolean): (Script, String) =
-    PredictionUtils.getGLMPredictionScript(mloutput.getBinaryBlockMatrix("B_out"), isSingleNode)
+    PredictionUtils.getGLMPredictionScript(mloutput.getBinaryBlockMatrix("B_out"), isSingleNode, 3)
    
   def transform(X: MatrixBlock): MatrixBlock = transform(X, mloutput, labelMapping, sc, "means")
-  def transform(df: DataFrame): DataFrame = transform(df, mloutput, labelMapping, sc, "means")
+  def transform(df: ScriptsUtils.SparkDataType): DataFrame = transform(df, mloutput, labelMapping, sc, "means")
 }
 
 /**

--- a/src/main/scala/org/apache/sysml/api/ml/LogisticRegression.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/LogisticRegression.scala
@@ -34,6 +34,10 @@ import org.apache.spark.SparkConf
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.regression.LabeledPoint
 import scala.reflect.ClassTag
+import scala.collection.immutable.HashMap
+import org.apache.spark.sql.functions.udf
+import org.apache.sysml.runtime.matrix.data.MatrixBlock
+import org.apache.sysml.runtime.DMLRuntimeException
 
 trait HasIcpt extends Params {
   final val icpt: Param[Int] = new Param[Int](this, "icpt", "Intercept presence, shifting and rescaling X columns")
@@ -81,12 +85,62 @@ class LogisticRegression(override val uid: String, val sc: SparkContext) extends
     copyValues(that, extra)
   }
   override def transformSchema(schema: StructType): StructType = schema
+  
+  // Note: will update the y_mb as this will be called by Python mllearn
+  def fit(X_mb: MatrixBlock, y_mb: MatrixBlock): LogisticRegressionModel = {
+    val ml = new MLContext(sc)
+    val labelMapping = new java.util.HashMap[String, Int]
+    val revLabelMapping = new java.util.HashMap[Int, String]
+    if(y_mb.getNumColumns != 1) {
+      throw new RuntimeException("Expected a column vector for y")
+    }
+    if(y_mb.isInSparseFormat()) {
+      throw new DMLRuntimeException("Sparse block is not implemented for fit")
+    }
+    else {
+      val denseBlock = y_mb.getDenseBlock()
+      var id:Int = 1
+      for(i <- 0 until denseBlock.length) {
+        val v = denseBlock(i).toString()
+        if(!labelMapping.containsKey(v)) {
+          labelMapping.put(v, id)
+          revLabelMapping.put(id, v)
+          id += 1
+        }
+        denseBlock.update(i, labelMapping.get(v))
+      }  
+    }
+    
+    val mloutput = {
+      val paramsMap: Map[String, String] = Map(
+        "icpt" -> this.getIcpt.toString(),
+        "reg" -> this.getRegParam.toString(),
+        "tol" -> this.getTol.toString,
+        "moi" -> this.getMaxOuterIte.toString,
+        "mii" -> this.getMaxInnerIter.toString,
+
+        "X" -> " ",
+        "Y" -> " ",
+        "B" -> " ")
+      ml.registerInput("X", X_mb);
+      ml.registerInput("Y_vec", y_mb);
+      ml.registerOutput("B_out");
+      ml.executeScript(ScriptsUtils.getDMLScript(LogisticRegression.scriptPath), paramsMap)
+    }
+    new LogisticRegressionModel("logisticRegression")(mloutput, revLabelMapping, sc)
+  }
   override def fit(df: DataFrame): LogisticRegressionModel = {
     val ml = new MLContext(df.rdd.sparkContext)
     val mcXin = new MatrixCharacteristics()
     val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(sc, df, mcXin, false, "features")
-    val yin = df.select("label").rdd.map { _.apply(0).toString() }
-
+    val temp = df.select("label").distinct.rdd.map(_.apply(0).toString).collect()
+    val labelMapping = new java.util.HashMap[String, Int]
+    val revLabelMapping = new java.util.HashMap[Int, String]
+    for(i <- 0 until temp.length) {
+      labelMapping.put(temp(i), i+1)
+      revLabelMapping.put(i+1, temp(i))
+    }
+    val yin = df.select("label").rdd.map( x => labelMapping.get(x.apply(0).toString).toString )
     val mloutput = {
       val paramsMap: Map[String, String] = Map(
         "icpt" -> this.getIcpt.toString(),
@@ -102,67 +156,151 @@ class LogisticRegression(override val uid: String, val sc: SparkContext) extends
       ml.registerInput("Y_vec", yin, "csv");
       ml.registerOutput("B_out");
       ml.executeScript(ScriptsUtils.getDMLScript(LogisticRegression.scriptPath), paramsMap)
-      //ml.execute(ScriptsUtils.resolvePath(LogisticRegression.scriptPath), paramsMap)
     }
-    new LogisticRegressionModel("logisticRegression")(mloutput)
+    new LogisticRegressionModel("logisticRegression")(mloutput, revLabelMapping, sc)
   }
 }
 object LogisticRegressionModel {
   final val scriptPath = "scripts" + File.separator + "algorithms" + File.separator + "GLM-predict.dml"
 }
 
+class LogisticRegressionModelSerializableData(val labelMapping: java.util.HashMap[Int, String]) extends Serializable {
+ def mapLabelStr(x:Double):String = {
+   if(labelMapping.containsKey(x.toInt))
+     labelMapping.get(x.toInt)
+   else
+     throw new RuntimeException("Incorrect label mapping")
+ }
+ def mapLabelDouble(x:Double):Double = {
+   if(labelMapping.containsKey(x.toInt))
+     labelMapping.get(x.toInt).toDouble
+   else
+     throw new RuntimeException("Incorrect label mapping")
+ }
+ val mapLabel_udf =  {
+      try {
+        val it = labelMapping.values().iterator()
+        while(it.hasNext()) {
+          it.next().toDouble
+        }
+        udf(mapLabelDouble _)
+      } catch {
+        case e: Exception => udf(mapLabelStr _)
+      }
+    }
+}
 /**
  * Logistic Regression Scala API
  */
 
 class LogisticRegressionModel(
   override val uid: String)(
-    val mloutput: MLOutput) extends Model[LogisticRegressionModel] with HasIcpt
+    val mloutput: MLOutput, val labelMapping: java.util.HashMap[Int, String], val sc: SparkContext) extends Model[LogisticRegressionModel] with HasIcpt
     with HasRegParam with HasTol with HasMaxOuterIter with HasMaxInnerIter {
   override def copy(extra: ParamMap): LogisticRegressionModel = {
-    val that = new LogisticRegressionModel(uid)(mloutput)
+    val that = new LogisticRegressionModel(uid)(mloutput, labelMapping, sc)
     copyValues(that, extra)
   }
+  var outputRawPredictions = true
+  def setOutputRawPredictions(outRawPred:Boolean): Unit = { outputRawPredictions = outRawPred }
   override def transformSchema(schema: StructType): StructType = schema
+   
+  def transform(X: MatrixBlock): MatrixBlock = {
+    if(outputRawPredictions) {
+      throw new RuntimeException("Outputting raw prediction is not supported")
+    }
+    else {
+      val isSingleNode = true
+      val ret = computePredictedLabels(doGLMPredict(isSingleNode, null, X), isSingleNode).getMatrixBlock("Prediction");
+      if(ret.getNumColumns != 1) {
+        throw new RuntimeException("Expected predicted label to be a column vector")
+      }
+      if(ret.isInSparseFormat()) {
+        throw new RuntimeException("Since predicted label is a column vector, expected it to be in dense format")
+      }
+      else {
+        updateLabels(true, null, ret, null)
+      }
+      return ret
+    }
+  }
+  
+  def updateLabels(isSingleNode:Boolean, df:DataFrame, X: MatrixBlock, labelColName:String): DataFrame = {
+    if(isSingleNode) {
+      for(i <- 0 until X.getNumRows) {
+        val v:Int = X.getValue(i, 0).toInt
+        if(labelMapping.containsKey(v)) {
+          X.setValue(i, 0, labelMapping.get(v).toDouble)
+        }
+        else {
+          throw new RuntimeException("No mapping found for " + v + " in " + labelMapping.toString())
+        }
+      }
+      return null
+    }
+    else {
+      val serObj = new LogisticRegressionModelSerializableData(labelMapping)
+      return df.withColumn(labelColName, serObj.mapLabel_udf(df(labelColName)))
+               .withColumnRenamed(labelColName, "prediction")
+    }
+  }
+  
+  def doGLMPredict(isSingleNode:Boolean, df:DataFrame, X: MatrixBlock): MLOutput = {
+    val ml = new MLContext(sc)
+    val paramsMap: Map[String, String] = Map(
+        "X" -> " ",
+        "B" -> " ",
+        "dfam" -> "3")
+      if(isSingleNode) {
+        ml.registerInput("X", X);
+        ml.registerInput("B_full", mloutput.getMatrixBlock("B_out"), mloutput.getMatrixCharacteristics("B_out"));
+      }
+      else {
+        val mcXin = new MatrixCharacteristics()
+        val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(df.rdd.sparkContext, df, mcXin, false, "features")
+        ml.registerInput("X", Xin, mcXin);
+        ml.registerInput("B_full", mloutput.getBinaryBlockedRDD("B_out"), mloutput.getMatrixCharacteristics("B_out"));  
+      }
+      ml.registerOutput("means");
+      ml.executeScript(ScriptsUtils.getDMLScript(LogisticRegressionModel.scriptPath), paramsMap)
+  }
+  
+  def computePredictedLabels(mlscoreoutput:MLOutput, isSingleNode:Boolean): MLOutput = {
+    val mlNew = new MLContext(sc)
+    if(isSingleNode) {
+      mlNew.registerInput("Prob", mlscoreoutput.getMatrixBlock("means"), mlscoreoutput.getMatrixCharacteristics("means"));
+    }
+    else {
+      mlNew.registerInput("Prob", mlscoreoutput.getBinaryBlockedRDD("means"), mlscoreoutput.getMatrixCharacteristics("means"));
+    }
+    mlNew.registerOutput("Prediction")
+    mlNew.executeScript(
+      """
+        Prob = read("temp1");
+        Prediction = rowIndexMax(Prob); # assuming one-based label mapping
+        write(Prediction, "tempOut", "csv");
+        """)
+  }
+  
+  def joinUsingID(df1:DataFrame, df2:DataFrame):DataFrame = {
+    val tempDF1 = df1.withColumnRenamed("ID", "ID1")
+    tempDF1.join(df2, tempDF1.col("ID1").equalTo(df2.col("ID"))).drop("ID1")
+  }
+  
   override def transform(df: DataFrame): DataFrame = {
     val ml = new MLContext(df.rdd.sparkContext)
 
-    val mcXin = new MatrixCharacteristics()
-    val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(df.rdd.sparkContext, df, mcXin, false, "features")
-
-    val mlscoreoutput = {
-      val paramsMap: Map[String, String] = Map(
-        "X" -> " ",
-        "B" -> " ")
-      ml.registerInput("X", Xin, mcXin);
-      ml.registerInput("B_full", mloutput.getBinaryBlockedRDD("B_out"), mloutput.getMatrixCharacteristics("B_out"));
-      ml.registerOutput("means");
-      ml.executeScript(ScriptsUtils.getDMLScript(LogisticRegressionModel.scriptPath), paramsMap)
+    val isSingleNode = false
+    val glmPredOut = doGLMPredict(isSingleNode, df, null)
+    val predLabelOut = computePredictedLabels(glmPredOut, isSingleNode)
+    val predictedDF = updateLabels(isSingleNode, predLabelOut.getDF(df.sqlContext, "Prediction"), null, "C1").select("ID", "prediction")
+    val prob = glmPredOut.getDF(df.sqlContext, "means", true).withColumnRenamed("C1", "probability").select("ID", "probability")
+    val dataset = RDDConverterUtils.addIDToDataFrame(df, df.sqlContext, "ID")
+    
+    if(outputRawPredictions) {
+      // Not supported: rawPred = 1 / (1 + exp(- X * t(B_full)) );
     }
-
-    val prob = mlscoreoutput.getDF(df.sqlContext, "means", true).withColumnRenamed("C1", "probability")
-
-    val mlNew = new MLContext(df.rdd.sparkContext)
-    mlNew.registerInput("X", Xin, mcXin);
-    mlNew.registerInput("B_full", mloutput.getBinaryBlockedRDD("B_out"), mloutput.getMatrixCharacteristics("B_out"));
-    mlNew.registerInput("Prob", mlscoreoutput.getBinaryBlockedRDD("means"), mlscoreoutput.getMatrixCharacteristics("means"));
-    mlNew.registerOutput("Prediction");
-    mlNew.registerOutput("rawPred");
-
-    val outNew = mlNew.executeScript("Prob = read(\"temp1\"); "
-      + "Prediction = rowIndexMax(Prob); "
-      + "write(Prediction, \"tempOut\", \"csv\")"
-      + "X = read(\"temp2\");"
-      + "B_full = read(\"temp3\");"
-      + "rawPred = 1 / (1 + exp(- X * t(B_full)) );" // Raw prediction logic: 
-      + "write(rawPred, \"tempOut1\", \"csv\")");
-
-    val pred = outNew.getDF(df.sqlContext, "Prediction").withColumnRenamed("C1", "prediction").withColumnRenamed("ID", "ID1")
-    val rawPred = outNew.getDF(df.sqlContext, "rawPred", true).withColumnRenamed("C1", "rawPrediction").withColumnRenamed("ID", "ID2")
-    var predictionsNProb = prob.join(pred, prob.col("ID").equalTo(pred.col("ID1"))).select("ID", "probability", "prediction")
-    predictionsNProb = predictionsNProb.join(rawPred, predictionsNProb.col("ID").equalTo(rawPred.col("ID2"))).select("ID", "probability", "prediction", "rawPrediction")
-    val dataset1 = RDDConverterUtils.addIDToDataFrame(df, df.sqlContext, "ID")
-    dataset1.join(predictionsNProb, dataset1.col("ID").equalTo(predictionsNProb.col("ID")))
+    return joinUsingID(dataset, joinUsingID(prob, predictedDF))
   }
 }
 

--- a/src/main/scala/org/apache/sysml/api/ml/NaiveBayes.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/NaiveBayes.scala
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.api.ml
+
+import java.io.File
+import org.apache.spark.SparkContext
+import org.apache.spark.ml.{ Model, Estimator }
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.ml.param.{ Params, Param, ParamMap, DoubleParam }
+import org.apache.sysml.api.{ MLContext, MLOutput }
+import org.apache.sysml.runtime.matrix.MatrixCharacteristics
+import org.apache.sysml.runtime.matrix.data.MatrixBlock
+import org.apache.sysml.runtime.DMLRuntimeException
+import org.apache.sysml.runtime.instructions.spark.utils.{ RDDConverterUtilsExt => RDDConverterUtils }
+
+trait HasLaplace extends Params {
+  final val laplace: Param[Double] = new Param[Double](this, "laplace", "Laplace smoothing specified by the user to avoid creation of 0 probabilities.")
+  setDefault(laplace, 1.0)
+  final def getLaplace: Double = $(laplace)
+}
+
+object NaiveBayes {
+  final val scriptPath = "scripts" + File.separator + "algorithms" + File.separator + "naive-bayes.dml"
+}
+
+class NaiveBayes(override val uid: String, val sc: SparkContext) extends Estimator[NaiveBayesModel] with HasLaplace {
+  override def copy(extra: ParamMap): Estimator[NaiveBayesModel] = {
+    val that = new NaiveBayes(uid, sc)
+    copyValues(that, extra)
+  }
+  def setLaplace(value: Double) = set(laplace, value)
+  override def transformSchema(schema: StructType): StructType = schema
+  
+  // Note: will update the y_mb as this will be called by Python mllearn
+  def fit(X_mb: MatrixBlock, y_mb: MatrixBlock): NaiveBayesModel = {
+    val ml = new MLContext(sc)
+    val revLabelMapping = new java.util.HashMap[Int, String]
+    PredictionUtils.fillLabelMapping(y_mb, revLabelMapping)
+    
+    val mloutput = {
+      ml.registerInput("D", X_mb);
+      ml.registerInput("C", y_mb);
+      ml.registerOutput("classPrior");
+      ml.registerOutput("classConditionals");
+      ml.executeScript(ScriptsUtils.getDMLScript(NaiveBayes.scriptPath), getParamMap())
+    }
+    new NaiveBayesModel("naivebayes")(mloutput, revLabelMapping, sc)
+  }
+  
+  def fit(df: DataFrame): NaiveBayesModel = {
+    val ml = new MLContext(df.rdd.sparkContext)
+    val mcXin = new MatrixCharacteristics()
+    val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(sc, df, mcXin, false, "features")
+    val revLabelMapping = new java.util.HashMap[Int, String]
+    val yin = PredictionUtils.fillLabelMapping(df, revLabelMapping)
+    val mloutput = {
+      ml.registerInput("D", Xin, mcXin);
+      ml.registerInput("C", yin, "csv");
+      ml.registerOutput("classPrior");
+      ml.registerOutput("classConditionals");
+      ml.executeScript(ScriptsUtils.getDMLScript(NaiveBayes.scriptPath), getParamMap())
+    }
+    new NaiveBayesModel("naive")(mloutput, revLabelMapping, sc)
+  }
+  
+  def getParamMap(): Map[String, String] = {
+    Map("X" -> " ",
+        "Y" -> " ",
+        "prior" -> " ",
+        "conditionals" -> " ",
+        "accuracy" -> " ",
+        "laplace" -> getLaplace.toString())
+  }
+}
+
+
+object NaiveBayesModel {
+  final val scriptPath = "scripts" + File.separator + "algorithms" + File.separator + "naive-bayes-predict.dml"
+}
+
+class NaiveBayesModel(
+  override val uid: String)(
+    val mloutput: MLOutput, val labelMapping: java.util.HashMap[Int, String], val sc: SparkContext) extends Model[NaiveBayesModel] with HasLaplace {
+  override def copy(extra: ParamMap): NaiveBayesModel = {
+    val that = new NaiveBayesModel(uid)(mloutput, labelMapping, sc)
+    copyValues(that, extra)
+  }
+  
+  def transformSchema(schema: StructType): StructType = schema
+  
+  var priorMB: MatrixBlock = null
+  var conditionalMB: MatrixBlock = null
+  def setPriorAndConditional(prior:MatrixBlock, conditional:MatrixBlock) {
+    priorMB = prior
+    conditionalMB = conditional
+  }
+  
+  def transform(X: MatrixBlock): MatrixBlock = {
+    val isSingleNode = true
+    val ml = new MLContext(sc)
+    ml.registerInput("D", X)
+    ml.registerInput("prior", mloutput.getMatrixBlock("classPrior"), mloutput.getMatrixCharacteristics("classPrior"))
+    ml.registerInput("conditionals", mloutput.getMatrixBlock("classConditionals"), mloutput.getMatrixCharacteristics("classConditionals"))
+    ml.registerOutput("probs")
+    val nbPredict = ml.executeScript(ScriptsUtils.getDMLScript(NaiveBayesModel.scriptPath), getPredictParams())
+    val ret = PredictionUtils.computePredictedClassLabelsFromProbability(nbPredict, isSingleNode, sc, "probs").getMatrixBlock("Prediction");
+    if(ret.getNumColumns != 1) {
+      throw new RuntimeException("Expected predicted label to be a column vector")
+    }
+    PredictionUtils.updateLabels(isSingleNode, null, ret, null, labelMapping)
+    return ret
+  }
+  
+  def transform(df: org.apache.spark.sql.DataFrame): org.apache.spark.sql.DataFrame = {
+    val isSingleNode = false
+    val ml = new MLContext(sc)
+    val mcXin = new MatrixCharacteristics()
+    val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(df.rdd.sparkContext, df, mcXin, false, "features")
+    ml.registerInput("D", Xin, mcXin);
+    ml.registerInput("prior", mloutput.getMatrixBlock("classPrior"), mloutput.getMatrixCharacteristics("classPrior"))
+    ml.registerInput("conditionals", mloutput.getMatrixBlock("classConditionals"), mloutput.getMatrixCharacteristics("classConditionals"))
+    ml.registerOutput("probs")
+    val nbPredict = ml.executeScript(ScriptsUtils.getDMLScript(NaiveBayesModel.scriptPath), getPredictParams())
+    val predLabelOut = PredictionUtils.computePredictedClassLabelsFromProbability(nbPredict, isSingleNode, sc, "probs")
+    val predictedDF = PredictionUtils.updateLabels(isSingleNode, predLabelOut.getDF(df.sqlContext, "Prediction"), null, "C1", labelMapping).select("ID", "prediction")
+    val prob = nbPredict.getDF(df.sqlContext, "probs", true).withColumnRenamed("C1", "probability").select("ID", "probability")
+    val dataset = RDDConverterUtils.addIDToDataFrame(df, df.sqlContext, "ID")
+    return PredictionUtils.joinUsingID(dataset, PredictionUtils.joinUsingID(prob, predictedDF))
+  }
+  
+  def getPredictParams(): Map[String, String] = {
+    Map("X" -> " ",
+        "prior" -> " ",
+        "conditionals" -> " ",
+        "probabilities" -> " ")
+  }
+
+}

--- a/src/main/scala/org/apache/sysml/api/ml/NaiveBayes.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/NaiveBayes.scala
@@ -50,7 +50,7 @@ class NaiveBayes(override val uid: String, val sc: SparkContext) extends Estimat
     new NaiveBayesModel("naive")(ret._1, ret._2, sc)
   }
   
-  def fit(df: DataFrame): NaiveBayesModel = {
+  def fit(df: ScriptsUtils.SparkDataType): NaiveBayesModel = {
     val ret = fit(df, sc)
     new NaiveBayesModel("naive")(ret._1, ret._2, sc)
   }
@@ -104,6 +104,6 @@ class NaiveBayesModel(override val uid: String)
   }
   
   def transform(X: MatrixBlock): MatrixBlock = transform(X, mloutput, labelMapping, sc, "probs")
-  def transform(df: DataFrame): DataFrame = transform(df, mloutput, labelMapping, sc, "probs")
+  def transform(df: ScriptsUtils.SparkDataType): DataFrame = transform(df, mloutput, labelMapping, sc, "probs")
   
 }

--- a/src/main/scala/org/apache/sysml/api/ml/PredictionUtils.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/PredictionUtils.scala
@@ -19,6 +19,8 @@
 
 package org.apache.sysml.api.ml
 
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.rdd.RDD
 import org.apache.sysml.api.{ MLContext, MLOutput }
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.SparkContext
@@ -45,18 +47,99 @@ object PredictionUtils {
     ml.executeScript(ScriptsUtils.getDMLScript(LogisticRegressionModel.scriptPath), paramsMap)
   }
   
+  def fillLabelMapping(df: DataFrame, revLabelMapping: java.util.HashMap[Int, String]): RDD[String]  = {
+    val temp = df.select("label").distinct.rdd.map(_.apply(0).toString).collect()
+    val labelMapping = new java.util.HashMap[String, Int]
+    for(i <- 0 until temp.length) {
+      labelMapping.put(temp(i), i+1)
+      revLabelMapping.put(i+1, temp(i))
+    }
+    df.select("label").rdd.map( x => labelMapping.get(x.apply(0).toString).toString )
+  }
+  
+  def fillLabelMapping(y_mb: MatrixBlock, revLabelMapping: java.util.HashMap[Int, String]): Unit = {
+    val labelMapping = new java.util.HashMap[String, Int]
+    if(y_mb.getNumColumns != 1) {
+      throw new RuntimeException("Expected a column vector for y")
+    }
+    if(y_mb.isInSparseFormat()) {
+      throw new DMLRuntimeException("Sparse block is not implemented for fit")
+    }
+    else {
+      val denseBlock = y_mb.getDenseBlock()
+      var id:Int = 1
+      for(i <- 0 until denseBlock.length) {
+        val v = denseBlock(i).toString()
+        if(!labelMapping.containsKey(v)) {
+          labelMapping.put(v, id)
+          revLabelMapping.put(id, v)
+          id += 1
+        }
+        denseBlock.update(i, labelMapping.get(v))
+      }  
+    }
+  }
+  
+  class LabelMappingData(val labelMapping: java.util.HashMap[Int, String]) extends Serializable {
+   def mapLabelStr(x:Double):String = {
+     if(labelMapping.containsKey(x.toInt))
+       labelMapping.get(x.toInt)
+     else
+       throw new RuntimeException("Incorrect label mapping")
+   }
+   def mapLabelDouble(x:Double):Double = {
+     if(labelMapping.containsKey(x.toInt))
+       labelMapping.get(x.toInt).toDouble
+     else
+       throw new RuntimeException("Incorrect label mapping")
+   }
+   val mapLabel_udf =  {
+        try {
+          val it = labelMapping.values().iterator()
+          while(it.hasNext()) {
+            it.next().toDouble
+          }
+          udf(mapLabelDouble _)
+        } catch {
+          case e: Exception => udf(mapLabelStr _)
+        }
+      }
+  }  
+  def updateLabels(isSingleNode:Boolean, df:DataFrame, X: MatrixBlock, labelColName:String, labelMapping: java.util.HashMap[Int, String]): DataFrame = {
+    if(isSingleNode) {
+      if(X.isInSparseFormat()) {
+        throw new RuntimeException("Since predicted label is a column vector, expected it to be in dense format")
+      }
+      for(i <- 0 until X.getNumRows) {
+        val v:Int = X.getValue(i, 0).toInt
+        if(labelMapping.containsKey(v)) {
+          X.setValue(i, 0, labelMapping.get(v).toDouble)
+        }
+        else {
+          throw new RuntimeException("No mapping found for " + v + " in " + labelMapping.toString())
+        }
+      }
+      return null
+    }
+    else {
+      val serObj = new LabelMappingData(labelMapping)
+      return df.withColumn(labelColName, serObj.mapLabel_udf(df(labelColName)))
+               .withColumnRenamed(labelColName, "prediction")
+    }
+  }
+  
   def joinUsingID(df1:DataFrame, df2:DataFrame):DataFrame = {
     val tempDF1 = df1.withColumnRenamed("ID", "ID1")
     tempDF1.join(df2, tempDF1.col("ID1").equalTo(df2.col("ID"))).drop("ID1")
   }
   
-  def computePredictedClassLabelsFromProbability(mlscoreoutput:MLOutput, isSingleNode:Boolean, sc:SparkContext): MLOutput = {
+  def computePredictedClassLabelsFromProbability(mlscoreoutput:MLOutput, isSingleNode:Boolean, sc:SparkContext, inProbVar:String): MLOutput = {
     val mlNew = new MLContext(sc)
     if(isSingleNode) {
-      mlNew.registerInput("Prob", mlscoreoutput.getMatrixBlock("means"), mlscoreoutput.getMatrixCharacteristics("means"));
+      mlNew.registerInput("Prob", mlscoreoutput.getMatrixBlock(inProbVar), mlscoreoutput.getMatrixCharacteristics(inProbVar));
     }
     else {
-      mlNew.registerInput("Prob", mlscoreoutput.getBinaryBlockedRDD("means"), mlscoreoutput.getMatrixCharacteristics("means"));
+      mlNew.registerInput("Prob", mlscoreoutput.getBinaryBlockedRDD(inProbVar), mlscoreoutput.getMatrixCharacteristics(inProbVar));
     }
     mlNew.registerOutput("Prediction")
     mlNew.executeScript(

--- a/src/main/scala/org/apache/sysml/api/ml/PredictionUtils.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/PredictionUtils.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.api.ml
+
+import org.apache.sysml.api.{ MLContext, MLOutput }
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.SparkContext
+import org.apache.sysml.runtime.matrix.data.MatrixBlock
+import org.apache.sysml.runtime.DMLRuntimeException
+import org.apache.sysml.runtime.matrix.MatrixCharacteristics
+import org.apache.sysml.runtime.instructions.spark.utils.{ RDDConverterUtilsExt => RDDConverterUtils }
+
+object PredictionUtils {
+  
+  def doGLMPredict(isSingleNode:Boolean, df:DataFrame, X: MatrixBlock, sc:SparkContext, mloutput:MLOutput, B:String, paramsMap: Map[String, String]): MLOutput = {
+    val ml = new MLContext(sc)
+    if(isSingleNode) {
+      ml.registerInput("X", X);
+      ml.registerInput("B_full", mloutput.getMatrixBlock(B), mloutput.getMatrixCharacteristics(B));
+    }
+    else {
+      val mcXin = new MatrixCharacteristics()
+      val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(df.rdd.sparkContext, df, mcXin, false, "features")
+      ml.registerInput("X", Xin, mcXin);
+      ml.registerInput("B_full", mloutput.getBinaryBlockedRDD(B), mloutput.getMatrixCharacteristics(B));  
+    }
+    ml.registerOutput("means");
+    ml.executeScript(ScriptsUtils.getDMLScript(LogisticRegressionModel.scriptPath), paramsMap)
+  }
+  
+  def joinUsingID(df1:DataFrame, df2:DataFrame):DataFrame = {
+    val tempDF1 = df1.withColumnRenamed("ID", "ID1")
+    tempDF1.join(df2, tempDF1.col("ID1").equalTo(df2.col("ID"))).drop("ID1")
+  }
+  
+  def computePredictedClassLabelsFromProbability(mlscoreoutput:MLOutput, isSingleNode:Boolean, sc:SparkContext): MLOutput = {
+    val mlNew = new MLContext(sc)
+    if(isSingleNode) {
+      mlNew.registerInput("Prob", mlscoreoutput.getMatrixBlock("means"), mlscoreoutput.getMatrixCharacteristics("means"));
+    }
+    else {
+      mlNew.registerInput("Prob", mlscoreoutput.getBinaryBlockedRDD("means"), mlscoreoutput.getMatrixCharacteristics("means"));
+    }
+    mlNew.registerOutput("Prediction")
+    mlNew.executeScript(
+      """
+        Prob = read("temp1");
+        Prediction = rowIndexMax(Prob); # assuming one-based label mapping
+        write(Prediction, "tempOut", "csv");
+        """)
+  }
+}

--- a/src/main/scala/org/apache/sysml/api/ml/SVM.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/SVM.scala
@@ -71,7 +71,7 @@ class SVM (override val uid: String, val sc: SparkContext, val isMultiClass:Bool
     new SVMModel("svm")(ret._1, sc, isMultiClass, ret._2)
   }
   
-  def fit(df: DataFrame): SVMModel = {
+  def fit(df: ScriptsUtils.SparkDataType): SVMModel = {
     val ret = fit(df, sc)
     new SVMModel("svm")(ret._1, sc, isMultiClass, ret._2)
   }
@@ -109,5 +109,5 @@ class SVMModel (override val uid: String)(val mloutput: MLResults, val sc: Spark
   }
   
   def transform(X: MatrixBlock): MatrixBlock = transform(X, mloutput, labelMapping, sc, "scores")
-  def transform(df: DataFrame): DataFrame = transform(df, mloutput, labelMapping, sc, "scores")
+  def transform(df: ScriptsUtils.SparkDataType): DataFrame = transform(df, mloutput, labelMapping, sc, "scores")
 }

--- a/src/main/scala/org/apache/sysml/api/ml/SVM.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/SVM.scala
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.api.ml
+
+import java.io.File
+import org.apache.spark.SparkContext
+import org.apache.spark.ml.{ Model, Estimator }
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.ml.param.ParamMap
+import org.apache.sysml.api.{ MLContext, MLOutput }
+import org.apache.sysml.runtime.matrix.MatrixCharacteristics
+import org.apache.sysml.runtime.matrix.data.MatrixBlock
+import org.apache.sysml.runtime.DMLRuntimeException
+import org.apache.sysml.runtime.instructions.spark.utils.{ RDDConverterUtilsExt => RDDConverterUtils }
+
+object SVM {
+  final val scriptPathBinary = "scripts" + File.separator + "algorithms" + File.separator + "l2-svm.dml"
+  final val scriptPathMulticlass = "scripts" + File.separator + "algorithms" + File.separator + "m-svm.dml"
+}
+
+class SVM (override val uid: String, val sc: SparkContext, val isMultiClass:Boolean=false) extends Estimator[SVMModel] with HasIcpt
+    with HasRegParam with HasTol with HasMaxOuterIter {
+
+  def setIcpt(value: Int) = set(icpt, value)
+  def setMaxIter(value: Int) = set(maxOuterIter, value)
+  def setRegParam(value: Double) = set(regParam, value)
+  def setTol(value: Double) = set(tol, value)
+  
+  def setModelParams(m:SVMModel):SVMModel = {
+    m.setIcpt(this.getIcpt).setMaxIter(this.getMaxOuterIte).setRegParam(this.getRegParam).setTol(this.getTol)
+  }
+  
+  override def copy(extra: ParamMap): Estimator[SVMModel] = {
+    val that = new SVM(uid, sc, isMultiClass)
+    copyValues(that, extra)
+  }
+  def transformSchema(schema: StructType): StructType = schema
+  
+  def fit(X_mb: MatrixBlock, y_mb: MatrixBlock): SVMModel = {
+    val ml = new MLContext(sc)
+    val revLabelMapping = new java.util.HashMap[Int, String]
+    PredictionUtils.fillLabelMapping(y_mb, revLabelMapping)
+    if(y_mb.getNumColumns != 1) {
+      throw new RuntimeException("Expected a column vector for y")
+    }
+    val mloutput = {
+      ml.registerInput("X", X_mb);
+      ml.registerInput("Y", y_mb);
+      ml.registerOutput("w");
+      if(isMultiClass)
+        ml.executeScript(ScriptsUtils.getDMLScript(SVM.scriptPathMulticlass), getParamMap())
+      else {
+        ml.executeScript(ScriptsUtils.getDMLScript(SVM.scriptPathBinary), getParamMap())
+      }
+    }
+    setModelParams(new SVMModel("svm")(mloutput, sc, isMultiClass, revLabelMapping))
+  }
+  
+  def getParamMap(): Map[String, String] = {
+    Map(  "icpt" -> this.getIcpt.toString(),
+          "reg" -> this.getRegParam.toString(),
+          "tol" -> this.getTol.toString,
+          "maxiter" -> this.getMaxOuterIte.toString,
+          "X" -> " ",
+          "Y" -> " ",
+          "model" -> " ",
+          "Log" -> " ")
+  }
+  
+  def fit(df: DataFrame): SVMModel = {
+    val ml = new MLContext(df.rdd.sparkContext)
+    val mcXin = new MatrixCharacteristics()
+    val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(sc, df, mcXin, false, "features")
+    val revLabelMapping = new java.util.HashMap[Int, String]
+    val yin = PredictionUtils.fillLabelMapping(df, revLabelMapping)
+    val mloutput = {
+      ml.registerInput("X", Xin, mcXin);
+      ml.registerInput("Y", yin, "csv");
+      ml.registerOutput("w");
+      if(isMultiClass)
+        ml.executeScript(ScriptsUtils.getDMLScript(SVM.scriptPathMulticlass), getParamMap())
+      else {
+        ml.executeScript(ScriptsUtils.getDMLScript(SVM.scriptPathBinary), getParamMap())
+      }
+    }
+    setModelParams(new SVMModel("svm")(mloutput, sc, isMultiClass, revLabelMapping))
+  }
+  
+}
+
+object SVMModel {
+  final val predictionScriptPathBinary = "scripts" + File.separator + "algorithms" + File.separator + "l2-svm-predict.dml"
+  final val predictionScriptPathMulticlass = "scripts" + File.separator + "algorithms" + File.separator + "m-svm-predict.dml"
+}
+
+class SVMModel (override val uid: String)(val mloutput: MLOutput, val sc: SparkContext, val isMultiClass:Boolean, val labelMapping: java.util.HashMap[Int, String]) extends Model[SVMModel] with HasIcpt
+    with HasRegParam with HasTol with HasMaxOuterIter {
+  override def copy(extra: ParamMap): SVMModel = {
+    val that = new SVMModel(uid)(mloutput, sc, isMultiClass, labelMapping)
+    copyValues(that, extra)
+  }
+  
+  def setIcpt(value: Int) = set(icpt, value)
+  def setMaxIter(value: Int) = set(maxOuterIter, value)
+  def setRegParam(value: Double) = set(regParam, value)
+  def setTol(value: Double) = set(tol, value)
+  
+  override def transformSchema(schema: StructType): StructType = schema
+  
+  def transform(df: DataFrame): DataFrame = {
+    val ml = new MLContext(sc)
+    val mcXin = new MatrixCharacteristics()
+    val Xin = RDDConverterUtils.vectorDataFrameToBinaryBlock(df.rdd.sparkContext, df, mcXin, false, "features")
+    ml.registerInput("X", Xin, mcXin);
+    ml.registerOutput("scores");
+    val glmPredOut = {
+      if(isMultiClass) {
+        ml.registerInput("W", mloutput.getBinaryBlockedRDD("w"), mloutput.getMatrixCharacteristics("w"));
+        ml.executeScript(ScriptsUtils.getDMLScript(SVMModel.predictionScriptPathMulticlass), getPredictParams())
+      }
+      else {
+        ml.registerInput("w", mloutput.getBinaryBlockedRDD("w"), mloutput.getMatrixCharacteristics("w"));
+        ml.executeScript(ScriptsUtils.getDMLScript(SVMModel.predictionScriptPathBinary), getPredictParams())
+      }
+    }
+    val isSingleNode = false
+    val predLabelOut = PredictionUtils.computePredictedClassLabelsFromProbability(glmPredOut, isSingleNode, sc, "scores")
+    val predictedDF = PredictionUtils.updateLabels(isSingleNode, predLabelOut.getDF(df.sqlContext, "Prediction"), null, "C1", labelMapping).select("ID", "prediction")
+    val dataset = RDDConverterUtils.addIDToDataFrame(df, df.sqlContext, "ID")
+    return PredictionUtils.joinUsingID(dataset, predictedDF)
+  }
+  
+  def transform(X: MatrixBlock): MatrixBlock =  {
+    val ml = new MLContext(sc)
+    ml.registerInput("X", X);
+    ml.registerInput("w", mloutput.getMatrixBlock("w"), mloutput.getMatrixCharacteristics("w"));
+    ml.registerOutput("scores");
+    val glmPredOut = {
+      if(isMultiClass) {
+        ml.registerInput("W", mloutput.getMatrixBlock("w"), mloutput.getMatrixCharacteristics("w"));
+        ml.executeScript(ScriptsUtils.getDMLScript(SVMModel.predictionScriptPathMulticlass), getPredictParams())
+      }
+      else { 
+        ml.registerInput("w", mloutput.getMatrixBlock("w"), mloutput.getMatrixCharacteristics("w"));
+        ml.executeScript(ScriptsUtils.getDMLScript(SVMModel.predictionScriptPathBinary), getPredictParams())
+      }
+    }
+    val isSingleNode = true
+    val ret = PredictionUtils.computePredictedClassLabelsFromProbability(glmPredOut, isSingleNode, sc, "scores").getMatrixBlock("Prediction");
+    if(ret.getNumColumns != 1) {
+      throw new RuntimeException("Expected predicted label to be a column vector")
+    }
+    PredictionUtils.updateLabels(true, null, ret, null, labelMapping)
+    return ret
+  }
+  
+  
+  def getPredictParams(): Map[String, String] = {
+    Map(  "icpt" -> this.getIcpt.toString(),
+          "reg" -> this.getRegParam.toString(),
+          "tol" -> this.getTol.toString,
+          "maxiter" -> this.getMaxOuterIte.toString,
+          "X" -> " ",
+          "Y" -> " ",
+          "model" -> " ",
+          "Log" -> " ")
+  }
+
+}

--- a/src/main/scala/org/apache/sysml/api/ml/ScriptsUtils.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/ScriptsUtils.scala
@@ -26,6 +26,8 @@ import org.apache.sysml.runtime.DMLRuntimeException
 
 object ScriptsUtils {
   var systemmlHome = System.getenv("SYSTEMML_HOME")
+		  
+  type SparkDataType = org.apache.spark.sql.DataFrame // org.apache.spark.sql.Dataset[_]
 
   /**
    * set SystemML home


### PR DESCRIPTION
1. Fixed bugs in scala LogisticRegression wrapper (handling of raw predictions and passing dfam).

2. Extended java MLContext to accept MatrixBlock. Also added utility function in Python file. (Also created https://issues.apache.org/jira/browse/SYSTEMML-846. It should be a good migration task to learn Python MLContext).

3. Added mllearn class to allow scikit-learn and MLPipeline users to use SystemML. 

### Using SystemML's Logistic Regression (scikit-learn way):
``` python
from sklearn import datasets, neighbors
import SystemML as sml
from pyspark.sql import SQLContext
sqlCtx = SQLContext(sc)
digits = datasets.load_digits()
X_digits = digits.data
y_digits = digits.target + 1
n_samples = len(X_digits)
X_train = X_digits[:.9 * n_samples]
y_train = y_digits[:.9 * n_samples]
X_test = X_digits[.9 * n_samples:]
y_test = y_digits[.9 * n_samples:]
import time
t1 = time.time()
logistic = sml.mllearn.LogisticRegression(sqlCtx)
print('LogisticRegression score: %f' % logistic.fit(X_train, y_train).score(X_test, y_test))
t2 = time.time()
# Convert to DataFrame for i/o: current way to transfer data
logistic = sml.mllearn.LogisticRegression(sqlCtx, transferUsingDF=True)
print('LogisticRegression score: %f' % logistic.fit(X_train, y_train).score(X_test, y_test))
t3 = time.time()
print('Execution time: without DF: %f and with DF: %f' % (t2-t1, t3-t2))
```

Points to note:

- The execution time without DF is 1-2 seconds whereas with DF is 18-20 seconds.
- The current version only supports numeric labels/features.
- The above interface is especially useful if the input/output fit on the node, but the intermediate data doesn't.

### Using SystemML's Logistic Regression (MLPipeline way):
``` python
from pyspark.ml import Pipeline
import SystemML as sml
from pyspark.ml.feature import HashingTF, Tokenizer
from pyspark.sql import SQLContext
sqlCtx = SQLContext(sc)
training = sqlCtx.createDataFrame([
    (0L, "a b c d e spark", 1.0),
    (1L, "b d", 2.0),
    (2L, "spark f g h", 1.0),
    (3L, "hadoop mapreduce", 2.0),
    (4L, "b spark who", 1.0),
    (5L, "g d a y", 2.0),
    (6L, "spark fly", 1.0),
    (7L, "was mapreduce", 2.0),
    (8L, "e spark program", 1.0),
    (9L, "a e c l", 2.0),
    (10L, "spark compile", 1.0),
    (11L, "hadoop software", 2.0)
], ["id", "text", "label"])
tokenizer = Tokenizer(inputCol="text", outputCol="words")
hashingTF = HashingTF(inputCol="words", outputCol="features", numFeatures=20)
lr = sml.mllearn.LogisticRegression(sqlCtx)
pipeline = Pipeline(stages=[tokenizer, hashingTF, lr])
model = pipeline.fit(training)
test = sqlCtx.createDataFrame([
    (12L, "spark i j k"),
    (13L, "l m n"),
    (14L, "mapreduce spark"),
    (15L, "apache hadoop")], ["id", "text"])
prediction = model.transform(test)
prediction.show()
```

### Using SystemML's Linear Regression (scikit-learn way):
``` python
import numpy as np
from sklearn import datasets
import SystemML as sml
from pyspark.sql import SQLContext
# Load the diabetes dataset
diabetes = datasets.load_diabetes()
# Use only one feature
diabetes_X = diabetes.data[:, np.newaxis, 2]
# Split the data into training/testing sets
diabetes_X_train = diabetes_X[:-20]
diabetes_X_test = diabetes_X[-20:]
# Split the targets into training/testing sets
diabetes_y_train = diabetes.target[:-20]
diabetes_y_test = diabetes.target[-20:]
# Create linear regression object
regr = sml.mllearn.LinearRegression(sqlCtx)
# Train the model using the training sets
regr.fit(diabetes_X_train, diabetes_y_train)
# The mean square error
print("Residual sum of squares: %.2f" % np.mean((regr.predict(diabetes_X_test) - diabetes_y_test) ** 2))
```

### Using SystemML's SVM (scikit-learn way):
``` python
from sklearn import datasets, neighbors
import SystemML as sml
from pyspark.sql import SQLContext
sqlCtx = SQLContext(sc)
digits = datasets.load_digits()
X_digits = digits.data
y_digits = digits.target 
n_samples = len(X_digits)
X_train = X_digits[:.9 * n_samples]
y_train = y_digits[:.9 * n_samples]
X_test = X_digits[.9 * n_samples:]
y_test = y_digits[.9 * n_samples:]
svm = sml.mllearn.SVM(sqlCtx, is_multi_class=True)
print('LogisticRegression score: %f' % svm.fit(X_train, y_train).score(X_test, y_test))
```

### Using SystemML's SVM (MLPipeline way):
``` python
from pyspark.ml import Pipeline
import SystemML as sml
from pyspark.ml.feature import HashingTF, Tokenizer
from pyspark.sql import SQLContext
sqlCtx = SQLContext(sc)
training = sqlCtx.createDataFrame([
    (0L, "a b c d e spark", 1.0),
    (1L, "b d", 2.0),
    (2L, "spark f g h", 1.0),
    (3L, "hadoop mapreduce", 2.0),
    (4L, "b spark who", 1.0),
    (5L, "g d a y", 2.0),
    (6L, "spark fly", 1.0),
    (7L, "was mapreduce", 2.0),
    (8L, "e spark program", 1.0),
    (9L, "a e c l", 2.0),
    (10L, "spark compile", 1.0),
    (11L, "hadoop software", 2.0)
], ["id", "text", "label"])
tokenizer = Tokenizer(inputCol="text", outputCol="words")
hashingTF = HashingTF(inputCol="words", outputCol="features", numFeatures=20)
svm = sml.mllearn.SVM(sqlCtx, is_multi_class=True)
pipeline = Pipeline(stages=[tokenizer, hashingTF, svm])
model = pipeline.fit(training)
test = sqlCtx.createDataFrame([
    (12L, "spark i j k"),
    (13L, "l m n"),
    (14L, "mapreduce spark"),
    (15L, "apache hadoop")], ["id", "text"])
prediction = model.transform(test)
prediction.show()
```

### Using SystemML's Naive Bayes (Scikit learn way):
``` python
from sklearn.datasets import fetch_20newsgroups
from sklearn.feature_extraction.text import TfidfVectorizer
import SystemML as sml
from sklearn import metrics
from pyspark.sql import SQLContext
sqlCtx = SQLContext(sc)
categories = ['alt.atheism', 'talk.religion.misc', 'comp.graphics', 'sci.space']
newsgroups_train = fetch_20newsgroups(subset='train', categories=categories)
newsgroups_test = fetch_20newsgroups(subset='test', categories=categories)
vectorizer = TfidfVectorizer()
# Both vectors and vectors_test are SciPy CSR matrix
vectors = vectorizer.fit_transform(newsgroups_train.data)
vectors_test = vectorizer.transform(newsgroups_test.data)
nb = sml.mllearn.NaiveBayes(sqlCtx)
nb.fit(vectors, newsgroups_train.target)
pred = nb.predict(vectors_test)
metrics.f1_score(newsgroups_test.target, pred, average='weighted')
```