### PR TITLE
[SYSTEMML-1073] Remove maven-deploy-plugin from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -673,6 +673,28 @@
 		</profile>
 
 		<profile>
+			<id>deploy-release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-deploy-plugin</artifactId>
+						<version>2.8.2</version>
+						<configuration>
+							<updateReleaseInfo>true</updateReleaseInfo>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>deploy</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
 			<!-- Profile to create binary distributions.
 				Execute with `mvn clean package -P distribution` -->
 			<id>distribution</id>
@@ -756,21 +778,6 @@
 									</descriptors>
 								</configuration>
 							</execution-->
-						</executions>
-					</plugin>
-
-					<plugin>
-						<artifactId>maven-deploy-plugin</artifactId>
-						<version>2.8.2</version>
-						<configuration>
-							<updateReleaseInfo>true</updateReleaseInfo>
-						</configuration>
-						<executions>
-							<execution>
-								<goals>
-									<goal>deploy</goal>
-								</goals>
-							</execution>
 						</executions>
 					</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -673,28 +673,6 @@
 		</profile>
 
 		<profile>
-			<id>deploy-release</id>
-			<build>
-				<plugins>
-					<plugin>
-						<artifactId>maven-deploy-plugin</artifactId>
-						<version>2.8.2</version>
-						<configuration>
-							<updateReleaseInfo>true</updateReleaseInfo>
-						</configuration>
-						<executions>
-							<execution>
-								<goals>
-									<goal>deploy</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-
-		<profile>
 			<!-- Profile to create binary distributions.
 				Execute with `mvn clean package -P distribution` -->
 			<id>distribution</id>


### PR DESCRIPTION
Move maven-deploy-plugin out of distribution profile so that double
deploy doesn't happen when deploy to snapshot repository.

See https://issues.apache.org/jira/browse/SYSTEMML-1073

cc @lresende 
