### PR TITLE
[SYSTEMML-1148] Explicitly set value types for MLContext scalar inputs

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
@@ -50,6 +50,7 @@ import org.apache.sysml.conf.CompilerConfig.ConfigType;
 import org.apache.sysml.conf.ConfigurationManager;
 import org.apache.sysml.conf.DMLConfig;
 import org.apache.sysml.parser.ParseException;
+import org.apache.sysml.parser.Statement;
 import org.apache.sysml.runtime.controlprogram.LocalVariableMap;
 import org.apache.sysml.runtime.controlprogram.caching.FrameObject;
 import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
@@ -307,12 +308,38 @@ public final class MLContextUtil {
 	}
 
 	/**
+	 * Obtain the SystemML scalar value type string equivalent of an accepted
+	 * basic type (Integer, Boolean, Double, String)
+	 * 
+	 * @param object
+	 *            the object type to be examined
+	 * @return a String representing the type as a SystemML scalar value type
+	 */
+	public static String getBasicTypeString(Object object) {
+		if (!isBasicType(object)) {
+			throw new MLContextException("Type (" + object.getClass() + ") not a recognized basic type");
+		}
+		Class<? extends Object> clazz = object.getClass();
+		if (clazz.equals(Integer.class)) {
+			return Statement.INT_VALUE_TYPE;
+		} else if (clazz.equals(Boolean.class)) {
+			return Statement.BOOLEAN_VALUE_TYPE;
+		} else if (clazz.equals(Double.class)) {
+			return Statement.DOUBLE_VALUE_TYPE;
+		} else if (clazz.equals(String.class)) {
+			return Statement.STRING_VALUE_TYPE;
+		} else {
+			return null;
+		}
+	}
+
+	/**
 	 * Is the object one of the supported complex data types? (JavaRDD, RDD,
 	 * DataFrame, BinaryBlockMatrix, Matrix, double[][], MatrixBlock, URL)
 	 * 
 	 * @param object
 	 *            the object type to be examined
-	 * @return {@code true} if type is a complexe data type; otherwise
+	 * @return {@code true} if type is a complex data type; otherwise
 	 *         {@code false}.
 	 */
 	public static boolean isComplexType(Object object) {

--- a/src/main/java/org/apache/sysml/api/mlcontext/Script.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/Script.java
@@ -506,7 +506,7 @@ public class Script {
 					String quotedString = MLContextUtil.quotedString((String) inValue);
 					sb.append(" = " + quotedString + ";\n");
 				} else if (MLContextUtil.isBasicType(inValue)) {
-					sb.append(" = read('', data_type='scalar');\n");
+					sb.append(" = read('', data_type='scalar', value_type='" + MLContextUtil.getBasicTypeString(inValue) + "');\n");
 				} else if (MLContextUtil.doesSymbolTableContainFrameObject(symbolTable, in)) {
 					sb.append(" = read('', data_type='frame');\n");
 				} else {
@@ -517,7 +517,7 @@ public class Script {
 					String quotedString = MLContextUtil.quotedString((String) inValue);
 					sb.append(" = " + quotedString + "\n");
 				} else if (MLContextUtil.isBasicType(inValue)) {
-					sb.append(" = load('', data_type='scalar')\n");
+					sb.append(" = load('', data_type='scalar', value_type='" + MLContextUtil.getBasicTypeString(inValue) + "')\n");
 				} else if (MLContextUtil.doesSymbolTableContainFrameObject(symbolTable, in)) {
 					sb.append(" = load('', data_type='frame')\n");
 				} else {

--- a/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
@@ -2264,6 +2264,78 @@ public class MLContextTest extends AutomatedTestBase {
 		ml.execute(script);
 	}
 
+	@Test
+	public void testDisplayBooleanNotDML() {
+		System.out.println("MLContextTest - display boolean 'not' DML");
+		String s = "print(!b);";
+		Script script = dml(s).in("b", true);
+		setExpectedStdOut("FALSE");
+		ml.execute(script);
+	}
+
+	@Test
+	public void testDisplayBooleanNotPYDML() {
+		System.out.println("MLContextTest - display boolean 'not' PYDML");
+		String s = "print(!b)";
+		Script script = pydml(s).in("b", true);
+		setExpectedStdOut("False");
+		ml.execute(script);
+	}
+
+	@Test
+	public void testDisplayIntegerAddDML() {
+		System.out.println("MLContextTest - display integer add DML");
+		String s = "print(i+j);";
+		Script script = dml(s).in("i", 5).in("j", 6);
+		setExpectedStdOut("11");
+		ml.execute(script);
+	}
+
+	@Test
+	public void testDisplayIntegerAddPYDML() {
+		System.out.println("MLContextTest - display integer add PYDML");
+		String s = "print(i+j)";
+		Script script = pydml(s).in("i", 5).in("j", 6);
+		setExpectedStdOut("11");
+		ml.execute(script);
+	}
+
+	@Test
+	public void testDisplayStringConcatenationDML() {
+		System.out.println("MLContextTest - display string concatenation DML");
+		String s = "print(str1+str2);";
+		Script script = dml(s).in("str1", "hello").in("str2", "goodbye");
+		setExpectedStdOut("hellogoodbye");
+		ml.execute(script);
+	}
+
+	@Test
+	public void testDisplayStringConcatenationPYDML() {
+		System.out.println("MLContextTest - display string concatenation PYDML");
+		String s = "print(str1+str2)";
+		Script script = pydml(s).in("str1", "hello").in("str2", "goodbye");
+		setExpectedStdOut("hellogoodbye");
+		ml.execute(script);
+	}
+
+	@Test
+	public void testDisplayDoubleAddDML() {
+		System.out.println("MLContextTest - display double add DML");
+		String s = "print(i+j);";
+		Script script = dml(s).in("i", 5.1).in("j", 6.2);
+		setExpectedStdOut("11.3");
+		ml.execute(script);
+	}
+
+	@Test
+	public void testDisplayDoubleAddPYDML() {
+		System.out.println("MLContextTest - display double add PYDML");
+		String s = "print(i+j)";
+		Script script = pydml(s).in("i", 5.1).in("j", 6.2);
+		setExpectedStdOut("11.3");
+		ml.execute(script);
+	}
+
 	// NOTE: Uncomment these tests once they work
 
 	// @SuppressWarnings({ "rawtypes", "unchecked" })


### PR DESCRIPTION
Not explicitly setting the scalar value type of a basic input type
through the MLContext API can cause issues since the value type can
default to double. For example, "print(!b)" where b is a boolean can
throw an error since the NOT operation can be performed on a boolean
but not a double.