### PR TITLE
[SYSTEMML-889] Remove MLContext Java input output methods

### DIFF
--- a/docs/beginners-guide-python.md
+++ b/docs/beginners-guide-python.md
@@ -328,6 +328,6 @@ X_df = sqlCtx.createDataFrame(pd.DataFrame(X_digits[:.9 * n_samples]))
 y_df = sqlCtx.createDataFrame(pd.DataFrame(y_digits[:.9 * n_samples]))
 ml = sml.MLContext(sc)
 script = os.path.join(os.environ['SYSTEMML_HOME'], 'scripts', 'algorithms', 'MultiLogReg.dml')
-script = sml.dml(script).input(X=X_df, Y_vec=y_df).input(**{"$X": ' ', "$Y": ' ', "$B": ' '}).out("B_out")
+script = sml.dml(script).input(X=X_df, Y_vec=y_df).output("B_out")
 beta = ml.execute(script).getNumPyArray('B_out')
 ```

--- a/src/main/java/org/apache/sysml/api/mlcontext/Script.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/Script.java
@@ -247,17 +247,6 @@ public class Script {
 	}
 
 	/**
-	 * Pass a map of inputs to the script.
-	 *
-	 * @param inputs
-	 *            map of inputs (parameters ($) and variables).
-	 * @return {@code this} Script object to allow chaining of methods
-	 */
-	public Script input(Map<String, Object> inputs) {
-		return in(inputs);
-	}
-
-	/**
 	 * Pass a Scala Map of inputs to the script.
 	 * <p>
 	 * Note that the {@code Map} value type is not explicitly specified on this
@@ -279,26 +268,6 @@ public class Script {
 		in(javaMap);
 
 		return this;
-	}
-
-	/**
-	 * Pass a Scala Map of inputs to the script.
-	 * <p>
-	 * Note that the {@code Map} value type is not explicitly specified on this
-	 * method because {@code [String, Any]} can't be recognized on the Java side
-	 * since {@code Any} doesn't have an equivalent in the Java class hierarchy
-	 * ({@code scala.Any} is a superclass of {@code scala.AnyRef}, which is
-	 * equivalent to {@code java.lang.Object}). Therefore, specifying
-	 * {@code scala.collection.Map<String, Object>} as an input parameter to
-	 * this Java method is not encompassing enough and would require types such
-	 * as a {@code scala.Double} to be cast using {@code asInstanceOf[AnyRef]}.
-	 *
-	 * @param inputs
-	 *            Scala Map of inputs (parameters ($) and variables).
-	 * @return {@code this} Script object to allow chaining of methods
-	 */
-	public Script input(scala.collection.Map<String, ?> inputs) {
-		return in(inputs);
 	}
 
 	/**
@@ -330,20 +299,6 @@ public class Script {
 	}
 
 	/**
-	 * Pass a Scala Seq of inputs to the script. The inputs are either two-value
-	 * or three-value tuples, where the first value is the variable name, the
-	 * second value is the variable value, and the third optional value is the
-	 * metadata.
-	 *
-	 * @param inputs
-	 *            Scala Seq of inputs (parameters ($) and variables).
-	 * @return {@code this} Script object to allow chaining of methods
-	 */
-	public Script input(scala.collection.Seq<Object> inputs) {
-		return in(inputs);
-	}
-
-	/**
 	 * Obtain an unmodifiable map of all input parameters ($).
 	 *
 	 * @return input parameters ($)
@@ -366,19 +321,6 @@ public class Script {
 	}
 
 	/**
-	 * Register an input (parameter ($) or variable).
-	 *
-	 * @param name
-	 *            name of the input
-	 * @param value
-	 *            value of the input
-	 * @return {@code this} Script object to allow chaining of methods
-	 */
-	public Script input(String name, Object value) {
-		return in(name, value);
-	}
-
-	/**
 	 * Register an input (parameter ($) or variable) with optional matrix
 	 * metadata.
 	 *
@@ -393,22 +335,6 @@ public class Script {
 	public Script in(String name, Object value, MatrixFormat matrixFormat) {
 		MatrixMetadata matrixMetadata = new MatrixMetadata(matrixFormat);
 		return in(name, value, matrixMetadata);
-	}
-
-	/**
-	 * Register an input (parameter ($) or variable) with optional matrix
-	 * metadata.
-	 *
-	 * @param name
-	 *            name of the input
-	 * @param value
-	 *            value of the input
-	 * @param matrixFormat
-	 *            optional matrix format
-	 * @return {@code this} Script object to allow chaining of methods
-	 */
-	public Script input(String name, Object value, MatrixFormat matrixFormat) {
-		return in(name, value, matrixFormat);
 	}
 
 	/**
@@ -473,22 +399,6 @@ public class Script {
 	}
 
 	/**
-	 * Register an input (parameter ($) or variable) with optional matrix
-	 * metadata.
-	 *
-	 * @param name
-	 *            name of the input
-	 * @param value
-	 *            value of the input
-	 * @param matrixMetadata
-	 *            optional matrix metadata
-	 * @return {@code this} Script object to allow chaining of methods
-	 */
-	public Script input(String name, Object value, MatrixMetadata matrixMetadata) {
-		return in(name, value, matrixMetadata);
-	}
-
-	/**
 	 * Register an output variable.
 	 *
 	 * @param outputName
@@ -501,17 +411,6 @@ public class Script {
 	}
 
 	/**
-	 * Register an output variable.
-	 *
-	 * @param outputName
-	 *            name of the output variable
-	 * @return {@code this} Script object to allow chaining of methods
-	 */
-	public Script output(String outputName) {
-		return out(outputName);
-	}
-
-	/**
 	 * Register output variables.
 	 *
 	 * @param outputNames
@@ -521,17 +420,6 @@ public class Script {
 	public Script out(String... outputNames) {
 		outputVariables.addAll(Arrays.asList(outputNames));
 		return this;
-	}
-
-	/**
-	 * Register output variables.
-	 *
-	 * @param outputNames
-	 *            names of the output variables
-	 * @return {@code this} Script object to allow chaining of methods
-	 */
-	public Script output(String... outputNames) {
-		return output(outputNames);
 	}
 
 	/**

--- a/src/main/python/tests/test_mlcontext.py
+++ b/src/main/python/tests/test_mlcontext.py
@@ -31,7 +31,7 @@ ml = MLContext(sc)
 class TestAPI(unittest.TestCase):
 
     def test_output_string(self):
-        script = dml("x1 = 'Hello World'").out("x1")
+        script = dml("x1 = 'Hello World'").output("x1")
         self.assertEqual(ml.execute(script).get("x1"), "Hello World")
 
     def test_output_list(self):
@@ -40,7 +40,7 @@ class TestAPI(unittest.TestCase):
         x2 = x1 + 1
         x3 = x1 + 2
         """
-        script = dml(script).out("x1", "x2", "x3")
+        script = dml(script).output("x1", "x2", "x3")
         self.assertEqual(ml.execute(script).get("x1", "x2"), [0.2, 1.2])
         self.assertEqual(ml.execute(script).get("x1", "x3"), [0.2, 2.2])
 
@@ -50,7 +50,7 @@ class TestAPI(unittest.TestCase):
         m2 = m1 * 2
         """
         rdd1 = sc.parallelize(["1.0,2.0", "3.0,4.0"])
-        script = dml(sums).input(m1=rdd1).out("s1", "m2")
+        script = dml(sums).input(m1=rdd1).output("s1", "m2")
         s1, m2 = ml.execute(script).get("s1", "m2")
         self.assertEqual((s1, repr(m2)), (10.0, "Matrix"))
 
@@ -60,7 +60,7 @@ class TestAPI(unittest.TestCase):
         m2 = m1 * 2
         """
         rdd1 = sc.parallelize(["1.0,2.0", "3.0,4.0"])
-        script = dml(sums).input(m1=rdd1).out("m2")
+        script = dml(sums).input(m1=rdd1).output("m2")
         m2 = ml.execute(script).get("m2")
         self.assertEqual(repr(m2.toDF()), "DataFrame[ID: double, C1: double, C2: double]")
 
@@ -69,14 +69,14 @@ class TestAPI(unittest.TestCase):
         x2 = x1 + 1
         x3 = x1 + 2
         """
-        script = dml(script).input("x1", 5).out("x2", "x3")
+        script = dml(script).input("x1", 5).output("x2", "x3")
         self.assertEqual(ml.execute(script).get("x2", "x3"), [6, 7])
 
     def test_input(self):
         script = """
         x3 = x1 + x2
         """
-        script = dml(script).input(x1=5, x2=3).out("x3")
+        script = dml(script).input(x1=5, x2=3).output("x3")
         self.assertEqual(ml.execute(script).get("x3"), 8)
 
     def test_rdd(self):
@@ -87,13 +87,13 @@ class TestAPI(unittest.TestCase):
         """
         rdd1 = sc.parallelize(["1.0,2.0", "3.0,4.0"])
         rdd2 = sc.parallelize(["5.0,6.0", "7.0,8.0"])
-        script = dml(sums).input(m1=rdd1).input(m2=rdd2).out("s1", "s2", "s3")
+        script = dml(sums).input(m1=rdd1).input(m2=rdd2).output("s1", "s2", "s3")
         self.assertEqual(
             ml.execute(script).get("s1", "s2", "s3"), [10.0, 26.0, "whatever"])
 
     def test_pydml(self):
         script = "A = full('1 2 3 4 5 6 7 8 9', rows=3, cols=3)\nx = toString(A)"
-        script = pydml(script).out("x")
+        script = pydml(script).output("x")
         self.assertEqual(
             ml.execute(script).get("x"),
             '1.000 2.000 3.000\n4.000 5.000 6.000\n7.000 8.000 9.000\n'


### PR DESCRIPTION
This removes the `Script.input` and `Script.output` methods on the JVM side, hacks the Python side so that it is able to call the `Script.in` method on the JVM side, and updates `Script.out` to `Script.output` on the Python side (calling `Script.out` on the JVM side still).

This means that a Scala/Java user would use the clean `in(...)` and `out(...)` syntax, while a Python user would use the `input(...)` and `output(...)` syntax.