### PR TITLE
[SYSTEMML-1141] Enable configurable testTemp location

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysml/test/integration/AutomatedTestBase.java
@@ -166,8 +166,12 @@ public abstract class AutomatedTestBase
 	 */
 	private static final File CONFIG_TEMPLATE_FILE = new File(CONFIG_DIR, "SystemML-config.xml");
 	
-	/** Location under which we create local temporary directories for test cases. */
-	private static final String LOCAL_TEMP_ROOT_DIR = "target/testTemp";
+	/**
+	 * Location under which we create local temporary directories for test cases.
+	 * To adjust where testTemp is located, use -Dsystemml.testTemp.root.dir=<new location>.  This is necessary
+	 * if any parent directories are public-protected.
+	 */
+	private static final String LOCAL_TEMP_ROOT_DIR = System.getProperty("systemml.testTemp.root.dir","target/testTemp");
 	private static final File LOCAL_TEMP_ROOT = new File(LOCAL_TEMP_ROOT_DIR);
 	
 	/** Base directory for generated IN, OUT, EXPECTED test data artifacts instead of SCRIPT_DIR. */


### PR DESCRIPTION
Added the ability to override the default testTemp directory location of "target/testTemp" by setting JVM property `systemml.testTemp.root.dir` when invoking the maven command that produces the test failure.  (e.g., `mvn test -e -Dtest=CSVReadUnknownSizeTest -Dsystemml.testTemp.root.dir=/tmp/foo/testTemp`)

This enables formal build environments (typically larger enterprises) to better protect their assets while allowing tests to complete within less-protected hierarchies.