### PR TITLE
[SYSTEMML-1136] Remove unreferenced fields and member classes

### DIFF
--- a/src/main/java/org/apache/sysml/lops/Lop.java
+++ b/src/main/java/org/apache/sysml/lops/Lop.java
@@ -101,11 +101,6 @@ public abstract class Lop
 	private VisitStatus _visited = VisitStatus.NOTVISITED;
 
 	protected Lop.Type type;
-	
-	/**
-	 * transient indicator
-	 */
-	protected boolean hasTransientParameters = false;
 
 	/**
 	 * handle to all inputs and outputs.

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteDPParWorkerReducer.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteDPParWorkerReducer.java
@@ -70,6 +70,7 @@ public class RemoteDPParWorkerReducer extends ParWorker
 		
 	//MR ParWorker attributes  
 	protected String  _stringID       = null;
+	protected HashMap<String, String> _rvarFnames = null; // TODO investigate unused field
 
 	//cached collector/reporter
 	protected OutputCollector<Writable, Writable> _out = null;

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteDPParWorkerReducer.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteDPParWorkerReducer.java
@@ -69,8 +69,7 @@ public class RemoteDPParWorkerReducer extends ParWorker
 	private boolean _tSparseCol = false;
 		
 	//MR ParWorker attributes  
-	protected String  _stringID       = null; 
-	protected HashMap<String, String> _rvarFnames = null; 
+	protected String  _stringID       = null;
 
 	//cached collector/reporter
 	protected OutputCollector<Writable, Writable> _out = null;

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/JCudaObject.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/JCudaObject.java
@@ -517,9 +517,6 @@ public class JCudaObject extends GPUObject {
 		return isEmptyAndSparseAndAllocated;
 	}
 
-
-    long thisThread = Thread.currentThread().getId();
-
 	/**
 	 * Allocate necessary memory on the GPU for this {@link JCudaObject} instance.
 	 * 

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNN.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNN.java
@@ -78,15 +78,6 @@ public class LibMatrixDNN {
 		LoopedIm2ColConv2d, LoopedIm2ColConv2dBwdFilter, LoopedIm2ColConv2dBwdData
 	}
 	
-	public static class TemporaryConvolutionData {
-		public int [] minIndexArrR;
-		public int [] minIndexArrS;
-		public int [] maxIndexArrR;
-		public int [] maxIndexArrS;
-		int minCommonIndexS;
-		int maxCommonIndexS;
-	}
-	
 	private static AtomicLong conv2dSparseCount = new AtomicLong(0);
 	private static AtomicLong conv2dDenseCount = new AtomicLong(0);
 	private static AtomicLong conv2dBwdFilterSparseCount = new AtomicLong(0);
@@ -159,8 +150,6 @@ public class LibMatrixDNN {
 		
 		MatrixBlock input1; MatrixBlock input2; MatrixBlock output;
 		boolean reuseNonZeroedOutput = false;
-		
-		public TemporaryConvolutionData tmpData;
 		
 		private int convertToInt(long val) throws DMLRuntimeException {
 			if( val > Integer.MAX_VALUE ) {

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/Tagged.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/Tagged.java
@@ -34,7 +34,7 @@ public class Tagged<T extends WritableComparable> implements WritableComparable<
 //	private static final Log LOG = LogFactory.getLog(Tagged.class);
 	protected byte tag=-1;
 	protected T base;
-	public static int TAG_SIZE=Integer.SIZE/8;
+
 	public Tagged(T b, byte t)
 	{		
 		base=b;
@@ -77,26 +77,6 @@ public class Tagged<T extends WritableComparable> implements WritableComparable<
 	{
 		return base.toString()+" ~~ tag: "+tag;
 	}
-	
-	 /** A Comparator optimized for Tagged. */ 
-	public static class Comparator implements RawComparator<Tagged> {
-		
-		public int compare(byte[] b1, int s1, int l1,
-	                       byte[] b2, int s2, int l2) {
-	      byte thisValue = b1[s1];
-	      byte thatValue = b2[s2];
-	      return (thisValue-thatValue);
-	    }
-
-		@Override
-		@SuppressWarnings("unchecked")
-		public int compare(Tagged a, Tagged b) {
-			if(a.tag!=b.tag)
-				return a.tag-b.tag;
-			else 
-				return a.getBaseObject().compareTo(b.getBaseObject());
-		}
-	  }
 
 	@Override
 	@SuppressWarnings("unchecked")

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/TaggedMatrixIndexes.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/TaggedMatrixIndexes.java
@@ -81,19 +81,5 @@ public class TaggedMatrixIndexes extends Tagged<MatrixIndexes>
 	public int hashCode() {
 		 return base.hashCode() + tag;
 	}
-	
-	public static class Comparator implements RawComparator<TaggedMatrixIndexes>
-	{
-		@Override
-		public int compare(byte[] b1, int s1, int l1,
-                byte[] b2, int s2, int l2)
-		{
-			return WritableComparator.compareBytes(b1, s1, l1, b2, s2, l2);
-		}
 
-		@Override
-		public int compare(TaggedMatrixIndexes m1, TaggedMatrixIndexes m2) {
-			return m1.compareTo(m2);
-		}	
-	}
 }

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/TaggedTripleIndexes.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/TaggedTripleIndexes.java
@@ -114,37 +114,5 @@ public class TaggedTripleIndexes extends TaggedFirstSecondIndexes
 	public int hashCode() {
 		 return UtilFunctions.longHashCode((first<<32)+(second<<16)+third+tag+UtilFunctions.ADD_PRIME1)%UtilFunctions.DIVIDE_PRIME;
 	}
-	
-	public static class Comparator implements RawComparator<TaggedTripleIndexes>
-	{
-		@Override
-		public int compare(byte[] b1, int s1, int l1,
-                byte[] b2, int s2, int l2)
-		{
-			return WritableComparator.compareBytes(b1, s1, l1, b2, s2, l2);
-		}
-
-		@Override
-		public int compare(TaggedTripleIndexes m1, TaggedTripleIndexes m2) {
-			return m1.compareTo(m2);
-		}	
-	}
-	
-	 /**
-	   * Partition based on the first and second index.
-	   */
-	  public static class FirstTwoIndexesPartitioner implements Partitioner<TaggedTripleIndexes, MatrixBlock>{
-	    @Override
-	    public int getPartition(TaggedTripleIndexes key, MatrixBlock value, int numPartitions) {	   
-	    	return UtilFunctions.longHashCode((key.getFirstIndex()*127)
-	    			+key.getSecondIndex()+UtilFunctions.ADD_PRIME1)
-	    			%UtilFunctions.DIVIDE_PRIME%numPartitions;
-	    }
-
-		@Override
-		public void configure(JobConf arg0) {
-			
-		}
-	  }
 
 }

--- a/src/main/java/org/apache/sysml/runtime/matrix/operators/COVOperator.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/operators/COVOperator.java
@@ -28,7 +28,6 @@ public class COVOperator extends Operator
 	private static final long serialVersionUID = -8404264552880694469L;
 
 	public COV fn;
-	public int constant;
 	
 	public COVOperator(COV op)
 	{

--- a/src/main/java/org/apache/sysml/utils/Statistics.java
+++ b/src/main/java/org/apache/sysml/utils/Statistics.java
@@ -47,11 +47,9 @@ public class Statistics
 {	
 	private static long compileStartTime = 0;
 	private static long compileEndTime = 0;
-	public static long compileTime = 0;
 	
 	private static long execStartTime = 0;
 	private static long execEndTime = 0;
-	public static long execTime = 0;
 
 	// number of compiled/executed MR jobs
 	private static int iNoOfExecutedMRJobs = 0;

--- a/src/main/java/org/apache/sysml/utils/Statistics.java
+++ b/src/main/java/org/apache/sysml/utils/Statistics.java
@@ -47,9 +47,11 @@ public class Statistics
 {	
 	private static long compileStartTime = 0;
 	private static long compileEndTime = 0;
+	public static long compileTime = 0; // TODO investigate unused field
 	
 	private static long execStartTime = 0;
 	private static long execEndTime = 0;
+	public static long execTime = 0; // TODO investigate unused field
 
 	// number of compiled/executed MR jobs
 	private static int iNoOfExecutedMRJobs = 0;

--- a/src/main/java/org/apache/sysml/yarn/DMLAppMasterStatusReporter.java
+++ b/src/main/java/org/apache/sysml/yarn/DMLAppMasterStatusReporter.java
@@ -26,8 +26,9 @@ import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest;
 
 public class DMLAppMasterStatusReporter extends Thread
 {
+	public static long DEFAULT_REPORT_INTERVAL = 5000; // TODO investigate unused field
 	private static final Log LOG = LogFactory.getLog(DMLAppMasterStatusReporter.class);
-	
+
 	private AMRMClient<ContainerRequest> _rmClient;
 	private long _interval; //in ms
 	private volatile boolean _stop;

--- a/src/main/java/org/apache/sysml/yarn/DMLAppMasterStatusReporter.java
+++ b/src/main/java/org/apache/sysml/yarn/DMLAppMasterStatusReporter.java
@@ -26,10 +26,7 @@ import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest;
 
 public class DMLAppMasterStatusReporter extends Thread
 {
-	
-	public static long DEFAULT_REPORT_INTERVAL = 5000;
 	private static final Log LOG = LogFactory.getLog(DMLAppMasterStatusReporter.class);
-	
 	
 	private AMRMClient<ContainerRequest> _rmClient;
 	private long _interval; //in ms

--- a/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
+++ b/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
@@ -61,7 +61,6 @@ public class YarnClusterAnalyzer
 	public static long _remoteJVMMaxMemMap    = -1;
 	public static long _remoteJVMMaxMemReduce = -1;
 	public static long _remoteMRSortMem = -1;
-	public static boolean _localJT      = false;
 	public static long _blocksize       = -1;
 	
 	// Map from StatementBlock.ID to remoteJVMMaxMem (in bytes)

--- a/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
+++ b/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
@@ -61,6 +61,7 @@ public class YarnClusterAnalyzer
 	public static long _remoteJVMMaxMemMap    = -1;
 	public static long _remoteJVMMaxMemReduce = -1;
 	public static long _remoteMRSortMem = -1;
+	public static boolean _localJT      = false; // TODO investigate unused field
 	public static long _blocksize       = -1;
 	
 	// Map from StatementBlock.ID to remoteJVMMaxMem (in bytes)


### PR DESCRIPTION
Unreferenced fields and member classes should be removed from the project because they are not being used and are therefore essentially dead code.

Here is a list of unreferenced fields and member classes:

```
org.apache.sysml.lops.Lop.hasTransientParameters
org.apache.sysml.runtime.controlprogram.parfor.RemoteDPParWorkerReducer._rvarFnames
org.apache.sysml.runtime.instructions.gpu.context.JCudaObject.thisThread
org.apache.sysml.runtime.matrix.data.LibMatrixDNN.ConvolutionParameters.tmpData
org.apache.sysml.runtime.matrix.data.LibMatrixDNN.TemporaryConvolutionData.maxCommonIndexS
org.apache.sysml.runtime.matrix.data.LibMatrixDNN.TemporaryConvolutionData.maxIndexArrR
org.apache.sysml.runtime.matrix.data.LibMatrixDNN.TemporaryConvolutionData.maxIndexArrS
org.apache.sysml.runtime.matrix.data.LibMatrixDNN.TemporaryConvolutionData.minCommonIndexS
org.apache.sysml.runtime.matrix.data.LibMatrixDNN.TemporaryConvolutionData.minIndexArrR
org.apache.sysml.runtime.matrix.data.LibMatrixDNN.TemporaryConvolutionData.minIndexArrS
org.apache.sysml.runtime.matrix.data.Tagged.Comparator
org.apache.sysml.runtime.matrix.data.Tagged.TAG_SIZE
org.apache.sysml.runtime.matrix.data.TaggedMatrixIndexes.Comparator
org.apache.sysml.runtime.matrix.data.TaggedTripleIndexes.Comparator
org.apache.sysml.runtime.matrix.data.TaggedTripleIndexes.FirstTwoIndexesPartitioner
org.apache.sysml.runtime.matrix.operators.COVOperator.constant
org.apache.sysml.utils.Statistics.compileTime
org.apache.sysml.utils.Statistics.execTime
org.apache.sysml.yarn.DMLAppMasterStatusReporter.DEFAULT_REPORT_INTERVAL
org.apache.sysml.yarn.ropt.YarnClusterAnalyzer._localJT
```

All tests passed: https://sparktc.ibmcloud.com/jenkins/job/SystemML-OnDemand/224/
