### PR TITLE
[SYSTEMML-540] Improved dropout performance

### DIFF
--- a/scripts/staging/SystemML-NN/nn/layers/dropout.dml
+++ b/scripts/staging/SystemML-NN/nn/layers/dropout.dml
@@ -49,7 +49,6 @@ forward = function(matrix[double] X, double p, int seed)
   else {
     mask = rand(rows=nrow(X), cols=ncol(X), min=1, max=1, sparsity=0.5, seed=seed)
   }
-  mask = rand(rows=nrow(X), cols=ncol(X), min=0, max=1, seed=seed) <= p
   out = X * mask / p
 }
 

--- a/scripts/staging/SystemML-NN/nn/layers/dropout.dml
+++ b/scripts/staging/SystemML-NN/nn/layers/dropout.dml
@@ -42,12 +42,12 @@ forward = function(matrix[double] X, double p, int seed)
    *  - out: Ouptuts, of same shape as X.
    *  - mask: Dropout mask used to compute the output.
    */
-  # TODO: Replace 0.5 by p when DataOp is supported for rand.
-  if (seed == -1) {
+  if (seed == -1 & p == 0.5) {
     mask = rand(rows=nrow(X), cols=ncol(X), min=1, max=1, sparsity=0.5)
   }
   else {
-    mask = rand(rows=nrow(X), cols=ncol(X), min=1, max=1, sparsity=0.5, seed=seed)
+    seed = as.integer(floor(as.scalar(rand(rows=1, cols=1, min=1, max=100000))))
+    mask = rand(rows=nrow(X), cols=ncol(X), min=0, max=1, seed=seed) <= p 
   }
   out = X * mask / p
 }

--- a/scripts/staging/SystemML-NN/nn/layers/dropout.dml
+++ b/scripts/staging/SystemML-NN/nn/layers/dropout.dml
@@ -42,8 +42,12 @@ forward = function(matrix[double] X, double p, int seed)
    *  - out: Ouptuts, of same shape as X.
    *  - mask: Dropout mask used to compute the output.
    */
+  # TODO: Replace 0.5 by p when DataOp is supported for rand.
   if (seed == -1) {
-    seed = as.integer(floor(as.scalar(rand(rows=1, cols=1, min=1, max=100000))))
+    mask = rand(rows=nrow(X), cols=ncol(X), min=1, max=1, sparsity=0.5)
+  }
+  else {
+    mask = rand(rows=nrow(X), cols=ncol(X), min=1, max=1, sparsity=0.5, seed=seed)
   }
   mask = rand(rows=nrow(X), cols=ncol(X), min=0, max=1, seed=seed) <= p
   out = X * mask / p


### PR DESCRIPTION
The modified script avoids unnecessary dense intermediate and is especially useful in case of low p value

@dusenberrymw can you please review ? We can either fix the rand bug as part of this PR or in separate PR.