### PR TITLE
[SYSTEMML-1173] Improve StringIdentifier and DataExpression toString

### DIFF
--- a/src/main/java/org/apache/sysml/parser/DataExpression.java
+++ b/src/main/java/org/apache/sysml/parser/DataExpression.java
@@ -1767,15 +1767,20 @@ public class DataExpression extends DataIdentifier
 		sb.append(_opcode.toString());
 		sb.append("(");
 
+		boolean first = true;
 		for(Entry<String,Expression> e : _varParams.entrySet()) {
 			String key = e.getKey();
 			Expression expr = e.getValue();
-			sb.append(",");
+			if (!first) {
+				sb.append(", ");
+			} else {
+				first = false;
+			}
 			sb.append(key);
 			sb.append("=");
 			sb.append(expr);
 		}
-		sb.append(" )");
+		sb.append(")");
 		return sb.toString();
 	}
 

--- a/src/main/java/org/apache/sysml/parser/PrintStatement.java
+++ b/src/main/java/org/apache/sysml/parser/PrintStatement.java
@@ -95,7 +95,7 @@ public class PrintStatement extends Statement
 	
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append(_type + " (");
+		sb.append(_type + "(");
 		if ((_type == PRINTTYPE.PRINT) || (_type == PRINTTYPE.STOP)) {
 			sb.append(expressions.get(0).toString());
 		} else if (_type == PRINTTYPE.PRINTF) {

--- a/src/main/java/org/apache/sysml/parser/StringIdentifier.java
+++ b/src/main/java/org/apache/sysml/parser/StringIdentifier.java
@@ -46,7 +46,7 @@ public class StringIdentifier extends ConstIdentifier
 	}
 	
 	public String toString(){
-		return _val;
+		return "'" + _val + "'";
 	}
 	
 	@Override


### PR DESCRIPTION
For readability, surround StringIdentifier toString output with single quotes. Remove
extraneous first comma when outputting DataExpression. Remove extraneous space from
PrintStatement.