### PR TITLE
[SYSTEMML-870] PYDML script type from file extension

### DIFF
--- a/src/main/java/org/apache/sysml/api/DMLScript.java
+++ b/src/main/java/org/apache/sysml/api/DMLScript.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Scanner;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -345,6 +346,9 @@ public class DMLScript
 				setLoggingProperties( conf );
 		
 			//Step 2: prepare script invocation
+			if (StringUtils.endsWithIgnoreCase(args[1], ".pydml")) {
+				parsePyDML = true;
+			}
 			String dmlScriptStr = readDMLScript(args[0], args[1]);
 			Map<String, String> argVals = createArgumentsMap(namedScriptArgs, scriptArgs);
 			


### PR DESCRIPTION
-python flag currently is required by DMLScript to determine script type.
This PR makes -python optional by using .pydml extension to also determine script type.