### PR TITLE
[SYSTEMML-1171] Clean Up Python Distribution

### DIFF
--- a/src/main/python/MANIFEST.in
+++ b/src/main/python/MANIFEST.in
@@ -21,8 +21,4 @@
 include LICENSE
 include NOTICE
 include DISCLAIMER
-include systemml/systemml-java/scripts/sparkDML.sh
 recursive-include systemml/systemml-java *
-recursive-include systemml/systemml-java/scripts/algorithms *
-recursive-include systemml/systemml-java/scripts/datagen *
-recursive-include systemml/systemml-java/scripts/utils *

--- a/src/main/python/post_setup.py
+++ b/src/main/python/post_setup.py
@@ -35,6 +35,10 @@ ARTIFACT_VERSION_SHORT = ARTIFACT_VERSION.split("-")[0]
 
 root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.getcwd())))
 if platform.system() == "Windows":
-    os.rename(os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION_SHORT + '.zip'), os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION + '-python.zip'))
+    os.rename(
+        os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION_SHORT + '.zip'),
+        os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION + '-python.zip'))
 else:
-    os.rename(os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION_SHORT + '.tar.gz'), os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION + '-python.tgz'))
+    os.rename(
+        os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION_SHORT + '.tar.gz'),
+        os.path.join(root_dir, 'target', ARTIFACT_NAME + '-' + ARTIFACT_VERSION + '-python.tgz'))

--- a/src/main/python/pre_setup.py
+++ b/src/main/python/pre_setup.py
@@ -19,7 +19,8 @@
 #
 #-------------------------------------------------------------
 
-import os, shutil
+import os
+import shutil
 import fnmatch
 python_dir = 'systemml'
 java_dir='systemml-java'
@@ -30,5 +31,5 @@ os.mkdir(java_dir_full_path)
 root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.getcwd())))
 for file in os.listdir(os.path.join(root_dir, 'target')):
     if fnmatch.fnmatch(file, 'systemml-*-incubating-SNAPSHOT.jar'):
-        shutil.copyfile(os.path.join(root_dir, 'target', file), os.path.join(java_dir_full_path, file))
-shutil.copytree(os.path.join(root_dir, 'scripts'), os.path.join(java_dir_full_path, 'scripts'))
+        shutil.copyfile(os.path.join(root_dir, 'target', file),
+                        os.path.join(java_dir_full_path, file))

--- a/src/main/python/setup.py
+++ b/src/main/python/setup.py
@@ -51,7 +51,9 @@ PACKAGE_DATA = []
 for path, subdirs, files in os.walk(java_dir_full_path):
     for name in files:
         PACKAGE_DATA = PACKAGE_DATA + [ os.path.join(path, name).replace('./', '') ]
-PACKAGE_DATA = PACKAGE_DATA + [os.path.join(python_dir, 'LICENSE'), os.path.join(python_dir, 'DISCLAIMER'), os.path.join(python_dir, 'NOTICE')]
+PACKAGE_DATA = PACKAGE_DATA + [os.path.join(python_dir, 'LICENSE'),
+                               os.path.join(python_dir, 'DISCLAIMER'),
+                               os.path.join(python_dir, 'NOTICE')]
 
 setup(
     name=ARTIFACT_NAME,
@@ -59,14 +61,16 @@ setup(
     description='Apache SystemML is a distributed and declarative machine learning platform.',
     long_description='''
 
-    Apache SystemML is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+    Apache SystemML is an effort undergoing incubation at the Apache Software Foundation (ASF),
+    sponsored by the Apache Incubator PMC.
     While incubation status is not necessarily a reflection of the completeness
     or stability of the code, it does indicate that the project has yet to be
     fully endorsed by the ASF.
 
     Apache SystemML provides declarative large-scale machine learning (ML) that aims at
     flexible specification of ML algorithms and automatic generation of hybrid runtime
-    plans ranging from single-node, in-memory computations, to distributed computations on Apache Hadoop and Apache Spark.
+    plans ranging from single-node, in-memory computations, to distributed computations on Apache
+    Hadoop and Apache Spark.
     ''',
     url='http://systemml.apache.org/',
     author='Apache SystemML',


### PR DESCRIPTION
This cleans up the Python distribution package by removing the `scripts` folder
that is included, as it is not used by internal code, will be confusing
to users, and will cause confusion during release reviews.

Also includes some minor code formatting improvements.