### PR TITLE
[SYSTEMML-1173] Readability of StringIdentifier and DataExpression toString

### DIFF
--- a/src/main/java/org/apache/sysml/parser/AssignmentStatement.java
+++ b/src/main/java/org/apache/sysml/parser/AssignmentStatement.java
@@ -131,7 +131,13 @@ public class AssignmentStatement extends Statement
 			sb.append(_targetList.get(i).toString());
 		}
 		sb.append(" = ");
-		sb.append(_source.toString());
+		if (_source instanceof StringIdentifier) {
+			sb.append("\"");
+			sb.append(_source.toString());
+			sb.append("\"");
+		} else {
+			sb.append(_source.toString());
+		}
 		sb.append(";");
 		
 		return sb.toString();

--- a/src/main/java/org/apache/sysml/parser/BinaryExpression.java
+++ b/src/main/java/org/apache/sysml/parser/BinaryExpression.java
@@ -197,9 +197,20 @@ public class BinaryExpression extends Expression
 	}
 	
 	public String toString() {
-
-		return "(" + _left.toString() + " " + _opcode.toString() + " "
-				+ _right.toString() + ")";
+		String leftString;
+		String rightString;
+		if (_left instanceof StringIdentifier) {
+			leftString = "\"" + _left.toString() + "\"";
+		} else {
+			leftString = _left.toString();
+		}
+		if (_right instanceof StringIdentifier) {
+			rightString = "\"" + _right.toString() + "\"";
+		} else {
+			rightString = _right.toString();
+		}
+		return "(" + leftString + " " + _opcode.toString() + " "
+				+ rightString + ")";
 
 	}
 

--- a/src/main/java/org/apache/sysml/parser/DataExpression.java
+++ b/src/main/java/org/apache/sysml/parser/DataExpression.java
@@ -1767,15 +1767,26 @@ public class DataExpression extends DataIdentifier
 		sb.append(_opcode.toString());
 		sb.append("(");
 
+		boolean first = true;
 		for(Entry<String,Expression> e : _varParams.entrySet()) {
 			String key = e.getKey();
 			Expression expr = e.getValue();
-			sb.append(",");
+			if (!first) {
+				sb.append(", ");
+			} else {
+				first = false;
+			}
 			sb.append(key);
 			sb.append("=");
-			sb.append(expr);
+			if (expr instanceof StringIdentifier) {
+				sb.append("\"");
+				sb.append(expr);
+				sb.append("\"");
+			} else {
+				sb.append(expr);
+			}
 		}
-		sb.append(" )");
+		sb.append(")");
 		return sb.toString();
 	}
 

--- a/src/main/java/org/apache/sysml/parser/PrintStatement.java
+++ b/src/main/java/org/apache/sysml/parser/PrintStatement.java
@@ -95,16 +95,29 @@ public class PrintStatement extends Statement
 	
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append(_type + " (");
+		sb.append(_type + "(");
 		if ((_type == PRINTTYPE.PRINT) || (_type == PRINTTYPE.STOP)) {
-			sb.append(expressions.get(0).toString());
+			Expression expression = expressions.get(0);
+			if (expression instanceof StringIdentifier) {
+				sb.append("\"");
+				sb.append(expression.toString());
+				sb.append("\"");
+			} else {
+				sb.append(expression.toString());
+			}
 		} else if (_type == PRINTTYPE.PRINTF) {
 			for (int i = 0; i < expressions.size(); i++) {
 				if (i > 0) {
 					sb.append(", ");
 				}
 				Expression expression = expressions.get(i);
-				sb.append(expression.toString());
+				if (expression instanceof StringIdentifier) {
+					sb.append("\"");
+					sb.append(expression.toString());
+					sb.append("\"");
+				} else {
+					sb.append(expression.toString());
+				}
 			}
 		}
 

--- a/src/main/java/org/apache/sysml/parser/RelationalExpression.java
+++ b/src/main/java/org/apache/sysml/parser/RelationalExpression.java
@@ -198,11 +198,24 @@ public class RelationalExpression extends Expression
 			}
 		}
 	}
-	
-	
+
 	public String toString(){
-		return "(" + _left.toString() + " " + _opcode.toString() + " " + _right.toString() + ")";
+		String leftString;
+		String rightString;
+		if (_left instanceof StringIdentifier) {
+			leftString = "\"" + _left.toString() + "\"";
+		} else {
+			leftString = _left.toString();
+		}
+		if (_right instanceof StringIdentifier) {
+			rightString = "\"" + _right.toString() + "\"";
+		} else {
+			rightString = _right.toString();
+		}
+		return "(" + leftString + " " + _opcode.toString() + " "
+				+ rightString + ")";
 	}
+
 	@Override
 	public VariableSet variablesRead() {
 		VariableSet result = new VariableSet();


### PR DESCRIPTION
Surround relevant StringIdentifier toString calls with quotes. Remove extraneous
first comma when outputting DataExpression. Remove extraneous space from
PrintStatement.