### PR TITLE
[SYSTEMML-1186] adding python3 style div of scalar by matrix

### DIFF
--- a/src/main/python/systemml/defmatrix.py
+++ b/src/main/python/systemml/defmatrix.py
@@ -894,6 +894,12 @@ class matrix(object):
         """
         return binary_op(self, other, ' / ')
 
+    def __rtruediv__(self, other):
+        """
+        Performs division (Python 3 way).
+        """
+        return binary_op(other, self, ' / ')
+
     def __mod__(self, other):
         return binary_op(self, other, ' % ')
 

--- a/src/main/python/systemml/defmatrix.py
+++ b/src/main/python/systemml/defmatrix.py
@@ -894,12 +894,6 @@ class matrix(object):
         """
         return binary_op(self, other, ' / ')
 
-    def __rtruediv__(self, other):
-        """
-        Performs division (Python 3 way).
-        """
-        return binary_op(other, self, ' / ')
-
     def __mod__(self, other):
         return binary_op(self, other, ' % ')
 
@@ -919,6 +913,12 @@ class matrix(object):
         return binary_op(other, self, ' // ')
 
     def __rdiv__(self, other):
+        return binary_op(other, self, ' / ')
+
+    def __rtruediv__(self, other):
+        """
+        Performs division (Python 3 way).
+        """
         return binary_op(other, self, ' / ')
 
     def __rmod__(self, other):


### PR DESCRIPTION
Related Jira
https://issues.apache.org/jira/browse/SYSTEMML-1186?jql=project%20%3D%20SYSTEMML

This PR fixes the failing test for division of scalar by matrix in python3.
