### PR TITLE
[SYSTEMML-768] Fix coercion issue for table to CsparseMatrix

### DIFF
--- a/src/test/scripts/functions/ternary/CTableRowHist.R
+++ b/src/test/scripts/functions/ternary/CTableRowHist.R
@@ -37,7 +37,7 @@ Btmp1 = table (IA, VA);
 Btmp2 = as.matrix(as.data.frame.matrix(Btmp1));
 
 #remove first row and column (0 values, see missing removeEmpty)
-B = Btmp1[2:nrow(Btmp2),2:ncol(Btmp2)];
+B = Btmp2[2:nrow(Btmp2),2:ncol(Btmp2)];
 
 writeMM(as(B, "CsparseMatrix"), paste(args[2], "B", sep="")); 
 


### PR DESCRIPTION
This issue relates directly to the version of R in use.  R versions 3.3+ encounter the coercion issue displaying the following message:
```
Standard Error from R:Error in as(B, "CsparseMatrix") : 
  no method or default for coercing “table” to “CsparseMatrix”
Calls: writeMM -> as
```
It appears that R has fixed implicit coercion such that the following statements now (in R 3.3+) return a table rather than a matrix.
```
B1 = table (IA, VA);
B2 = as.matrix(as.data.frame.matrix(B1));
B = B1[2:nrow(B2),2:ncol(B2)];
writeMM(as(B, "CsparseMatrix"), paste(args[2], "B", sep=""));
```
This results a table coercion exception when attempting to write B as a CsparseMatrix.
The fix is to use the matrix B2 when creating variable B.  This will result in B getting treated as a matrix rather than a table.
```
B = B2[2:nrow(B2),2:ncol(B2)];
```
This suggests that R improved (or fixed) the handling of the assignment of B such that it now (in 3.3+) preserves the table datatype upon assignment.


