### PR TITLE
[SYSTEMML-926] Simplify distribution profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,6 @@
 
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version><!--$NO-MVN-MAN-VER$-->
 				<configuration>
 					<tarLongFileMode>gnu</tarLongFileMode>
 				</configuration>
@@ -640,14 +639,125 @@
 		</profile>
 
 		<profile>
-			<!-- Profile to create binary distributions.
-				Execute with `mvn clean package -P distribution` -->
-			<id>distribution</id>
+			<id>inmemory</id>
+			<activation>
+				<property>
+					<name>buildAll</name>
+				</property>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>
 						<artifactId>maven-assembly-plugin</artifactId>
-						<version>2.4</version><!--$NO-MVN-MAN-VER$-->
+						<configuration>
+							<tarLongFileMode>gnu</tarLongFileMode>
+						</configuration>
+						<executions>
+							<execution>
+								<id>create-inmemory-jar</id>
+								<phase>package</phase>
+								<goals>
+									<goal>single</goal>
+								</goals>
+								<configuration>
+									<descriptors>
+										<descriptor>src/assembly/inmemory.xml</descriptor>
+									</descriptors>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>cluster</id>
+			<activation>
+				<property>
+					<name>buildAll</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-assembly-plugin</artifactId>
+						<configuration>
+							<tarLongFileMode>gnu</tarLongFileMode>
+						</configuration>
+						<executions>
+							<execution>
+								<id>create-binary-cluster-distribution-assembly</id>
+								<phase>package</phase>
+								<goals>
+									<goal>single</goal>
+								</goals>
+								<configuration>
+									<descriptors>
+										<descriptor>src/assembly/distrib.xml</descriptor>
+									</descriptors>
+									<appendAssemblyId>true</appendAssemblyId>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>uberjar</id>
+			<activation>
+				<property>
+					<name>buildAll</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-assembly-plugin</artifactId>
+						<configuration>
+							<tarLongFileMode>gnu</tarLongFileMode>
+						</configuration>
+						<executions>
+							<execution>
+								<id>create-standalone-uberjar</id>
+								<phase>package</phase>
+								<goals>
+									<goal>single</goal>
+								</goals>
+								<configuration>
+									<descriptors>
+										<descriptor>src/assembly/standalone-jar.xml</descriptor>
+									</descriptors>
+									<archive>
+										<index>true</index>
+										<manifest>
+											<mainClass>org.apache.sysml.api.DMLScript</mainClass>
+										</manifest>
+									</archive>
+									<appendAssemblyId>true</appendAssemblyId>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<!-- Profile to create binary distributions.
+				Execute with `mvn clean package -P distribution` -->
+			<id>distribution</id>
+			<activation>
+				<property>
+					<name>buildAll</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-assembly-plugin</artifactId>
 						<configuration>
 							<tarLongFileMode>gnu</tarLongFileMode>
 						</configuration>
@@ -666,39 +776,6 @@
 							</execution>
 
 							<execution>
-								<id>create-binary-cluster-distribution-assembly</id>
-								<phase>package</phase>
-								<goals>
-									<goal>single</goal>
-								</goals>
-								<configuration>
-									<descriptors>
-										<descriptor>src/assembly/distrib.xml</descriptor>
-									</descriptors>
-									<appendAssemblyId>false</appendAssemblyId>
-								</configuration>
-							</execution>
-
-							<execution>
-								<id>create-standalone-jar</id>
-								<phase>package</phase>
-								<goals>
-									<goal>single</goal>
-								</goals>
-								<configuration>
-									<descriptors>
-										<descriptor>src/assembly/standalone-jar.xml</descriptor>
-									</descriptors>
-									<archive>
-										<index>true</index>
-										<manifest>
-											<mainClass>org.apache.sysml.api.DMLScript</mainClass>
-										</manifest>
-									</archive>
-								</configuration>
-							</execution>
-
-							<execution>
 								<id>create-binary-standalone-distribution-assembly</id>
 								<phase>package</phase>
 								<goals>
@@ -708,21 +785,10 @@
 									<descriptors>
 										<descriptor>src/assembly/standalone.xml</descriptor>
 									</descriptors>
+									<appendAssemblyId>false</appendAssemblyId>
 								</configuration>
 							</execution>
 
-							<!--execution>
-								<id>create-inmemory-jar</id>
-								<phase>package</phase>
-								<goals>
-									<goal>single</goal>
-								</goals>
-								<configuration>
-									<descriptors>
-										<descriptor>src/assembly/inmemory.xml</descriptor>
-									</descriptors>
-								</configuration>
-							</execution-->
 						</executions>
 					</plugin>
 

--- a/src/assembly/distrib.xml
+++ b/src/assembly/distrib.xml
@@ -21,15 +21,15 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 	<!-- Assembly file for the "distributed" SystemML release for running on a cluster with Spark or Hadoop. -->
-	<id>distrib</id>
+	<id>cluster</id>
 
 	<formats>
-		<format>tar.gz</format>
+		<format>tgz</format>
 		<format>zip</format>
 	</formats>
 
 	<includeBaseDirectory>true</includeBaseDirectory>
-	<baseDirectory>${artifactId}-${version}</baseDirectory>
+	<baseDirectory>${artifactId}-${version}-cluster</baseDirectory>
 
 	<fileSets>
 		<fileSet>

--- a/src/assembly/inmemory.xml
+++ b/src/assembly/inmemory.xml
@@ -75,6 +75,7 @@
 				<include>*:commons-configuration*</include>
 				<include>*:commons-lang*</include>
 				<include>*:commons-logging*</include>
+				<include>*:guava*</include>
 				<include>*:hadoop-auth*</include>
 				<include>*:hadoop-common*</include>
 				<include>*:hadoop-mapreduce-client-core*</include>

--- a/src/assembly/source.xml
+++ b/src/assembly/source.xml
@@ -24,7 +24,7 @@
 	<id>src</id>
 
 	<formats>
-		<format>tar.gz</format>
+		<format>tgz</format>
 		<format>zip</format>
 	</formats>
 

--- a/src/assembly/standalone-jar.xml
+++ b/src/assembly/standalone-jar.xml
@@ -21,7 +21,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 	<!-- Assembly file for the "standalone jar" SystemML release. -->
-	<id>standalone</id>
+	<id>uberjar</id>
 
 	<formats>
 		<format>jar</format>

--- a/src/assembly/standalone.xml
+++ b/src/assembly/standalone.xml
@@ -24,12 +24,12 @@
 	<id>standalone</id>
 
 	<formats>
-		<format>tar.gz</format>
+		<format>tgz</format>
 		<format>zip</format>
 	</formats>
 
 	<includeBaseDirectory>true</includeBaseDirectory>
-	<baseDirectory>${artifactId}-${version}-standalone</baseDirectory>
+	<baseDirectory>${artifactId}-${version}</baseDirectory>
 
 	<fileSets>
 		<fileSet>


### PR DESCRIPTION
Simplify "distribution" profile to build only 7 artifacts.
Remove "-standalone" extensions.
Fix in-memory jar (add guava) and move to "inmemory" profile.
Move distrib artifacts to "cluster" profile, add "-cluster" to names.
Move standalone jar to "uberjar" profile with "-uberjar" added.
Allow "buildAll" profile activation to build all 11 artifacts.
Update to use Apache parent pom for maven-assembly-plugin version.
Change .tar.gz extensions to .tgz.