### PR TITLE
[SYSTEMML-1127] Synchronize creation of the cache directory

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/util/IDHandler.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/util/IDHandler.java
@@ -122,9 +122,8 @@ public class IDHandler
 		    //get ip address
 		    InetAddress addr = InetAddress.getLocalHost();
 		    String host = addr.getHostAddress();
-		    //addr.getHostName()
-		    
-			uuid = pid + "_" + host;
+		    	
+		    uuid = pid + "_" + host;
 		}
 		catch(Exception ex)
 		{

--- a/src/main/java/org/apache/sysml/runtime/util/LocalFileUtils.java
+++ b/src/main/java/org/apache/sysml/runtime/util/LocalFileUtils.java
@@ -336,7 +336,7 @@ public class LocalFileUtils
 		return createWorkingDirectoryWithUUID( DMLScript.getUUID() );
 	}
 
-	public static String createWorkingDirectoryWithUUID( String uuid )
+	public static synchronized String createWorkingDirectoryWithUUID( String uuid )
 		throws DMLRuntimeException 
 	{
 		//create local tmp dir if not existing


### PR DESCRIPTION
This fixes a race condition that occurred while initializing the cache directory on remote spark workers. By synchronizing this, the problem should be resolved.

As per @mboehm7 's suggestion I synchronized the creation of the temporary cache directory. Initialization of the cache was already synchronized.