### PR TITLE
[SYSTEMML-621] Remove redundant nested error messages

### DIFF
--- a/src/main/java/org/apache/sysml/parser/DataExpression.java
+++ b/src/main/java/org/apache/sysml/parser/DataExpression.java
@@ -266,7 +266,6 @@ public class DataExpression extends DataIdentifier
 				// handle first parameter, which is data and may be unnamed
 				ParameterExpression firstParam = passedParamExprs.get(0);
 				if (firstParam.getName() != null && !firstParam.getName().equals(DataExpression.RAND_DATA)){
-					// throw exception -- must be filename as first parameter
 					errorListener.validationError(blp, bcp, "matrix method must have data parameter as first parameter or unnamed parameter");
 					return null;
 				} else {

--- a/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/common/CommonSyntacticValidator.java
@@ -646,7 +646,7 @@ public abstract class CommonSyntacticValidator {
 			}
 
 			// built-in read, rand ...
-			DataExpression dbife = DataExpression.getDataExpression(functionName, paramExpressions, fileName, line, col, line, col);
+			DataExpression dbife = DataExpression.getDataExpression(functionName, paramExpressions, fileName, line, col, line, col, errorListener);
 			if (dbife != null){
 				f.execute(dbife);
 				return true;


### PR DESCRIPTION
Addresses some redundant nested error messages for read, rand, and matrix statements.

Given the following DML:
```
a=read();
b=matrix();
c=rand(2,2);
```

This previously generated the following output:
```
ERROR a.dml line 1:0 unable to process builtin function expression read:ERROR: a.dml -- line 1, column 0 -- read method must have at least filename parameter
ERROR a.dml line 2:0 unable to process builtin function expression matrix:ERROR: a.dml -- line 2, column 0 -- for matrix statement, must specify at least 3 arguments (in order): data, rows, cols
ERROR a.dml line 3:0 unable to process builtin function expression rand:ERROR: a.dml -- line 3, column 0 -- for Rand Statement all arguments must be named parameters

--------------------------------------------------------------
The following 3 parse issues were encountered:
#1 a.dml [line 1:0] [Validation error] -> a=read();
   unable to process builtin function expression read:ERROR: a.dml -- line 1, column 0 -- read method must have at least filename parameter
#2 a.dml [line 2:0] [Validation error] -> b=matrix();
   unable to process builtin function expression matrix:ERROR: a.dml -- line 2, column 0 -- for matrix statement, must specify at least 3 arguments (in order): data, rows, cols
#3 a.dml [line 3:0] [Validation error] -> c=rand(2,2);
   unable to process builtin function expression rand:ERROR: a.dml -- line 3, column 0 -- for Rand Statement all arguments must be named parameters
--------------------------------------------------------------
```

With this PR it generates:
```
ERROR a.dml line 1:0 read method must have at least filename parameter
ERROR a.dml line 2:0 for matrix statement, must specify at least 3 arguments: data, rows, cols
ERROR a.dml line 3:0 for rand statement, all arguments must be named parameters

--------------------------------------------------------------
The following 3 parse issues were encountered:
#1 a.dml [line 1:0] [Validation error] -> a=read();
   read method must have at least filename parameter
#2 a.dml [line 2:0] [Validation error] -> b=matrix();
   for matrix statement, must specify at least 3 arguments: data, rows, cols
#3 a.dml [line 3:0] [Validation error] -> c=rand(2,2);
   for rand statement, all arguments must be named parameters
--------------------------------------------------------------
```