### PR TITLE
[SYSTEMML-1164] Fix IterablePredicate.toString NPE for incrementExpr

### DIFF
--- a/src/main/java/org/apache/sysml/parser/IterablePredicate.java
+++ b/src/main/java/org/apache/sysml/parser/IterablePredicate.java
@@ -56,8 +56,10 @@ public class IterablePredicate extends Expression
 		sb.append(_fromExpr.toString());
 		sb.append(",");
 		sb.append(_toExpr.toString());
-		sb.append(",");
-		sb.append(_incrementExpr.toString());
+		if (_incrementExpr != null) {
+			sb.append(",");
+			sb.append(_incrementExpr.toString());
+		}
 		sb.append( ")" );
 		if (_parforParams != null && _parforParams.size() > 0){
 			for (String key : _parforParams.keySet())


### PR DESCRIPTION
Add a null check for _incrementExpr to IterablePredicate's toString method,
since otherwise a NullPointerException can occur, such as when DMLProgram's
toString method is called, which can call IterablePredicate's toString.