### PR TITLE
[SYSTEMML-834] Improve MLContext DataFrame support

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/BinaryBlockMatrix.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/BinaryBlockMatrix.java
@@ -99,12 +99,21 @@ public class BinaryBlockMatrix {
 	public JavaPairRDD<MatrixIndexes, MatrixBlock> getBinaryBlocks() {
 		return binaryBlocks;
 	}
-	
-	public MatrixBlock getMatrixBlock() throws DMLRuntimeException {
-		MatrixCharacteristics mc = getMatrixCharacteristics();
-		MatrixBlock mb = SparkExecutionContext.toMatrixBlock(binaryBlocks, (int) mc.getRows(), (int) mc.getCols(), 
-				mc.getRowsPerBlock(), mc.getColsPerBlock(), mc.getNonZeros());
-		return mb;
+
+	/**
+	 * Obtain a SystemML binary-block matrix as a {@code MatrixBlock}
+	 * 
+	 * @return the SystemML binary-block matrix as a {@code MatrixBlock}
+	 */
+	public MatrixBlock getMatrixBlock() {
+		try {
+			MatrixCharacteristics mc = getMatrixCharacteristics();
+			MatrixBlock mb = SparkExecutionContext.toMatrixBlock(binaryBlocks, (int) mc.getRows(), (int) mc.getCols(),
+					mc.getRowsPerBlock(), mc.getColsPerBlock(), mc.getNonZeros());
+			return mb;
+		} catch (DMLRuntimeException e) {
+			throw new MLContextException("Exception while getting MatrixBlock from binary-block matrix", e);
+		}
 	}
 
 	/**

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
@@ -236,7 +236,7 @@ public class MLResults {
 	}
 
 	/**
-	 * Obtain an output as a {@code DataFrame} of doubles.
+	 * Obtain an output as a {@code DataFrame} of doubles with an ID column.
 	 * <p>
 	 * The following matrix in DML:
 	 * </p>
@@ -245,13 +245,13 @@ public class MLResults {
 	 * <p>
 	 * is equivalent to the following {@code DataFrame} of doubles:
 	 * </p>
-	 * <code>[0.0,1.0,2.0]
-	 * <br>[1.0,3.0,4.0]
+	 * <code>[1.0,1.0,2.0]
+	 * <br>[2.0,3.0,4.0]
 	 * </code>
 	 *
 	 * @param outputName
 	 *            the name of the output
-	 * @return the output as a {@code DataFrame} of doubles
+	 * @return the output as a {@code DataFrame} of doubles with an ID column
 	 */
 	public DataFrame getDataFrame(String outputName) {
 		MatrixObject mo = getMatrixObject(outputName);
@@ -259,9 +259,136 @@ public class MLResults {
 		return df;
 	}
 
+	/**
+	 * Obtain an output as a {@code DataFrame} of doubles or vectors with an ID
+	 * column.
+	 * <p>
+	 * The following matrix in DML:
+	 * </p>
+	 * <code>M = full('1 2 3 4', rows=2, cols=2);
+	 * </code>
+	 * <p>
+	 * is equivalent to the following {@code DataFrame} of doubles:
+	 * </p>
+	 * <code>[1.0,1.0,2.0]
+	 * <br>[2.0,3.0,4.0]
+	 * </code>
+	 * <p>
+	 * or the following {@code DataFrame} of vectors:
+	 * </p>
+	 * <code>[1.0,[1.0,2.0]]
+	 * <br>[2.0,[3.0,4.0]]
+	 * </code>
+	 *
+	 * @param outputName
+	 *            the name of the output
+	 * @param isVectorDF
+	 *            {@code true} for a vector {@code DataFrame}, {@code false} for
+	 *            a double {@code DataFrame}
+	 * @return the output as a {@code DataFrame} of doubles or vectors with an
+	 *         ID column
+	 */
 	public DataFrame getDataFrame(String outputName, boolean isVectorDF) {
 		MatrixObject mo = getMatrixObject(outputName);
 		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext, isVectorDF);
+		return df;
+	}
+
+	/**
+	 * Obtain an output as a {@code DataFrame} of doubles with an ID column.
+	 * <p>
+	 * The following matrix in DML:
+	 * </p>
+	 * <code>M = full('1 2 3 4', rows=2, cols=2);
+	 * </code>
+	 * <p>
+	 * is equivalent to the following {@code DataFrame} of doubles:
+	 * </p>
+	 * <code>[1.0,1.0,2.0]
+	 * <br>[2.0,3.0,4.0]
+	 * </code>
+	 *
+	 * @param outputName
+	 *            the name of the output
+	 * @return the output as a {@code DataFrame} of doubles with an ID column
+	 */
+	public DataFrame getDataFrameDoubleWithIDColumn(String outputName) {
+		MatrixObject mo = getMatrixObject(outputName);
+		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext, false);
+		return df;
+	}
+
+	/**
+	 * Obtain an output as a {@code DataFrame} of vectors with an ID column.
+	 * <p>
+	 * The following matrix in DML:
+	 * </p>
+	 * <code>M = full('1 2 3 4', rows=2, cols=2);
+	 * </code>
+	 * <p>
+	 * is equivalent to the following {@code DataFrame} of vectors:
+	 * </p>
+	 * <code>[1.0,[1.0,2.0]]
+	 * <br>[2.0,[3.0,4.0]]
+	 * </code>
+	 *
+	 * @param outputName
+	 *            the name of the output
+	 * @return the output as a {@code DataFrame} of vectors with an ID column
+	 */
+	public DataFrame getDataFrameVectorWithIDColumn(String outputName) {
+		MatrixObject mo = getMatrixObject(outputName);
+		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext, true);
+		return df;
+	}
+
+	/**
+	 * Obtain an output as a {@code DataFrame} of doubles with no ID column.
+	 * <p>
+	 * The following matrix in DML:
+	 * </p>
+	 * <code>M = full('1 2 3 4', rows=2, cols=2);
+	 * </code>
+	 * <p>
+	 * is equivalent to the following {@code DataFrame} of doubles:
+	 * </p>
+	 * <code>[1.0,2.0]
+	 * <br>[3.0,4.0]
+	 * </code>
+	 *
+	 * @param outputName
+	 *            the name of the output
+	 * @return the output as a {@code DataFrame} of doubles with no ID column
+	 */
+	public DataFrame getDataFrameDoubleNoIDColumn(String outputName) {
+		MatrixObject mo = getMatrixObject(outputName);
+		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext, false);
+		df = df.drop("ID");
+		return df;
+	}
+
+	/**
+	 * Obtain an output as a {@code DataFrame} of vectors with no ID column.
+	 * <p>
+	 * The following matrix in DML:
+	 * </p>
+	 * <code>M = full('1 2 3 4', rows=2, cols=2);
+	 * </code>
+	 * <p>
+	 * is equivalent to the following {@code DataFrame} of vectors:
+	 * </p>
+	 * <code>[[1.0,2.0]]
+	 * <br>[[3.0,4.0]]
+	 * </code>
+	 *
+	 * @param outputName
+	 *            the name of the output
+	 * @return the output as a {@code DataFrame} of vectors with no ID column
+	 */
+	public DataFrame getDataFrameVectorNoIDColumn(String outputName) {
+		MatrixObject mo = getMatrixObject(outputName);
+		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext, true);
+		df = df.drop("ID");
 		return df;
 	}
 
@@ -277,7 +404,6 @@ public class MLResults {
 		Matrix matrix = new Matrix(mo, sparkExecutionContext);
 		return matrix;
 	}
-
 
 	/**
 	 * Obtain an output as a {@code BinaryBlockMatrix}.
@@ -340,12 +466,12 @@ public class MLResults {
 
 	public Object get(String outputName) {
 		Data data = getData(outputName);
-	  if (data instanceof ScalarObject) {
-	  	ScalarObject so = (ScalarObject) data;
-	    	return so.getValue();
-	  } else {
-	      return data;
-	  }
+		if (data instanceof ScalarObject) {
+			ScalarObject so = (ScalarObject) data;
+			return so.getValue();
+		} else {
+			return data;
+		}
 	}
 
 	/**

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
@@ -363,7 +363,7 @@ public class MLResults {
 	public DataFrame getDataFrameDoubleNoIDColumn(String outputName) {
 		MatrixObject mo = getMatrixObject(outputName);
 		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext, false);
-		df = df.drop("ID");
+		df = df.sort("ID").drop("ID");
 		return df;
 	}
 
@@ -388,7 +388,7 @@ public class MLResults {
 	public DataFrame getDataFrameVectorNoIDColumn(String outputName) {
 		MatrixObject mo = getMatrixObject(outputName);
 		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext, true);
-		df = df.drop("ID");
+		df = df.sort("ID").drop("ID");
 		return df;
 	}
 

--- a/src/main/java/org/apache/sysml/api/mlcontext/Matrix.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/Matrix.java
@@ -129,7 +129,7 @@ public class Matrix {
 	 */
 	public DataFrame asDataFrameDoubleNoIDColumn() {
 		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext, false);
-		df = df.drop("ID");
+		df = df.sort("ID").drop("ID");
 		return df;
 	}
 
@@ -150,7 +150,7 @@ public class Matrix {
 	 */
 	public DataFrame asDataFrameVectorNoIDColumn() {
 		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext, true);
-		df = df.drop("ID");
+		df = df.sort("ID").drop("ID");
 		return df;
 	}
 

--- a/src/main/java/org/apache/sysml/api/mlcontext/Matrix.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/Matrix.java
@@ -103,12 +103,54 @@ public class Matrix {
 	}
 
 	/**
-	 * Obtain the matrix as a {@code DataFrame}
+	 * Obtain the matrix as a {@code DataFrame} of doubles with an ID column
 	 * 
-	 * @return the matrix as a {@code DataFrame}
+	 * @return the matrix as a {@code DataFrame} of doubles with an ID column
 	 */
 	public DataFrame asDataFrame() {
 		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext, false);
+		return df;
+	}
+
+	/**
+	 * Obtain the matrix as a {@code DataFrame} of doubles with an ID column
+	 * 
+	 * @return the matrix as a {@code DataFrame} of doubles with an ID column
+	 */
+	public DataFrame asDataFrameDoubleWithIDColumn() {
+		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext, false);
+		return df;
+	}
+
+	/**
+	 * Obtain the matrix as a {@code DataFrame} of doubles with no ID column
+	 * 
+	 * @return the matrix as a {@code DataFrame} of doubles with no ID column
+	 */
+	public DataFrame asDataFrameDoubleNoIDColumn() {
+		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext, false);
+		df = df.drop("ID");
+		return df;
+	}
+
+	/**
+	 * Obtain the matrix as a {@code DataFrame} of vectors with an ID column
+	 * 
+	 * @return the matrix as a {@code DataFrame} of vectors with an ID column
+	 */
+	public DataFrame asDataFrameVectorWithIDColumn() {
+		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext, true);
+		return df;
+	}
+
+	/**
+	 * Obtain the matrix as a {@code DataFrame} of vectors with no ID column
+	 * 
+	 * @return the matrix as a {@code DataFrame} of vectors with no ID column
+	 */
+	public DataFrame asDataFrameVectorNoIDColumn() {
+		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext, true);
+		df = df.drop("ID");
 		return df;
 	}
 

--- a/src/main/java/org/apache/sysml/api/mlcontext/MatrixFormat.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MatrixFormat.java
@@ -34,6 +34,58 @@ public enum MatrixFormat {
 	 * (I J V) format (sparse). I and J represent matrix coordinates and V
 	 * represents the value. The I J and V values are space-separated.
 	 */
-	IJV;
+	IJV,
+
+	/**
+	 * DataFrame of doubles with an ID column.
+	 */
+	DF_DOUBLES_WITH_ID_COLUMN,
+
+	/**
+	 * DataFrame of doubles with no ID column.
+	 */
+	DF_DOUBLES_WITH_NO_ID_COLUMN,
+
+	/**
+	 * Vector DataFrame with an ID column.
+	 */
+	DF_VECTOR_WITH_ID_COLUMN,
+
+	/**
+	 * Vector DataFrame with no ID column.
+	 */
+	DF_VECTOR_WITH_NO_ID_COLUMN;
+
+	/**
+	 * Is the matrix format vector-based?
+	 * 
+	 * @return {@code true} if matrix is a vector-based DataFrame, {@code false}
+	 *         otherwise.
+	 */
+	public boolean isVectorBased() {
+		if (this == DF_VECTOR_WITH_ID_COLUMN) {
+			return true;
+		} else if (this == DF_VECTOR_WITH_NO_ID_COLUMN) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Does the DataFrame have an ID column?
+	 * 
+	 * @return {@code true} if the DataFrame has an ID column, {@code false}
+	 *         otherwise.
+	 */
+	public boolean hasIDColumn() {
+		if (this == DF_DOUBLES_WITH_ID_COLUMN) {
+			return true;
+		} else if (this == DF_VECTOR_WITH_ID_COLUMN) {
+			return true;
+		} else {
+			return false;
+		}
+	}
 
 }


### PR DESCRIPTION
Adds support for 4 types of DataFrame inputs and outputs via MLContext (doubles with ID column, doubles with no ID column, vectors with ID column, vectors with no ID column).