### PR TITLE
[SYSTEMML-769] [SYSTEMML-1140] Disable sparse for Deep Learning related script

### DIFF
--- a/src/main/java/org/apache/sysml/parser/AParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/AParserWrapper.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.conf.ConfigurationManager;
 import org.apache.sysml.parser.common.CommonSyntacticValidator;
 import org.apache.sysml.parser.common.CustomErrorListener.ParseIssue;
@@ -59,6 +60,9 @@ public abstract class AParserWrapper
 	public static AParserWrapper createParser(boolean pydml)
 	{
 		AParserWrapper ret = null;
+		
+		// Always enable sparse before parsing phase (works for all the APIs).
+		DMLScript.DISABLE_SPARSE = false;
 		
 		//create the parser instance
 		if( pydml )

--- a/src/main/java/org/apache/sysml/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysml/parser/BuiltinFunctionExpression.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 
+import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.parser.LanguageException.LanguageErrorCodes;
 import org.apache.sysml.runtime.util.ConvolutionUtils;
 
@@ -1105,6 +1106,9 @@ public class BuiltinFunctionExpression extends DataIdentifier
 		
 		case BIAS_ADD:
 		{
+			// Disable sparse for Deep Learning related script at parsing phase.
+			DMLScript.DISABLE_SPARSE = true;
+						
 			Identifier input_id = getFirstExpr().getOutput();
 			Expression input = _args[0];
 			Expression bias = _args[1];
@@ -1123,6 +1127,9 @@ public class BuiltinFunctionExpression extends DataIdentifier
 		case AVG_POOL:
 		case MAX_POOL_BACKWARD:
 		{
+			// Disable sparse for Deep Learning related script at parsing phase.
+			DMLScript.DISABLE_SPARSE = true;
+			
 			// At DML level:
 			// output = conv2d(input, filter, input_shape=[1, 3, 2, 2], filter_shape=[1, 3, 2, 2], 
 			// strides=[1, 1], padding=[1,1])


### PR DESCRIPTION
@bertholdreinwald @mboehm7 @dusenberrymw @prithvirajsen This will disable sparse for convolutional neural network. The autoencoder will still have sparse enabled.