### PR TITLE
[SYSTEMML-865] Add Matrix Wrapper to Python MLContext

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
@@ -340,12 +340,14 @@ public class MLResults {
 
 	public Object get(String outputName) {
 		Data data = getData(outputName);
-	  if (data instanceof ScalarObject) {
-	  	ScalarObject so = (ScalarObject) data;
-	    	return so.getValue();
-	  } else {
-	      return data;
-	  }
+		if (data instanceof ScalarObject) {
+			ScalarObject so = (ScalarObject) data;
+			return so.getValue();
+		} else if(data instanceof MatrixObject) {
+			return getMatrix(outputName);
+		} else {
+			return data;
+		}
 	}
 
 	/**

--- a/src/main/python/SystemML.py
+++ b/src/main/python/SystemML.py
@@ -65,6 +65,7 @@ def pydml(scriptString):
 
 def _java2py(sc, obj):
     """ Convert Java object to Python. """
+    # TODO: Port this private PySpark function.
     obj = pyspark.mllib.common._java2py(sc, obj)
     if isinstance(obj, JavaObject):
         class_name = obj.getClass().getSimpleName()
@@ -77,6 +78,7 @@ def _py2java(sc, obj):
     """ Convert Python object to Java. """
     if isinstance(obj, Matrix):
         obj = obj._java_matrix
+    # TODO: Port this private PySpark function.
     obj = pyspark.mllib.common._py2java(sc, obj)
     return obj
 
@@ -100,22 +102,20 @@ class Matrix(object):
     def __repr__(self):
         return "Matrix"
 
-    def toDF(self, keepIndex=False):
+    def toDF(self):
         """
-        Convert the Matrix to a DataFrame.
+        Convert the Matrix to a PySpark SQL DataFrame.
 
-        Parameters
-        ----------
-        keepIndex: Boolean
-            Either keep the row index in the DataFrame as a column named "ID",
-            or sort the DataFrame by the row index, then drop the index column.
-            Note: If the index is dropped, the DataFrame will be returned ordered,
-            but the order may not be preserved in subsequent operations.
+        Returns
+        -------
+        df: PySpark SQL DataFrame
+            A PySpark SQL DataFrame representing the matrix, with
+            one "ID" column containing the row index (since Spark
+            DataFrames are unordered), followed by columns of doubles
+            for each column in the matrix.
         """
         jdf = self._java_matrix.asDataFrame()
         df = _java2py(self.sc, jdf)
-        if not keepIndex:
-            df = df.sort("ID").drop("ID")
         return df
 
 


### PR DESCRIPTION
This allows the Java API to return a `Matrix` type, with the Python side creating a simple wrapper around it.  Then, the user can either use this `Matrix` object in a future SystemML script, or can convert it to a DataFrame with `toDF()`.  For the latter conversion, I've opted to go ahead and sort by the row index, and then drop the index column by default, although the option exists for the user to instead keep the row index ("ID") column to preserve order through any future operations on the DataFrame.

cc @MechCoder, @deroneriksson 