### PR TITLE
[SYSTEMML-1145] Fix distribution build on Windows

### DIFF
--- a/src/main/python/post_setup.py
+++ b/src/main/python/post_setup.py
@@ -22,6 +22,7 @@
 from __future__ import print_function
 import os
 import sys
+import platform
 
 try:
     exec(open('systemml/project_info.py').read())
@@ -33,4 +34,7 @@ ARTIFACT_VERSION = __project_version__
 ARTIFACT_VERSION_SHORT = ARTIFACT_VERSION.split("-")[0]
 
 root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.getcwd())))
-os.rename(os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION_SHORT + '.tar.gz'), os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION + '-python.tgz'))
+if platform.system() == "Windows":
+    os.rename(os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION_SHORT + '.zip'), os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION + '-python.zip'))
+else:
+    os.rename(os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION_SHORT + '.tar.gz'), os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION + '-python.tgz'))


### PR DESCRIPTION
Added platform.system() check for renaming python artifact to prevent distribution build failure on Windows.