### PR TITLE
[SYSTEMML-902] Improve FrameObject toString output

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/controlprogram/caching/FrameObject.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/caching/FrameObject.java
@@ -43,6 +43,7 @@ import org.apache.sysml.runtime.matrix.MetaData;
 import org.apache.sysml.runtime.matrix.data.FileFormatProperties;
 import org.apache.sysml.runtime.matrix.data.FrameBlock;
 import org.apache.sysml.runtime.matrix.data.InputInfo;
+import org.apache.sysml.runtime.matrix.data.NumItemsByEachReducerMetaData;
 import org.apache.sysml.runtime.matrix.data.OutputInfo;
 
 public class FrameObject extends CacheableData<FrameBlock>
@@ -241,6 +242,41 @@ public class FrameObject extends CacheableData<FrameBlock>
 		//note: the write of an RDD to HDFS might trigger
 		//lazy evaluation of pending transformations.				
 		SparkExecutionContext.writeFrameRDDtoHDFS(rdd, fname, oinfo);	
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder str = new StringBuilder();
+		str.append("Frame: ");
+		str.append(_hdfsFileName + ", ");
+
+		if (_metaData instanceof NumItemsByEachReducerMetaData) {
+			str.append("NumItemsByEachReducerMetaData");
+		} else {
+			try {
+				MatrixFormatMetaData md = (MatrixFormatMetaData) _metaData;
+				if (md != null) {
+					MatrixCharacteristics mc = ((MatrixDimensionsMetaData) _metaData).getMatrixCharacteristics();
+					str.append(mc.toString());
+
+					InputInfo ii = md.getInputInfo();
+					if (ii == null)
+						str.append("null");
+					else {
+						str.append(", ");
+						str.append(InputInfo.inputInfoToString(ii));
+					}
+				} else {
+					str.append("null, null");
+				}
+			} catch (Exception ex) {
+				LOG.error(ex);
+			}
+		}
+		str.append(", ");
+		str.append(isDirty() ? "dirty" : "not-dirty");
+
+		return str.toString();
 	}
 
 }

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/caching/FrameObject.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/caching/FrameObject.java
@@ -43,7 +43,6 @@ import org.apache.sysml.runtime.matrix.MetaData;
 import org.apache.sysml.runtime.matrix.data.FileFormatProperties;
 import org.apache.sysml.runtime.matrix.data.FrameBlock;
 import org.apache.sysml.runtime.matrix.data.InputInfo;
-import org.apache.sysml.runtime.matrix.data.NumItemsByEachReducerMetaData;
 import org.apache.sysml.runtime.matrix.data.OutputInfo;
 
 public class FrameObject extends CacheableData<FrameBlock>
@@ -250,28 +249,24 @@ public class FrameObject extends CacheableData<FrameBlock>
 		str.append("Frame: ");
 		str.append(_hdfsFileName + ", ");
 
-		if (_metaData instanceof NumItemsByEachReducerMetaData) {
-			str.append("NumItemsByEachReducerMetaData");
-		} else {
-			try {
-				MatrixFormatMetaData md = (MatrixFormatMetaData) _metaData;
-				if (md != null) {
-					MatrixCharacteristics mc = ((MatrixDimensionsMetaData) _metaData).getMatrixCharacteristics();
-					str.append(mc.toString());
+		try {
+			MatrixFormatMetaData md = (MatrixFormatMetaData) _metaData;
+			if (md != null) {
+				MatrixCharacteristics mc = ((MatrixDimensionsMetaData) _metaData).getMatrixCharacteristics();
+				str.append(mc.toString());
 
-					InputInfo ii = md.getInputInfo();
-					if (ii == null)
-						str.append("null");
-					else {
-						str.append(", ");
-						str.append(InputInfo.inputInfoToString(ii));
-					}
-				} else {
-					str.append("null, null");
+				InputInfo ii = md.getInputInfo();
+				if (ii == null)
+					str.append("null");
+				else {
+					str.append(", ");
+					str.append(InputInfo.inputInfoToString(ii));
 				}
-			} catch (Exception ex) {
-				LOG.error(ex);
+			} else {
+				str.append("null, null");
 			}
+		} catch (Exception ex) {
+			LOG.error(ex);
 		}
 		str.append(", ");
 		str.append(isDirty() ? "dirty" : "not-dirty");


### PR DESCRIPTION
Override toString for FrameObject, similar to MatrixObject.

Example of outputting MatrixObject and FrameObject via MLContext, before PR:
```
scala> val res = ml.execute(dmlScript)
res: org.apache.sysml.api.mlcontext.MLResults = 
  [1] (Matrix) tA: Matrix: scratch_space//_p7667_9.31.117.12//_t0/tA_290, [3 x 2, nnz=6, blocks (1000 x 1000)], binaryblock, dirty
  [2] (Frame) tAM: org.apache.sysml.runtime.controlprogram.caching.FrameObject@6c6c4579
```

After PR:
```
scala> val res = ml.execute(dmlScript)
res: org.apache.sysml.api.mlcontext.MLResults = 
  [1] (Matrix) tA: Matrix: scratch_space//_p42840_9.31.117.12//_t0/tA_1, [3 x 2, nnz=6, blocks (1000 x 1000)], binaryblock, dirty
  [2] (Frame) tAM: Frame: scratch_space//_p42840_9.31.117.12//_t0/tAM, [3 x 2, nnz=6, blocks (1000 x 1000)], binaryblock, dirty
```