### PR TITLE
[SYSTEMML-999] Include tests in MLContext package suite

### DIFF
--- a/src/test_suites/java/org/apache/sysml/test/integration/functions/frame/ZPackageSuite.java
+++ b/src/test_suites/java/org/apache/sysml/test/integration/functions/frame/ZPackageSuite.java
@@ -26,13 +26,19 @@ import org.junit.runners.Suite;
  *  won't run two of them at once. */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+	FrameAppendDistTest.class,
 	FrameAppendTest.class,
 	FrameCastingTest.class,
 	FrameConverterTest.class,
 	FrameCopyTest.class,
+	FrameEvictionTest.class,
+	FrameFunctionTest.class,
 	FrameGetSetTest.class,
+	FrameIndexingDistTest.class,
 	FrameIndexingTest.class,
 	FrameMatrixCastingTest.class,
+	FrameMatrixReblockTest.class,
+	FrameMatrixWriteTest.class,
 	FrameMetaReadWriteTest.class,
 	FrameReadWriteTest.class,
 	FrameScalarCastingTest.class,

--- a/src/test_suites/java/org/apache/sysml/test/integration/functions/mlcontext/ZPackageSuite.java
+++ b/src/test_suites/java/org/apache/sysml/test/integration/functions/mlcontext/ZPackageSuite.java
@@ -26,9 +26,12 @@ import org.junit.runners.Suite;
  *  won't run two of them at once. */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+	DataFrameMatrixConversionTest.class,
+	DataFrameRowFrameConversionTest.class,
+	DataFrameVectorFrameConversionTest.class,
+	FrameTest.class,
 	GNMFTest.class
 })
-
 
 /** This class is just a holder for the above JUnit annotations. */
 public class ZPackageSuite {

--- a/src/test_suites/java/org/apache/sysml/test/integration/mlcontext/ZPackageSuite.java
+++ b/src/test_suites/java/org/apache/sysml/test/integration/mlcontext/ZPackageSuite.java
@@ -27,8 +27,10 @@ import org.junit.runners.Suite;
  *  they should not be run in parallel. */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-  org.apache.sysml.test.integration.mlcontext.MLContextTest.class,
-  org.apache.sysml.test.integration.mlcontext.MLContextFrameTest.class
+  org.apache.sysml.test.integration.mlcontext.MLContextFrameTest.class,
+  org.apache.sysml.test.integration.mlcontext.MLContextMultipleScriptsTest.class,
+  org.apache.sysml.test.integration.mlcontext.MLContextScratchCleanupTest.class,
+  org.apache.sysml.test.integration.mlcontext.MLContextTest.class
 })
 
 


### PR DESCRIPTION
Included references to MLContextMultipleScriptsTest and MLContextScratchCleanupTest for MLContext package test suite.