### PR TITLE
[SYSTEMML-1081] Fix of incorrect dimensions after indexing operation

### DIFF
--- a/src/main/java/org/apache/sysml/parser/StatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/StatementBlock.java
@@ -691,7 +691,8 @@ public class StatementBlock extends LiveVariableAnalysis
 								+ source.getOutput().getDim1() + " rows and " + source.getOutput().getDim2() + " cols ", conditional);
 					}
 					
-					((IndexedIdentifier)target).setDimensions(targetSize._row, targetSize._col);		
+					// Commenting this since "z[2, 2] =  2.5" doesnot change the dimension of z
+					// ((IndexedIdentifier)target).setDimensions(targetSize._row, targetSize._col);		
 				}
 				
 				ids.addVariable(target.getName(), target);


### PR DESCRIPTION
To reproduce this bug, please try following DML script:
z = matrix (0, rows = 2, cols = 5);
z[2, 2] = 2.5;
z[2, 3] = 5.0;
z[2, 4] = 10.0;
n = ncol(z);
print ("ncol (z) = " + ncol (z) + ", but n = " + n);

This prints ncol (z) = 5, but n = 1.

@bertholdreinwald @asurve @mboehm7 