### PR TITLE
[SYSTEMML-949] Delete ANTLR tokens files during initialize phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,6 +426,25 @@
 							</filesets>
 						</configuration>
 					</execution>
+					<execution>
+						<!-- remove antlr tokens files during initialize phase so antlr4 -->
+						<!-- plugin can regenerate them during generate-sources phase -->
+						<id>remove-antlr-tokens-files</id>
+						<phase>initialize</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+						<configuration>
+							<filesets>
+								<fileset>
+									<directory>src/main/java</directory>
+									<includes>
+										<include>*.tokens</include>
+									</includes>
+								</fileset>
+							</filesets>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -566,6 +566,20 @@
 												</ignore>
 											</action>
 										</pluginExecution>
+										<pluginExecution>
+											<pluginExecutionFilter>
+												<groupId>org.apache.maven.plugins</groupId>
+												<artifactId>maven-clean-plugin</artifactId>
+												<versionRange>[3.0.0,)</versionRange>
+												<goals>
+													<goal>clean</goal>
+												</goals>
+											</pluginExecutionFilter>
+											<action>
+												<ignore>
+												</ignore>
+											</action>
+										</pluginExecution>
 									</pluginExecutions>
 								</lifecycleMappingMetadata>
 							</configuration>


### PR DESCRIPTION
Delete ANTLR tokens files during initialize phase of maven lifecycle
so they can be regenerated during the generate-sources phase of maven
lifecycle that the antlr4-maven-plugin's antlr4 goal binds to.