### PR TITLE
Update spark-mlcontext-programming-guide.md

### DIFF
--- a/spark-mlcontext-programming-guide.md
+++ b/spark-mlcontext-programming-guide.md
@@ -1923,6 +1923,9 @@ getScalarInt: (outputs: org.apache.sysml.api.MLOutput, symbol: String)Int
 <div data-lang="Statements" markdown="1">
 {% highlight scala %}
 import org.apache.sysml.api.MLOutput
+import org.apache.spark.sql.SQLContext
+
+val sqlContext = new SQLContext(sc)
 def getScalar(outputs: MLOutput, symbol: String): Any =
 outputs.getDF(sqlContext, symbol).first()(1)
 def getScalarDouble(outputs: MLOutput, symbol: String): Double =

--- a/spark-mlcontext-programming-guide.md
+++ b/spark-mlcontext-programming-guide.md
@@ -2287,7 +2287,7 @@ val numRows = 10000
 val numCols = 1000
 val rawData = LinearDataGenerator.generateLinearRDD(sc, numRows, numCols, 1).toDF()
 
-//In case the line above doesn't compile please use this one:
+//For Spark version <= 1.6.0 you can use createDataFrame() (comment the line above and uncomment the line below), and for Spark version >= 1.6.1 use .toDF()
 //val rawData = sqlContext.createDataFrame(LinearDataGenerator.generateLinearRDD(sc, numRows, numCols, 1))
 
 

--- a/spark-mlcontext-programming-guide.md
+++ b/spark-mlcontext-programming-guide.md
@@ -2287,6 +2287,10 @@ val numRows = 10000
 val numCols = 1000
 val rawData = LinearDataGenerator.generateLinearRDD(sc, numRows, numCols, 1).toDF()
 
+//In case the line above doesn't compile please use this one:
+//val rawData = sqlContext.createDataFrame(LinearDataGenerator.generateLinearRDD(sc, numRows, numCols, 1))
+
+
 // Repartition into a more parallelism-friendly number of partitions
 val data = rawData.repartition(64).cache()
 {% endhighlight %}


### PR DESCRIPTION
added creation of sqlContext, otherwise it was not running on my Spark 1.6 jupyter notebook (datascience experience of IBM)