### PR TITLE
[SYSTEMML-1133] Remove unused constants from project

### DIFF
--- a/src/main/java/org/apache/sysml/api/MLMatrix.java
+++ b/src/main/java/org/apache/sysml/api/MLMatrix.java
@@ -21,8 +21,6 @@ package org.apache.sysml.api;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.DataFrame;
@@ -66,7 +64,6 @@ import scala.Tuple2;
  */
 public class MLMatrix extends DataFrame {
 	private static final long serialVersionUID = -7005940673916671165L;
-	protected static final Log LOG = LogFactory.getLog(DMLScript.class.getName());
 	
 	protected MatrixCharacteristics mc = null;
 	protected MLContext ml = null;

--- a/src/main/java/org/apache/sysml/hops/Hop.java
+++ b/src/main/java/org/apache/sysml/hops/Hop.java
@@ -54,8 +54,6 @@ public abstract class Hop
 	protected static final Log LOG =  LogFactory.getLog(Hop.class.getName());
 	
 	public static final long CPThreshold = 2000;
-	protected static final boolean BREAKONSCALARS = false;
-	protected static final boolean SPLITLARGEMATRIXMULT = true;
 
 	public enum VisitStatus {
 		DONE, 

--- a/src/main/java/org/apache/sysml/hops/OptimizerUtils.java
+++ b/src/main/java/org/apache/sysml/hops/OptimizerUtils.java
@@ -91,7 +91,6 @@ public class OptimizerUtils
 	public static final long INT_SIZE = 4;
 	public static final long CHAR_SIZE = 1;
 	public static final long BOOLEAN_SIZE = 1;
-	public static final double BIT_SIZE = (double)1/8;
 	public static final double INVALID_SIZE = -1d; // memory estimate not computed
 
 	//constants for valid CP matrix dimension sizes / nnz (dense/sparse)

--- a/src/main/java/org/apache/sysml/lops/AppendCP.java
+++ b/src/main/java/org/apache/sysml/lops/AppendCP.java
@@ -27,8 +27,6 @@ import org.apache.sysml.parser.Expression.*;
 
 public class AppendCP extends Lop
 {
-	public static final String OPCODE = "append";
-	
 	private boolean _cbind = true;
 	
 	public AppendCP(Lop input1, Lop input2, Lop input3, DataType dt, ValueType vt, boolean cbind) 

--- a/src/main/java/org/apache/sysml/lops/AppendCP.java
+++ b/src/main/java/org/apache/sysml/lops/AppendCP.java
@@ -27,6 +27,8 @@ import org.apache.sysml.parser.Expression.*;
 
 public class AppendCP extends Lop
 {
+	public static final String OPCODE = "append"; // TODO investigate unused constant
+
 	private boolean _cbind = true;
 	
 	public AppendCP(Lop input1, Lop input2, Lop input3, DataType dt, ValueType vt, boolean cbind) 

--- a/src/main/java/org/apache/sysml/lops/Checkpoint.java
+++ b/src/main/java/org/apache/sysml/lops/Checkpoint.java
@@ -45,7 +45,6 @@ public class Checkpoint extends Lop
 	public static final StorageLevel DEFAULT_STORAGE_LEVEL = StorageLevel.MEMORY_AND_DISK();
 	public static final StorageLevel SER_STORAGE_LEVEL = StorageLevel.MEMORY_AND_DISK_SER();
 	public static final boolean CHECKPOINT_SPARSE_CSR = true; 
-	public static final String STORAGE_LEVEL = "storage.level"; 
 
 	private StorageLevel _storageLevel;
 	

--- a/src/main/java/org/apache/sysml/parser/LanguageException.java
+++ b/src/main/java/org/apache/sysml/parser/LanguageException.java
@@ -53,7 +53,6 @@ public class LanguageException extends DMLException
     	public static final String UNSUPPORTED_EXPRESSION = "Unsupported Expression";
     	public static final String INVALID_PARAMETERS = "Invalid Parameters";
     	public static final String UNSUPPORTED_PARAMETERS = "Unsupported Parameters";
-    	public static final String GENERIC_ERROR = "Language Syntax Error";
     }
 
 }

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ParForProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ParForProgramBlock.java
@@ -221,7 +221,6 @@ public class ParForProgramBlock extends ForProgramBlock
 	public static final int     MAX_RETRYS_ON_ERROR         = 1;
 	public static final boolean FORCE_CP_ON_REMOTE_MR       = true; // compile body to CP if exec type forced to MR
 	public static final boolean LIVEVAR_AWARE_EXPORT        = true; //export only read variables according to live variable analysis
- 	public static final boolean LIVEVAR_AWARE_CLEANUP       = true; //cleanup pinned variables according to live variable analysis
 	public static final boolean RESET_RECOMPILATION_FLAGs   = true;
  	
  	public static final String PARFOR_FNAME_PREFIX          = "/parfor/"; 

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/ProgramConverter.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/ProgramConverter.java
@@ -147,6 +147,7 @@ public class ProgramConverter
 	public static final String NOT_SUPPORTED_MR_PARFOR           = "Not supported: Nested ParFOR REMOTE_MR due to possible deadlocks." +
 			                                                       "(LOCAL can be used for innner ParFOR)";
 	public static final String NOT_SUPPORTED_PB                  = "Not supported: type of program block";
+	public static final String NOT_SUPPORTED_EXECUTION_CONTEXT   = "Parsing of external system execution context not supported yet."; // TODO investigate unused constant
 	
 	////////////////////////////////
 	// CREATION of DEEP COPIES

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/ProgramConverter.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/ProgramConverter.java
@@ -108,7 +108,6 @@ public class ProgramConverter
 	public static final String LEVELIN           = "\u23a8"; //variant of left curly bracket; "\u007b"; //"{";
 	public static final String LEVELOUT          = "\u23ac"; //variant of right curly bracket; "\u007d"; //"}";	
 	public static final String EMPTY             = "null";
-	public static final String EXT_FUNCTION      = "extfunct";
 	
 	//public static final String CP_ROOT_THREAD_SEPARATOR = "/";//File.separator;
 	public static final String CP_ROOT_THREAD_ID = "_t0";       
@@ -148,8 +147,6 @@ public class ProgramConverter
 	public static final String NOT_SUPPORTED_MR_PARFOR           = "Not supported: Nested ParFOR REMOTE_MR due to possible deadlocks." +
 			                                                       "(LOCAL can be used for innner ParFOR)";
 	public static final String NOT_SUPPORTED_PB                  = "Not supported: type of program block";
-	public static final String NOT_SUPPORTED_EXECUTION_CONTEXT   = "Parsing of external system execution context not supported yet.";
-	
 	
 	////////////////////////////////
 	// CREATION of DEEP COPIES

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/opt/CostEstimator.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/opt/CostEstimator.java
@@ -46,6 +46,7 @@ public abstract class CostEstimator
 	public static final long   FACTOR_NUM_ITERATIONS   = 10; //default problem size
 	public static final double DEFAULT_TIME_ESTIMATE   = 5;  //default execution time: 5ms
 	public static final double DEFAULT_MEM_ESTIMATE_CP = 1024; //default memory consumption: 1KB 
+	public static final double DEFAULT_MEM_ESTIMATE_MR = 10*1024*1024; //default memory consumption: 20MB // TODO investigate unused constant
 	
 	
 	/**

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/opt/CostEstimator.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/opt/CostEstimator.java
@@ -46,7 +46,6 @@ public abstract class CostEstimator
 	public static final long   FACTOR_NUM_ITERATIONS   = 10; //default problem size
 	public static final double DEFAULT_TIME_ESTIMATE   = 5;  //default execution time: 5ms
 	public static final double DEFAULT_MEM_ESTIMATE_CP = 1024; //default memory consumption: 1KB 
-	public static final double DEFAULT_MEM_ESTIMATE_MR = 10*1024*1024; //default memory consumption: 20MB 
 	
 	
 	/**

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/opt/OptimizerRuleBased.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/opt/OptimizerRuleBased.java
@@ -152,6 +152,7 @@ public class OptimizerRuleBased extends Optimizer
 	public static final double PROB_SIZE_THRESHOLD_REMOTE = 100; //wrt # top-level iterations (min)
 	public static final double PROB_SIZE_THRESHOLD_PARTITIONING = 2; //wrt # top-level iterations (min)
 	public static final double PROB_SIZE_THRESHOLD_MB = 256*1024*1024; //wrt overall memory consumption (min)
+	public static final int MAX_REPLICATION_FACTOR_PARTITIONING = 5; // TODO investigate unused constant
 	public static final int MAX_REPLICATION_FACTOR_EXPORT = 7;    
 	public static final boolean ALLOW_REMOTE_NESTED_PARALLELISM = false;
 	public static final boolean APPLY_REWRITE_NESTED_PARALLELISM = false;

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/opt/OptimizerRuleBased.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/opt/OptimizerRuleBased.java
@@ -152,7 +152,6 @@ public class OptimizerRuleBased extends Optimizer
 	public static final double PROB_SIZE_THRESHOLD_REMOTE = 100; //wrt # top-level iterations (min)
 	public static final double PROB_SIZE_THRESHOLD_PARTITIONING = 2; //wrt # top-level iterations (min)
 	public static final double PROB_SIZE_THRESHOLD_MB = 256*1024*1024; //wrt overall memory consumption (min)
-	public static final int MAX_REPLICATION_FACTOR_PARTITIONING = 5;     
 	public static final int MAX_REPLICATION_FACTOR_EXPORT = 7;    
 	public static final boolean ALLOW_REMOTE_NESTED_PARALLELISM = false;
 	public static final boolean APPLY_REWRITE_NESTED_PARALLELISM = false;

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/opt/PerfTestTool.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/opt/PerfTestTool.java
@@ -105,14 +105,9 @@ public class PerfTestTool
 	public static final long    MAX_DATASIZE           = 1000000; 
 	public static final long    DEFAULT_DATASIZE       = 500000;//(MAX_DATASIZE-MIN_DATASIZE)/2;
 	public static final long    DATASIZE_MR_SCALE      = 20;
-	public static final double  MIN_DIMSIZE            = 1;
-	public static final double  MAX_DIMSIZE            = 1000; 
 	public static final double  MIN_SPARSITY           = 0.1;
 	public static final double  MAX_SPARSITY           = 1.0;
 	public static final double  DEFAULT_SPARSITY       = 0.5;//(MAX_SPARSITY-MIN_SPARSITY)/2;
-	public static final double  MIN_SORT_IO_MEM        = 10;
-	public static final double  MAX_SORT_IO_MEM        = 500;
-	public static final double  DEFAULT_SORT_IO_MEM    = 256; //BI: default 256MB, hadoop: default 100MB
 	
 	//internal parameters
 	private static final boolean READ_STATS_ON_STARTUP  = false;

--- a/src/main/java/org/apache/sysml/runtime/instructions/Instruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/Instruction.java
@@ -48,7 +48,6 @@ public abstract class Instruction
 	public static final String VALUETYPE_PREFIX = Lop.VALUETYPE_PREFIX;
 	public static final String LITERAL_PREFIX = Lop.LITERAL_PREFIX;
 	public static final String INSTRUCTION_DELIM = Lop.INSTRUCTION_DELIMITOR;
-	public static final String NAME_VALUE_SEPARATOR = Lop.NAME_VALUE_SEPARATOR;
 	public static final String SP_INST_PREFIX = "sp_";
 	public static final String GPU_INST_PREFIX = "gpu_";
 	

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRConfigurationNames.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRConfigurationNames.java
@@ -34,11 +34,9 @@ public abstract class MRConfigurationNames {
 	protected static final Log LOG = LogFactory.getLog(MRConfigurationNames.class.getName());
 
 	// non-deprecated properties
-	public static final String DFS_DATANODE_DATA_DIR_PERM = "dfs.datanode.data.dir.perm"; // hdfs-default.xml
 	public static final String DFS_REPLICATION = "dfs.replication"; // hdfs-default.xml
 	public static final String IO_FILE_BUFFER_SIZE = "io.file.buffer.size"; // core-default.xml
 	public static final String IO_SERIALIZATIONS = "io.serializations"; // core-default.xml
-	public static final String MR_APPLICATION_CLASSPATH = "mapreduce.application.classpath"; // mapred-default.xml
 	public static final String MR_CHILD_JAVA_OPTS = "mapred.child.java.opts"; // mapred-default.xml
 	public static final String MR_FRAMEWORK_NAME = "mapreduce.framework.name"; // mapred-default.xml
 	public static final String MR_JOBTRACKER_STAGING_ROOT_DIR = "mapreduce.jobtracker.staging.root.dir"; // mapred-default.xml

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRConfigurationNames.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRConfigurationNames.java
@@ -37,6 +37,7 @@ public abstract class MRConfigurationNames {
 	public static final String DFS_REPLICATION = "dfs.replication"; // hdfs-default.xml
 	public static final String IO_FILE_BUFFER_SIZE = "io.file.buffer.size"; // core-default.xml
 	public static final String IO_SERIALIZATIONS = "io.serializations"; // core-default.xml
+	public static final String MR_APPLICATION_CLASSPATH = "mapreduce.application.classpath"; // mapred-default.xml // TODO investigate unused constant
 	public static final String MR_CHILD_JAVA_OPTS = "mapred.child.java.opts"; // mapred-default.xml
 	public static final String MR_FRAMEWORK_NAME = "mapreduce.framework.name"; // mapred-default.xml
 	public static final String MR_JOBTRACKER_STAGING_ROOT_DIR = "mapreduce.jobtracker.staging.root.dir"; // mapred-default.xml

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
@@ -231,6 +231,9 @@ public class MRJobConfiguration
 	 * group name for the counters on number of output nonZeros
 	 */
 	public static final String NUM_NONZERO_CELLS="nonzeros";
+
+	public static final String PARFOR_NUMTASKS="numtasks"; // TODO investigate unused constant
+	public static final String PARFOR_NUMITERATOINS="numiterations"; // TODO investigate unused constant
 	
 	public static final String TF_NUM_COLS 		= "transform.num.columns";
 	public static final String TF_HAS_HEADER 	= "transform.has.header";

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MRJobConfiguration.java
@@ -232,17 +232,6 @@ public class MRJobConfiguration
 	 */
 	public static final String NUM_NONZERO_CELLS="nonzeros";
 	
-	/*
-	 * Counter group for determining the dimensions of result matrix. It is 
-	 * useful in operations like ctable and groupedAgg, in which the dimensions 
-	 * of result matrix are known only after computing the matrix.
-	 */
-	public static final String MAX_ROW_DIMENSION = "maxrows";
-	public static final String MAX_COL_DIMENSION = "maxcols";
-	
-	public static final String PARFOR_NUMTASKS="numtasks";
-	public static final String PARFOR_NUMITERATOINS="numiterations";
-	
 	public static final String TF_NUM_COLS 		= "transform.num.columns";
 	public static final String TF_HAS_HEADER 	= "transform.has.header";
 	public static final String TF_DELIM 		= "transform.field.delimiter";

--- a/src/main/java/org/apache/sysml/runtime/matrix/mapred/MapperBase.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/mapred/MapperBase.java
@@ -24,13 +24,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.Reporter;
-
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.instructions.mr.AggregateBinaryInstruction;
 import org.apache.sysml.runtime.instructions.mr.CSVReblockInstruction;
@@ -48,8 +45,6 @@ import org.apache.sysml.runtime.matrix.data.TaggedMatrixValue;
 @SuppressWarnings("rawtypes")
 public abstract class MapperBase extends MRBaseForCommonInstructions
 {
-	
-	protected static final Log LOG = LogFactory.getLog(MapperBase.class);
 	
 	//the indexes that this particular input matrix file represents
 	protected ArrayList<Byte> representativeMatrixes=null;

--- a/src/main/java/org/apache/sysml/runtime/transform/GenTfMtdMR.java
+++ b/src/main/java/org/apache/sysml/runtime/transform/GenTfMtdMR.java
@@ -44,8 +44,6 @@ import org.apache.sysml.runtime.matrix.mapred.MRJobConfiguration;
 
 public class GenTfMtdMR {
 
-	public static final String DELIM = ",";
-
 	public static long runJob(String inputPath, String txMtdPath, String specWithIDs, String smallestFile, String partOffsetsFile, CSVFileFormatProperties inputDataProperties, long numCols, int replication, String headerLine) throws IOException, ClassNotFoundException, InterruptedException {
 		JobConf job = new JobConf(GenTfMtdMR.class);
 		job.setJobName("GenTfMTD");

--- a/src/main/java/org/apache/sysml/runtime/util/UtilFunctions.java
+++ b/src/main/java/org/apache/sysml/runtime/util/UtilFunctions.java
@@ -45,7 +45,6 @@ public class UtilFunctions
 	//prime numbers for old hash function (divide prime close to max int, 
 	//because it determines the max hash domain size
 	public static final long ADD_PRIME1 = 99991;
-	public static final long ADD_PRIME2 = 853;
 	public static final int DIVIDE_PRIME = 1405695061; 
 	
 	public static int longHashCode(long v) {

--- a/src/main/java/org/apache/sysml/udf/PackageFunction.java
+++ b/src/main/java/org/apache/sysml/udf/PackageFunction.java
@@ -22,9 +22,6 @@ package org.apache.sysml.udf;
 import java.io.Serializable;
 import java.util.ArrayList;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import org.apache.sysml.runtime.controlprogram.parfor.util.IDSequence;
 
 /**
@@ -33,9 +30,7 @@ import org.apache.sysml.runtime.controlprogram.parfor.util.IDSequence;
  * 
  */
 public abstract class PackageFunction implements Serializable 
-{	
-	protected static final Log LOG = LogFactory.getLog(PackageFunction.class.getName());
-	
+{
 	private static final long serialVersionUID = 3274150928865462856L;
 	
 	private ArrayList<FunctionParameter> _function_inputs; // function inputs


### PR DESCRIPTION
Unused (unreferenced) constants should be removed from the project because they are misleading.

Here is a list of unused constants in the project:

```
org.apache.sysml.api.MLMatrix.LOG
org.apache.sysml.hops.Hop.BREAKONSCALARS
org.apache.sysml.hops.Hop.SPLITLARGEMATRIXMULT
org.apache.sysml.hops.OptimizerUtils.BIT_SIZE
org.apache.sysml.lops.AppendCP.OPCODE
org.apache.sysml.lops.Checkpoint.STORAGE_LEVEL
org.apache.sysml.parser.LanguageException.LanguageErrorCodes.GENERIC_ERROR
org.apache.sysml.runtime.controlprogram.parfor.opt.CostEstimator.DEFAULT_MEM_ESTIMATE_MR
org.apache.sysml.runtime.controlprogram.parfor.opt.OptimizerRuleBased.MAX_REPLICATION_FACTOR_PARTITIONING
org.apache.sysml.runtime.controlprogram.parfor.opt.PerfTestTool.DEFAULT_SORT_IO_MEM
org.apache.sysml.runtime.controlprogram.parfor.opt.PerfTestTool.MAX_DIMSIZE
org.apache.sysml.runtime.controlprogram.parfor.opt.PerfTestTool.MAX_SORT_IO_MEM
org.apache.sysml.runtime.controlprogram.parfor.opt.PerfTestTool.MIN_DIMSIZE
org.apache.sysml.runtime.controlprogram.parfor.opt.PerfTestTool.MIN_SORT_IO_MEM
org.apache.sysml.runtime.controlprogram.parfor.ProgramConverter.EXT_FUNCTION
org.apache.sysml.runtime.controlprogram.parfor.ProgramConverter.NOT_SUPPORTED_EXECUTION_CONTEXT
org.apache.sysml.runtime.controlprogram.ParForProgramBlock.LIVEVAR_AWARE_CLEANUP
org.apache.sysml.runtime.instructions.Instruction.NAME_VALUE_SEPARATOR
org.apache.sysml.runtime.matrix.mapred.MapperBase.LOG
org.apache.sysml.runtime.matrix.mapred.MRConfigurationNames.DFS_DATANODE_DATA_DIR_PERM
org.apache.sysml.runtime.matrix.mapred.MRConfigurationNames.MR_APPLICATION_CLASSPATH
org.apache.sysml.runtime.matrix.mapred.MRJobConfiguration.MAX_COL_DIMENSION
org.apache.sysml.runtime.matrix.mapred.MRJobConfiguration.MAX_ROW_DIMENSION
org.apache.sysml.runtime.matrix.mapred.MRJobConfiguration.PARFOR_NUMITERATOINS
org.apache.sysml.runtime.matrix.mapred.MRJobConfiguration.PARFOR_NUMTASKS
org.apache.sysml.runtime.transform.GenTfMtdMR.DELIM
org.apache.sysml.runtime.util.UtilFunctions.ADD_PRIME2
org.apache.sysml.udf.PackageFunction.LOG
```

All tests passed: https://sparktc.ibmcloud.com/jenkins/job/SystemML-OnDemand/221/
