### PR TITLE
[SYSTEMML-884] Fix Scala Map MLContext input

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/Script.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/Script.java
@@ -232,6 +232,13 @@ public class Script {
 		return this;
 	}
 
+	/**
+	 * Pass a map of inputs to the script.
+	 *
+	 * @param inputs
+	 *            map of inputs (parameters ($) and variables).
+	 * @return {@code this} Script object to allow chaining of methods
+	 */
 	public Script input(Map<String, Object> inputs) {
 		return in(inputs);
 	}
@@ -243,14 +250,23 @@ public class Script {
 	 *            Scala Map of inputs (parameters ($) and variables).
 	 * @return {@code this} Script object to allow chaining of methods
 	 */
-	public Script in(scala.collection.Map<String, Object> inputs) {
-		Map<String, Object> javaMap = JavaConversions.mapAsJavaMap(inputs);
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public Script in(scala.collection.Map inputs) {
+		Map javaMap = JavaConversions.mapAsJavaMap(inputs);
 		in(javaMap);
 
 		return this;
 	}
 
-	public Script input(scala.collection.Map<String, Object> inputs) {
+	/**
+	 * Pass a Scala Map of inputs to the script.
+	 *
+	 * @param inputs
+	 *            Scala Map of inputs (parameters ($) and variables).
+	 * @return {@code this} Script object to allow chaining of methods
+	 */
+	@SuppressWarnings("rawtypes")
+	public Script input(scala.collection.Map inputs) {
 		return in(inputs);
 	}
 
@@ -282,6 +298,16 @@ public class Script {
 		return this;
 	}
 
+	/**
+	 * Pass a Scala Seq of inputs to the script. The inputs are either two-value
+	 * or three-value tuples, where the first value is the variable name, the
+	 * second value is the variable value, and the third optional value is the
+	 * metadata.
+	 *
+	 * @param inputs
+	 *            Scala Seq of inputs (parameters ($) and variables).
+	 * @return {@code this} Script object to allow chaining of methods
+	 */
 	public Script input(scala.collection.Seq<Object> inputs) {
 		return in(inputs);
 	}
@@ -308,6 +334,15 @@ public class Script {
 		return in(name, value, null);
 	}
 
+	/**
+	 * Register an input (parameter ($) or variable).
+	 *
+	 * @param name
+	 *            name of the input
+	 * @param value
+	 *            value of the input
+	 * @return {@code this} Script object to allow chaining of methods
+	 */
 	public Script input(String name, Object value) {
 		return in(name, value);
 	}
@@ -352,6 +387,18 @@ public class Script {
 		return this;
 	}
 
+	/**
+	 * Register an input (parameter ($) or variable) with optional matrix
+	 * metadata.
+	 *
+	 * @param name
+	 *            name of the input
+	 * @param value
+	 *            value of the input
+	 * @param matrixMetadata
+	 *            optional matrix metadata
+	 * @return {@code this} Script object to allow chaining of methods
+	 */
 	public Script input(String name, Object value, MatrixMetadata matrixMetadata) {
 		return in(name, value, matrixMetadata);
 	}
@@ -369,6 +416,17 @@ public class Script {
 	}
 
 	/**
+	 * Register an output variable.
+	 *
+	 * @param outputName
+	 *            name of the output variable
+	 * @return {@code this} Script object to allow chaining of methods
+	 */
+	public Script output(String outputName) {
+		return out(outputName);
+	}
+
+	/**
 	 * Register output variables.
 	 *
 	 * @param outputNames
@@ -378,6 +436,17 @@ public class Script {
 	public Script out(String... outputNames) {
 		outputVariables.addAll(Arrays.asList(outputNames));
 		return this;
+	}
+
+	/**
+	 * Register output variables.
+	 *
+	 * @param outputNames
+	 *            names of the output variables
+	 * @return {@code this} Script object to allow chaining of methods
+	 */
+	public Script output(String... outputNames) {
+		return output(outputNames);
 	}
 
 	/**

--- a/src/main/java/org/apache/sysml/api/mlcontext/Script.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/Script.java
@@ -245,6 +245,15 @@ public class Script {
 
 	/**
 	 * Pass a Scala Map of inputs to the script.
+	 * <p>
+	 * Note that the {@code Map} key/value types are not explicitly specified on
+	 * this method because {@code [String, Any]} can't be recognized on the Java
+	 * side since {@code Any} doesn't have an equivalent in the Java class
+	 * hierarchy ({@code scala.Any} is a superclass of {@code scala.AnyRef},
+	 * which is equivalent to {@code java.lang.Object}). Therefore, specifying
+	 * {@code scala.collection.Map<String, Object>} as an input parameter to
+	 * this Java method is not encompassing enough and would require types such
+	 * as a {@code scala.Double} to be cast using {@code asInstanceOf[AnyRef]}.
 	 *
 	 * @param inputs
 	 *            Scala Map of inputs (parameters ($) and variables).
@@ -260,6 +269,15 @@ public class Script {
 
 	/**
 	 * Pass a Scala Map of inputs to the script.
+	 * <p>
+	 * Note that the {@code Map} key/value types are not explicitly specified on
+	 * this method because {@code [String, Any]} can't be recognized on the Java
+	 * side since {@code Any} doesn't have an equivalent in the Java class
+	 * hierarchy ({@code scala.Any} is a superclass of {@code scala.AnyRef},
+	 * which is equivalent to {@code java.lang.Object}). Therefore, specifying
+	 * {@code scala.collection.Map<String, Object>} as an input parameter to
+	 * this Java method is not encompassing enough and would require types such
+	 * as a {@code scala.Double} to be cast using {@code asInstanceOf[AnyRef]}.
 	 *
 	 * @param inputs
 	 *            Scala Map of inputs (parameters ($) and variables).


### PR DESCRIPTION
Update ```scala.collection.Map<String, Object>``` to ```scala.collection.Map```.
to avoid asInstanceOf casts of ints/doubles/etc from Scala.
Add comments to input methods of Script.
Create output methods for Script.