### PR TITLE
[SYSTEMML-540] Added fused relu_maxpooling

### DIFF
--- a/src/main/java/org/apache/sysml/lops/ConvolutionTransform.java
+++ b/src/main/java/org/apache/sysml/lops/ConvolutionTransform.java
@@ -30,7 +30,7 @@ public class ConvolutionTransform extends Lop
 
 	
 	public enum OperationTypes {
-		MAX_POOLING, MAX_POOLING_BACKWARD,
+		MAX_POOLING, MAX_POOLING_BACKWARD, RELU_MAX_POOLING,
 		DIRECT_CONV2D, DIRECT_CONV2D_BACKWARD_FILTER, DIRECT_CONV2D_BACKWARD_DATA,
 		BIAS_ADD
 	};
@@ -98,6 +98,9 @@ public class ConvolutionTransform extends Lop
 				
 		case MAX_POOLING:
 			return "maxpooling";
+			
+		case RELU_MAX_POOLING:
+			return "relu_maxpooling";
 			
 		case MAX_POOLING_BACKWARD:
 			return "maxpooling_backward";

--- a/src/main/java/org/apache/sysml/runtime/instructions/CPInstructionParser.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/CPInstructionParser.java
@@ -218,6 +218,7 @@ public class CPInstructionParser extends InstructionParser
 		String2CPInstructionType.put( "rsort"      , CPINSTRUCTION_TYPE.Reorg);
 
 		// Opcodes related to convolutions
+		String2CPInstructionType.put( "relu_maxpooling"      , CPINSTRUCTION_TYPE.Convolution);
 		String2CPInstructionType.put( "maxpooling"      , CPINSTRUCTION_TYPE.Convolution);
 		String2CPInstructionType.put( "maxpooling_backward"      , CPINSTRUCTION_TYPE.Convolution);
 		String2CPInstructionType.put( "conv2d"      , CPINSTRUCTION_TYPE.Convolution);

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ConvolutionCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ConvolutionCPInstruction.java
@@ -20,6 +20,7 @@
 package org.apache.sysml.runtime.instructions.cp;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.apache.sysml.parser.Expression.DataType;
 import org.apache.sysml.parser.Expression.ValueType;
@@ -89,7 +90,7 @@ public class ConvolutionCPInstruction extends UnaryCPInstruction {
 
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
 		String opcode = parts[0];
-		if (opcode.equalsIgnoreCase("maxpooling")) {
+		if (opcode.equalsIgnoreCase("maxpooling") || opcode.equalsIgnoreCase("relu_maxpooling")) {
 			InstructionUtils.checkNumFields(parts, 15);
 			// stride1, stride2, padding1, padding2
 			// input_shape1, input_shape2, input_shape3, input_shape4,
@@ -231,12 +232,14 @@ public class ConvolutionCPInstruction extends UnaryCPInstruction {
 		int Q = (int) ConvolutionUtils.getQ(W, S, stride_w, pad_w);
 		
 		ConvolutionParameters params = new ConvolutionParameters(N, C, H, W, K, R, S, stride_h, stride_w, pad_h, pad_w, _numThreads);
-		if (instOpcode.equalsIgnoreCase("maxpooling")) {
+		if (instOpcode.equalsIgnoreCase("maxpooling") || instOpcode.equalsIgnoreCase("relu_maxpooling")) {
 			if(matBlock.isEmptyBlock()) {
 				outputBlock = new MatrixBlock(N, C*P*Q, true, 0);
 			}
 			else {
 				outputBlock = getDenseOutputBlock(ec, N, C*P*Q);
+				if(instOpcode.equalsIgnoreCase("maxpooling"))
+					Arrays.fill(outputBlock.getDenseBlock(), -Double.MAX_VALUE);
 				LibMatrixDNN.maxpooling(matBlock, outputBlock, params);
 			}
 		}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/ConvolutionParameters.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/ConvolutionParameters.java
@@ -19,8 +19,6 @@
 
 package org.apache.sysml.runtime.matrix.data;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.util.ConvolutionUtils;
 
@@ -33,9 +31,10 @@ public class ConvolutionParameters {
 	public int K; public int R; public int S; public int stride_h; public int stride_w; public int pad_h; public int pad_w;
 	public int P; public int Q; public int numThreads;
 	
-	public AtomicLong outputNNZ = new AtomicLong(-1);
 	
 	MatrixBlock input1; MatrixBlock input2; MatrixBlock output;
+	
+	public int [] start_indexes_h, end_indexes_h, start_indexes_w, end_indexes_w; 
 	
 	private int convertToInt(long val) throws DMLRuntimeException {
 		if( val > Integer.MAX_VALUE ) {


### PR DESCRIPTION
- Fused relu_maxpooling reduces the unnecessary dense-to-sparse-to-dense conversion.
- Note: fused relu_maxpooling is only supported in CP, not on GPU as both relu and maxpooling invoke CuDNN functions.
- Also, improve the performance of maxpooling by computing indexes apriori.

@mboehm7 @bertholdreinwald @dusenberrymw 