### PR TITLE
[SYSTEMML-957] Bug fix for seq() in for loop

### DIFF
--- a/src/main/java/org/apache/sysml/parser/dml/Dml.g4
+++ b/src/main/java/org/apache/sysml/parser/dml/Dml.g4
@@ -87,7 +87,7 @@ iterablePredicate returns [ org.apache.sysml.parser.common.ExpressionInfo info ]
          $info = new org.apache.sysml.parser.common.ExpressionInfo();
   } :
     from=expression ':' to=expression #IterablePredicateColonExpression
-    | ID '(' from=expression ',' to=expression ',' increment=expression ')' #IterablePredicateSeqExpression
+    | ID '(' from=expression ',' to=expression (',' increment=expression)? ')' #IterablePredicateSeqExpression
     ;
 
 functionStatement returns [ org.apache.sysml.parser.common.StatementInfo info ]

--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -775,7 +775,8 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		}
 		ctx.info.from = ctx.from.info.expr;
 		ctx.info.to = ctx.to.info.expr;
-		ctx.info.increment = ctx.increment.info.expr;
+		if(ctx.increment != null && ctx.increment.info != null)
+			ctx.info.increment = ctx.increment.info.expr;
 	}
 
 

--- a/src/main/java/org/apache/sysml/parser/pydml/Pydml.g4
+++ b/src/main/java/org/apache/sysml/parser/pydml/Pydml.g4
@@ -203,7 +203,7 @@ iterablePredicate returns [ org.apache.sysml.parser.common.ExpressionInfo info ]
          $info = new org.apache.sysml.parser.common.ExpressionInfo();
   } :
     from=expression ':' to=expression #IterablePredicateColonExpression
-    | ID OPEN_PAREN from=expression ',' to=expression ',' increment=expression CLOSE_PAREN #IterablePredicateSeqExpression
+    | ID OPEN_PAREN from=expression ',' to=expression (',' increment=expression)? CLOSE_PAREN #IterablePredicateSeqExpression
     ;
 
 functionStatement returns [ org.apache.sysml.parser.common.StatementInfo info ]

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -1368,7 +1368,8 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		}
 		ctx.info.from = ctx.from.info.expr;
 		ctx.info.to = ctx.to.info.expr;
-		ctx.info.increment = ctx.increment.info.expr;
+		if(ctx.increment != null && ctx.increment.info != null)
+			ctx.info.increment = ctx.increment.info.expr;
 	}
 
 

--- a/src/test/java/org/apache/sysml/test/integration/functions/parfor/ForLoopPredicateTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/parfor/ForLoopPredicateTest.java
@@ -37,6 +37,7 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 	private final static String TEST_NAME4 = "for_pred2b"; //var seq
 	private final static String TEST_NAME5 = "for_pred3a"; //expression
 	private final static String TEST_NAME6 = "for_pred3b"; //expression seq
+	private final static String TEST_NAME7 = "for_pred1a_seq"; //const seq two parameters (this tests is only for parser)
 	private final static String TEST_DIR = "functions/parfor/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + ForLoopPredicateTest.class.getSimpleName() + "/";
 	
@@ -53,12 +54,19 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[]{"R"}));
 		addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5, new String[]{"R"}));
 		addTestConfiguration(TEST_NAME6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6, new String[]{"R"}));
+		addTestConfiguration(TEST_NAME7, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME7, new String[]{"R"}));
 	}
 
 	@Test
 	public void testForConstIntegerPredicate() 
 	{
 		runForPredicateTest(1, true);
+	}
+	
+	@Test
+	public void testForConstIntegerSeq2ParametersPredicate() 
+	{
+		runForPredicateTest(7, true);
 	}
 	
 	@Test
@@ -95,6 +103,12 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 	public void testForConstDoublePredicate() 
 	{
 		runForPredicateTest(1, false);
+	}
+	
+	@Test
+	public void testForConstDoubleSeq2ParametersPredicate() 
+	{
+		runForPredicateTest(7, false);
 	}
 	
 	@Test
@@ -143,6 +157,7 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 			case 4: TEST_NAME = TEST_NAME4; break;
 			case 5: TEST_NAME = TEST_NAME5; break;
 			case 6: TEST_NAME = TEST_NAME6; break;
+			case 7: TEST_NAME = TEST_NAME7; break;
 		}
 		
 		getAndLoadTestConfiguration(TEST_NAME);

--- a/src/test/scripts/functions/parfor/for_pred1a_seq.dml
+++ b/src/test/scripts/functions/parfor/for_pred1a_seq.dml
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+sum = 0;
+for( i in seq($1, $2) ) 
+{
+   sum = sum + 1; 
+}  
+
+R = matrix(1, rows=1, cols=1);
+R = R * sum;
+write(R, $4);


### PR DESCRIPTION
To reproduce this bug, please use following scripts:

Works as expected:
```bash
for(i in seq(1,5,1)) {
        print(i)
}
for(i in 1:5) {
        print(i)
}
```

Doesnot work:
```bash
for(i in seq(1,5)) {
        print(i)
}
```