### PR TITLE
[SYSTEMML-900] Rename DataFrame ID column

### DIFF
--- a/src/main/java/org/apache/sysml/api/MLOutput.java
+++ b/src/main/java/org/apache/sysml/api/MLOutput.java
@@ -101,7 +101,7 @@ public class MLOutput {
 	
 	/**
 	 * Note, the output DataFrame has an additional column ID.
-	 * An easy way to get DataFrame without ID is by df.sort("ID").drop("ID")
+	 * An easy way to get DataFrame without ID is by df.sort("__INDEX").drop("__INDEX")
 	 * @param sqlContext
 	 * @param varName
 	 * @return
@@ -181,7 +181,7 @@ public class MLOutput {
 		
 		List<StructField> fields = new ArrayList<StructField>();
 		// LongTypes throw an error: java.lang.Double incompatible with java.lang.Long
-		fields.add(DataTypes.createStructField("ID", DataTypes.DoubleType, false));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, false));
 		for(int k = 0; k < alRange.size(); k++) {
 			String colName = alRange.get(k)._1;
 			long low = alRange.get(k)._2._1;

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextConversionUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextConversionUtil.java
@@ -454,7 +454,7 @@ public class MLContextConversionUtil {
 		}
 
 		if (isDataFrameWithIDColumn(matrixMetadata)) {
-			dataFrame = dataFrame.sort("ID").drop("ID");
+			dataFrame = dataFrame.sort("__INDEX").drop("__INDEX");
 		}
 
 		boolean isVectorBasedDataFrame = isVectorBasedDataFrame(matrixMetadata);
@@ -507,7 +507,7 @@ public class MLContextConversionUtil {
 		StructType schema = dataFrame.schema();
 		boolean hasID = false;
 		try {
-			schema.fieldIndex("ID");
+			schema.fieldIndex("__INDEX");
 			hasID = true;
 		} catch (IllegalArgumentException iae) {
 		}

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextConversionUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextConversionUtil.java
@@ -516,16 +516,16 @@ public class MLContextConversionUtil {
 		if (hasID) {
 			Object object = firstRow.get(1);
 			if (object instanceof Vector) {
-				mf = MatrixFormat.DF_VECTOR_WITH_ID_COLUMN;
+				mf = MatrixFormat.DF_VECTOR_WITH_INDEX;
 			} else {
-				mf = MatrixFormat.DF_DOUBLES_WITH_ID_COLUMN;
+				mf = MatrixFormat.DF_DOUBLES_WITH_INDEX;
 			}
 		} else {
 			Object object = firstRow.get(0);
 			if (object instanceof Vector) {
-				mf = MatrixFormat.DF_VECTOR_WITH_NO_ID_COLUMN;
+				mf = MatrixFormat.DF_VECTOR;
 			} else {
-				mf = MatrixFormat.DF_DOUBLES_WITH_NO_ID_COLUMN;
+				mf = MatrixFormat.DF_DOUBLES;
 			}
 		}
 		if (mf == null) {

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
@@ -456,7 +456,7 @@ public class MLResults {
 		}
 		MatrixObject mo = getMatrixObject(outputName);
 		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext, false);
-		df = df.sort("ID").drop("ID");
+		df = df.sort("__INDEX").drop("__INDEX");
 		return df;
 	}
 
@@ -484,7 +484,7 @@ public class MLResults {
 		}
 		MatrixObject mo = getMatrixObject(outputName);
 		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(mo, sparkExecutionContext, true);
-		df = df.sort("ID").drop("ID");
+		df = df.sort("__INDEX").drop("__INDEX");
 		return df;
 	}
 

--- a/src/main/java/org/apache/sysml/api/mlcontext/Matrix.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/Matrix.java
@@ -129,7 +129,7 @@ public class Matrix {
 	 */
 	public DataFrame asDataFrameDoubleNoIDColumn() {
 		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext, false);
-		df = df.sort("ID").drop("ID");
+		df = df.sort("__INDEX").drop("__INDEX");
 		return df;
 	}
 
@@ -150,7 +150,7 @@ public class Matrix {
 	 */
 	public DataFrame asDataFrameVectorNoIDColumn() {
 		DataFrame df = MLContextConversionUtil.matrixObjectToDataFrame(matrixObject, sparkExecutionContext, true);
-		df = df.sort("ID").drop("ID");
+		df = df.sort("__INDEX").drop("__INDEX");
 		return df;
 	}
 

--- a/src/main/java/org/apache/sysml/api/mlcontext/MatrixFormat.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MatrixFormat.java
@@ -37,24 +37,24 @@ public enum MatrixFormat {
 	IJV,
 
 	/**
-	 * DataFrame of doubles with an ID column.
+	 * DataFrame of doubles with a row index.
 	 */
-	DF_DOUBLES_WITH_ID_COLUMN,
+	DF_DOUBLES_WITH_INDEX,
 
 	/**
-	 * DataFrame of doubles with no ID column.
+	 * DataFrame of doubles with no row index.
 	 */
-	DF_DOUBLES_WITH_NO_ID_COLUMN,
+	DF_DOUBLES,
 
 	/**
-	 * Vector DataFrame with an ID column.
+	 * Vector DataFrame with a row index.
 	 */
-	DF_VECTOR_WITH_ID_COLUMN,
+	DF_VECTOR_WITH_INDEX,
 
 	/**
-	 * Vector DataFrame with no ID column.
+	 * Vector DataFrame with no row index.
 	 */
-	DF_VECTOR_WITH_NO_ID_COLUMN;
+	DF_VECTOR;
 
 	/**
 	 * Is the matrix format vector-based?
@@ -63,9 +63,9 @@ public enum MatrixFormat {
 	 *         otherwise.
 	 */
 	public boolean isVectorBased() {
-		if (this == DF_VECTOR_WITH_ID_COLUMN) {
+		if (this == DF_VECTOR_WITH_INDEX) {
 			return true;
-		} else if (this == DF_VECTOR_WITH_NO_ID_COLUMN) {
+		} else if (this == DF_VECTOR) {
 			return true;
 		} else {
 			return false;
@@ -73,15 +73,15 @@ public enum MatrixFormat {
 	}
 
 	/**
-	 * Does the DataFrame have an ID column?
+	 * Does the DataFrame have a row index?
 	 * 
-	 * @return {@code true} if the DataFrame has an ID column, {@code false}
+	 * @return {@code true} if the DataFrame has a row index, {@code false}
 	 *         otherwise.
 	 */
 	public boolean hasIDColumn() {
-		if (this == DF_DOUBLES_WITH_ID_COLUMN) {
+		if (this == DF_DOUBLES_WITH_INDEX) {
 			return true;
-		} else if (this == DF_VECTOR_WITH_ID_COLUMN) {
+		} else if (this == DF_VECTOR_WITH_INDEX) {
 			return true;
 		} else {
 			return false;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/FrameRDDConverterUtils.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/FrameRDDConverterUtils.java
@@ -331,7 +331,7 @@ public class FrameRDDConverterUtils
 	{
 		
 		if(containsID)
-			df = df.drop("ID");
+			df = df.drop("__INDEX");
 		
 		//determine unknown dimensions if required
 		if( !mcOut.dimsKnown(true) ) {

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
@@ -217,7 +217,7 @@ public class RDDConverterUtilsExt
 			throws DMLRuntimeException {
 		
 		if(containsID) {
-			inputDF = dropColumn(inputDF.sort("ID"), "ID");
+			inputDF = dropColumn(inputDF.sort("__INDEX"), "__INDEX");
 		}
 		
 		DataFrame df = inputDF.select(vectorColumnName);
@@ -276,7 +276,7 @@ public class RDDConverterUtilsExt
 			throw new DMLRuntimeException("No column other than \"" + column + "\" present in the dataframe.");
 		}
 		
-		// Round about way to do in Java (not exposed in Spark 1.3.0): df = df.drop("ID");
+		// Round about way to do in Java (not exposed in Spark 1.3.0): df = df.drop("__INDEX");
 		return df.select(firstCol, scala.collection.JavaConversions.asScalaBuffer(columnToSelect).toList());
 	}
 	
@@ -405,7 +405,7 @@ public class RDDConverterUtilsExt
 		}
 		
 		if(containsID) {
-			df = dropColumn(df.sort("ID"), "ID");
+			df = dropColumn(df.sort("__INDEX"), "__INDEX");
 		}
 			
 		//determine unknown dimensions and sparsity if required
@@ -447,7 +447,7 @@ public class RDDConverterUtilsExt
 		
 		List<StructField> fields = new ArrayList<StructField>();
 		// LongTypes throw an error: java.lang.Double incompatible with java.lang.Long
-		fields.add(DataTypes.createStructField("ID", DataTypes.DoubleType, false));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, false));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), false));
 		// fields.add(DataTypes.createStructField("C1", DataTypes.createArrayType(DataTypes.DoubleType), false));
 		
@@ -509,7 +509,7 @@ public class RDDConverterUtilsExt
 		
 		List<StructField> fields = new ArrayList<StructField>();
 		// LongTypes throw an error: java.lang.Double incompatible with java.lang.Long
-		fields.add(DataTypes.createStructField("ID", DataTypes.DoubleType, false)); 
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, false)); 
 		for(int i = 1; i <= numColumns; i++) {
 			fields.add(DataTypes.createStructField("C" + i, DataTypes.DoubleType, false));
 		}

--- a/src/main/python/systemml/mlcontext.py
+++ b/src/main/python/systemml/mlcontext.py
@@ -120,7 +120,7 @@ class Matrix(object):
         -------
         df: PySpark SQL DataFrame
             A PySpark SQL DataFrame representing the matrix, with
-            one "ID" column containing the row index (since Spark
+            one "__INDEX" column containing the row index (since Spark
             DataFrames are unordered), followed by columns of doubles
             for each column in the matrix.
         """

--- a/src/main/python/tests/test_mlcontext.py
+++ b/src/main/python/tests/test_mlcontext.py
@@ -62,7 +62,7 @@ class TestAPI(unittest.TestCase):
         rdd1 = sc.parallelize(["1.0,2.0", "3.0,4.0"])
         script = dml(sums).input(m1=rdd1).output("m2")
         m2 = ml.execute(script).get("m2")
-        self.assertEqual(repr(m2.toDF()), "DataFrame[ID: double, C1: double, C2: double]")
+        self.assertEqual(repr(m2.toDF()), "DataFrame[__INDEX: double, C1: double, C2: double]")
 
     def test_input_single(self):
         script = """

--- a/src/main/python/tests/test_mllearn.py
+++ b/src/main/python/tests/test_mllearn.py
@@ -79,7 +79,7 @@ class TestMLLearn(unittest.TestCase):
             (9, "a e c l", 2.0),
             (10, "spark compile", 1.0),
             (11, "hadoop software", 2.0)
-            ], ["id", "text", "label"])
+            ], ["__INDEX", "text", "label"])
         tokenizer = Tokenizer(inputCol="text", outputCol="words")
         hashingTF = HashingTF(inputCol="words", outputCol="features", numFeatures=20)
         lr = LogisticRegression(sqlCtx)
@@ -89,7 +89,7 @@ class TestMLLearn(unittest.TestCase):
             (12, "spark i j k", 1.0),
             (13, "l m n", 2.0),
             (14, "mapreduce spark", 1.0),
-            (15, "apache hadoop", 2.0)], ["id", "text", "label"])
+            (15, "apache hadoop", 2.0)], ["__INDEX", "text", "label"])
         result = model.transform(test)
         predictionAndLabels = result.select("prediction", "label")
         evaluator = MulticlassClassificationEvaluator()

--- a/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLClassifier.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLClassifier.scala
@@ -147,14 +147,14 @@ trait BaseSystemMLClassifierModel extends BaseSystemMLEstimatorModel {
     val Xin_bin = new BinaryBlockMatrix(Xin, mcXin)
     val modelPredict = ml.execute(script._1.in(script._2, Xin_bin))
     val predLabelOut = PredictionUtils.computePredictedClassLabelsFromProbability(modelPredict, isSingleNode, sc, probVar)
-    val predictedDF = PredictionUtils.updateLabels(isSingleNode, predLabelOut.getDataFrame("Prediction"), null, "C1", labelMapping).select("ID", "prediction")
+    val predictedDF = PredictionUtils.updateLabels(isSingleNode, predLabelOut.getDataFrame("Prediction"), null, "C1", labelMapping).select("__INDEX", "prediction")
     if(outputProb) {
-      val prob = modelPredict.getDataFrame(probVar, true).withColumnRenamed("C1", "probability").select("ID", "probability")
-      val dataset = RDDConverterUtils.addIDToDataFrame(df.asInstanceOf[DataFrame], df.sqlContext, "ID")
+      val prob = modelPredict.getDataFrame(probVar, true).withColumnRenamed("C1", "probability").select("__INDEX", "probability")
+      val dataset = RDDConverterUtils.addIDToDataFrame(df.asInstanceOf[DataFrame], df.sqlContext, "__INDEX")
       return PredictionUtils.joinUsingID(dataset, PredictionUtils.joinUsingID(prob, predictedDF))
     }
     else {
-      val dataset = RDDConverterUtils.addIDToDataFrame(df.asInstanceOf[DataFrame], df.sqlContext, "ID")
+      val dataset = RDDConverterUtils.addIDToDataFrame(df.asInstanceOf[DataFrame], df.sqlContext, "__INDEX")
       return PredictionUtils.joinUsingID(dataset, predictedDF)
     }
     

--- a/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLRegressor.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLRegressor.scala
@@ -79,8 +79,8 @@ trait BaseSystemMLRegressorModel extends BaseSystemMLEstimatorModel {
     val script = getPredictionScript(mloutput, isSingleNode)
     val Xin_bin = new BinaryBlockMatrix(Xin, mcXin)
     val modelPredict = ml.execute(script._1.in(script._2, Xin_bin))
-    val predictedDF = modelPredict.getDataFrame(predictionVar).select("ID", "C1").withColumnRenamed("C1", "prediction")
-    val dataset = RDDConverterUtils.addIDToDataFrame(df.asInstanceOf[DataFrame], df.sqlContext, "ID")
+    val predictedDF = modelPredict.getDataFrame(predictionVar).select("__INDEX", "C1").withColumnRenamed("C1", "prediction")
+    val dataset = RDDConverterUtils.addIDToDataFrame(df.asInstanceOf[DataFrame], df.sqlContext, "__INDEX")
     return PredictionUtils.joinUsingID(dataset, predictedDF)
   }
 }

--- a/src/main/scala/org/apache/sysml/api/ml/PredictionUtils.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/PredictionUtils.scala
@@ -131,8 +131,8 @@ object PredictionUtils {
   }
   
   def joinUsingID(df1:DataFrame, df2:DataFrame):DataFrame = {
-    val tempDF1 = df1.withColumnRenamed("ID", "ID1")
-    tempDF1.join(df2, tempDF1.col("ID1").equalTo(df2.col("ID"))).drop("ID1")
+    val tempDF1 = df1.withColumnRenamed("__INDEX", "ID1")
+    tempDF1.join(df2, tempDF1.col("ID1").equalTo(df2.col("__INDEX"))).drop("ID1")
   }
   
   def computePredictedClassLabelsFromProbability(mlscoreoutput:MLResults, isSingleNode:Boolean, sc:SparkContext, inProbVar:String): MLResults = {

--- a/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
@@ -564,7 +564,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("ID", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
@@ -591,7 +591,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("ID", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
@@ -618,7 +618,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("ID", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
@@ -645,7 +645,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("ID", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
@@ -672,7 +672,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddTuple.map(new DoubleVectorRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("ID", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
@@ -697,7 +697,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddTuple.map(new DoubleVectorRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("ID", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
@@ -2102,7 +2102,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("ID", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
@@ -2127,7 +2127,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("ID", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
@@ -2152,7 +2152,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddTuple.map(new DoubleVectorRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("ID", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
@@ -2175,7 +2175,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddTuple.map(new DoubleVectorRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("ID", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);

--- a/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
@@ -518,7 +518,7 @@ public class MLContextTest extends AutomatedTestBase {
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
-		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_DOUBLES_WITH_NO_ID_COLUMN);
+		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_DOUBLES);
 
 		Script script = dml("print('sum: ' + sum(M));").in("M", dataFrame, mm);
 		setExpectedStdOut("sum: 450.0");
@@ -544,7 +544,7 @@ public class MLContextTest extends AutomatedTestBase {
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
-		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_DOUBLES_WITH_NO_ID_COLUMN);
+		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_DOUBLES);
 
 		Script script = pydml("print('sum: ' + sum(M))").in("M", dataFrame, mm);
 		setExpectedStdOut("sum: 450.0");
@@ -571,7 +571,7 @@ public class MLContextTest extends AutomatedTestBase {
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
-		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_DOUBLES_WITH_ID_COLUMN);
+		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_DOUBLES_WITH_INDEX);
 
 		Script script = dml("print('sum: ' + sum(M));").in("M", dataFrame, mm);
 		setExpectedStdOut("sum: 45.0");
@@ -598,7 +598,7 @@ public class MLContextTest extends AutomatedTestBase {
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
-		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_DOUBLES_WITH_ID_COLUMN);
+		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_DOUBLES_WITH_INDEX);
 
 		Script script = pydml("print('sum: ' + sum(M))").in("M", dataFrame, mm);
 		setExpectedStdOut("sum: 45.0");
@@ -625,7 +625,7 @@ public class MLContextTest extends AutomatedTestBase {
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
-		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_DOUBLES_WITH_ID_COLUMN);
+		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_DOUBLES_WITH_INDEX);
 
 		Script script = dml("print('M[1,1]: ' + as.scalar(M[1,1]));").in("M", dataFrame, mm);
 		setExpectedStdOut("M[1,1]: 1.0");
@@ -652,7 +652,7 @@ public class MLContextTest extends AutomatedTestBase {
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
-		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_DOUBLES_WITH_ID_COLUMN);
+		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_DOUBLES_WITH_INDEX);
 
 		Script script = pydml("print('M[0,0]: ' + scalar(M[0,0]))").in("M", dataFrame, mm);
 		setExpectedStdOut("M[0,0]: 1.0");
@@ -677,7 +677,7 @@ public class MLContextTest extends AutomatedTestBase {
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
-		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_VECTOR_WITH_ID_COLUMN);
+		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_VECTOR_WITH_INDEX);
 
 		Script script = dml("print('sum: ' + sum(M));").in("M", dataFrame, mm);
 		setExpectedStdOut("sum: 45.0");
@@ -702,7 +702,7 @@ public class MLContextTest extends AutomatedTestBase {
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
-		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_VECTOR_WITH_ID_COLUMN);
+		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_VECTOR_WITH_INDEX);
 
 		Script script = dml("print('sum: ' + sum(M))").in("M", dataFrame, mm);
 		setExpectedStdOut("sum: 45.0");
@@ -726,7 +726,7 @@ public class MLContextTest extends AutomatedTestBase {
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
-		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_VECTOR_WITH_NO_ID_COLUMN);
+		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_VECTOR);
 
 		Script script = dml("print('sum: ' + sum(M));").in("M", dataFrame, mm);
 		setExpectedStdOut("sum: 45.0");
@@ -750,7 +750,7 @@ public class MLContextTest extends AutomatedTestBase {
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
-		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_VECTOR_WITH_NO_ID_COLUMN);
+		MatrixMetadata mm = new MatrixMetadata(MatrixFormat.DF_VECTOR);
 
 		Script script = dml("print('sum: ' + sum(M))").in("M", dataFrame, mm);
 		setExpectedStdOut("sum: 45.0");


### PR DESCRIPTION
The use of "ID" as the name of DataFrame column for ordering can cause confusion and unexpected results because ID is a name that can commonly be used. By changing the column name to a more unique name such as "__INDEX", we can avoid such conflicts.