### PR TITLE
[SYSTEMML-906] [SYSTEMML-907] Update df first to df schema

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextConversionUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextConversionUtil.java
@@ -34,10 +34,12 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.mllib.linalg.Vector;
+import org.apache.spark.mllib.linalg.VectorUDT;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.DataFrame;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.sysml.api.MLContextProxy;
 import org.apache.sysml.conf.ConfigurationManager;
@@ -466,23 +468,23 @@ public class MLContextConversionUtil {
 			hasID = true;
 		} catch (IllegalArgumentException iae) {
 		}
-		Row firstRow = dataFrame.first();
+
+		StructField[] fields = schema.fields();
 		MatrixFormat mf = null;
 		if (hasID) {
-			Object object = firstRow.get(1);
-			if (object instanceof Vector) {
+			if (fields[1].dataType() instanceof VectorUDT) {
 				mf = MatrixFormat.DF_VECTOR_WITH_INDEX;
 			} else {
 				mf = MatrixFormat.DF_DOUBLES_WITH_INDEX;
 			}
 		} else {
-			Object object = firstRow.get(0);
-			if (object instanceof Vector) {
+			if (fields[0].dataType() instanceof VectorUDT) {
 				mf = MatrixFormat.DF_VECTOR;
 			} else {
 				mf = MatrixFormat.DF_DOUBLES;
 			}
 		}
+
 		if (mf == null) {
 			throw new MLContextException("DataFrame format not recognized as an accepted SystemML MatrixFormat");
 		}

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
@@ -604,7 +604,14 @@ public final class MLContextUtil {
 		for (StructField field : fields) {
 			DataType dataType = field.dataType();
 			if ((dataType != DataTypes.DoubleType) && (dataType != DataTypes.IntegerType)
-					&& (!(dataType instanceof VectorUDT))) {
+					&& (dataType != DataTypes.LongType) && (!(dataType instanceof VectorUDT))) {
+				// uncomment if we support arrays of doubles for matrices
+				// if (dataType instanceof ArrayType) {
+				// ArrayType arrayType = (ArrayType) dataType;
+				// if (arrayType.elementType() == DataTypes.DoubleType) {
+				// continue;
+				// }
+				// }
 				return false;
 			}
 		}
@@ -978,9 +985,8 @@ public final class MLContextUtil {
 	 *         FrameObject, {@code false} otherwise.
 	 */
 	public static boolean doesSymbolTableContainFrameObject(LocalVariableMap symbolTable, String variableName) {
-		return (symbolTable != null
-			&& symbolTable.keySet().contains(variableName)
-			&& symbolTable.get(variableName) instanceof FrameObject);
+		return (symbolTable != null && symbolTable.keySet().contains(variableName)
+				&& symbolTable.get(variableName) instanceof FrameObject);
 	}
 
 	/**
@@ -995,8 +1001,7 @@ public final class MLContextUtil {
 	 *         MatrixObject, {@code false} otherwise.
 	 */
 	public static boolean doesSymbolTableContainMatrixObject(LocalVariableMap symbolTable, String variableName) {
-		return (symbolTable != null
-			&& symbolTable.keySet().contains(variableName)
-			&& symbolTable.get(variableName) instanceof MatrixObject);
+		return (symbolTable != null && symbolTable.keySet().contains(variableName)
+				&& symbolTable.get(variableName) instanceof MatrixObject);
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
@@ -509,12 +509,12 @@ public class MLContextTest extends AutomatedTestBase {
 		list.add("70,80,90");
 		JavaRDD<String> javaRddString = sc.parallelize(list);
 
-		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
+		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
@@ -535,12 +535,12 @@ public class MLContextTest extends AutomatedTestBase {
 		list.add("70,80,90");
 		JavaRDD<String> javaRddString = sc.parallelize(list);
 
-		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
+		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
@@ -561,13 +561,13 @@ public class MLContextTest extends AutomatedTestBase {
 		list.add("3,7,8,9");
 		JavaRDD<String> javaRddString = sc.parallelize(list);
 
-		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
+		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
@@ -588,13 +588,13 @@ public class MLContextTest extends AutomatedTestBase {
 		list.add("3,7,8,9");
 		JavaRDD<String> javaRddString = sc.parallelize(list);
 
-		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
+		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
@@ -615,13 +615,13 @@ public class MLContextTest extends AutomatedTestBase {
 		list.add("2,4,5,6");
 		JavaRDD<String> javaRddString = sc.parallelize(list);
 
-		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
+		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
@@ -642,13 +642,13 @@ public class MLContextTest extends AutomatedTestBase {
 		list.add("2,4,5,6");
 		JavaRDD<String> javaRddString = sc.parallelize(list);
 
-		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
+		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
@@ -672,7 +672,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddTuple.map(new DoubleVectorRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
@@ -697,7 +697,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddTuple.map(new DoubleVectorRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
@@ -784,6 +784,20 @@ public class MLContextTest extends AutomatedTestBase {
 		public Row call(String str) throws Exception {
 			String[] fields = str.split(",");
 			return RowFactory.create((Object[]) fields);
+		}
+	}
+
+	static class CommaSeparatedValueStringToDoubleArrayRow implements Function<String, Row> {
+		private static final long serialVersionUID = -8058786466523637317L;
+
+		@Override
+		public Row call(String str) throws Exception {
+			String[] strings = str.split(",");
+			Double[] doubles = new Double[strings.length];
+			for (int i = 0; i < strings.length; i++) {
+				doubles[i] = Double.parseDouble(strings[i]);
+			}
+			return RowFactory.create((Object[]) doubles);
 		}
 	}
 
@@ -1835,12 +1849,12 @@ public class MLContextTest extends AutomatedTestBase {
 		list.add("70,80,90");
 		JavaRDD<String> javaRddString = sc.parallelize(list);
 
-		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
+		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
@@ -1861,12 +1875,12 @@ public class MLContextTest extends AutomatedTestBase {
 		list.add("70,80,90");
 		JavaRDD<String> javaRddString = sc.parallelize(list);
 
-		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
+		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
@@ -2051,12 +2065,12 @@ public class MLContextTest extends AutomatedTestBase {
 		list.add("4,4,4");
 		JavaRDD<String> javaRddString = sc.parallelize(list);
 
-		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
+		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
@@ -2075,12 +2089,12 @@ public class MLContextTest extends AutomatedTestBase {
 		list.add("4,4,4");
 		JavaRDD<String> javaRddString = sc.parallelize(list);
 
-		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
+		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
@@ -2099,13 +2113,13 @@ public class MLContextTest extends AutomatedTestBase {
 		list.add("3,4,4,4");
 		JavaRDD<String> javaRddString = sc.parallelize(list);
 
-		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
+		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
@@ -2124,13 +2138,13 @@ public class MLContextTest extends AutomatedTestBase {
 		list.add("3,4,4,4");
 		JavaRDD<String> javaRddString = sc.parallelize(list);
 
-		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToRow());
+		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C1", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C2", DataTypes.StringType, true));
-		fields.add(DataTypes.createStructField("C3", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
 
@@ -2152,7 +2166,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddTuple.map(new DoubleVectorRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
@@ -2175,7 +2189,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddTuple.map(new DoubleVectorRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.StringType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);

--- a/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
@@ -564,7 +564,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.IntegerType, true));
 		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
@@ -591,7 +591,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.IntegerType, true));
 		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
@@ -618,7 +618,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.IntegerType, true));
 		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
@@ -645,7 +645,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.IntegerType, true));
 		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
@@ -672,7 +672,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddTuple.map(new DoubleVectorRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.IntegerType, true));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
@@ -697,7 +697,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddTuple.map(new DoubleVectorRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.IntegerType, true));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
@@ -2116,7 +2116,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.IntegerType, true));
 		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
@@ -2141,7 +2141,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddString.map(new CommaSeparatedValueStringToDoubleArrayRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.IntegerType, true));
 		fields.add(DataTypes.createStructField("C1", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C2", DataTypes.DoubleType, true));
 		fields.add(DataTypes.createStructField("C3", DataTypes.DoubleType, true));
@@ -2166,7 +2166,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddTuple.map(new DoubleVectorRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.IntegerType, true));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);
@@ -2189,7 +2189,7 @@ public class MLContextTest extends AutomatedTestBase {
 		JavaRDD<Row> javaRddRow = javaRddTuple.map(new DoubleVectorRow());
 		SQLContext sqlContext = new SQLContext(sc);
 		List<StructField> fields = new ArrayList<StructField>();
-		fields.add(DataTypes.createStructField("__INDEX", DataTypes.DoubleType, true));
+		fields.add(DataTypes.createStructField("__INDEX", DataTypes.IntegerType, true));
 		fields.add(DataTypes.createStructField("C1", new VectorUDT(), true));
 		StructType schema = DataTypes.createStructType(fields);
 		DataFrame dataFrame = sqlContext.createDataFrame(javaRddRow, schema);


### PR DESCRIPTION
Utilize DataFrame schema to determine matrix/frame characteristics
rather than calling first().