### PR TITLE
Allow Scala UDF to be passed to SystemML via external UDF mechanism

### DIFF
--- a/docs/spark-mlcontext-programming-guide.md
+++ b/docs/spark-mlcontext-programming-guide.md
@@ -1636,6 +1636,45 @@ scala> for (i <- 1 to 5) {
 
 </div>
 
+## Passing Scala UDF to SystemML
+
+SystemML allows the users to pass a Scala UDF (with input/output types supported by SystemML)
+to the DML script via MLContext. The restrictions for the supported Scala UDFs are as follows:
+
+1. Only types specified by DML language is supported for parameters and return types (i.e. Int, Double, Boolean, String, double[][]).
+2. At minimum, the function should have 1 argument and 1 return value.
+3. At max, the function can have 10 arguments and 10 return values. 
+
+{% highlight scala %}
+import org.apache.sysml.api.mlcontext._
+import org.apache.sysml.api.mlcontext.ScriptFactory._
+val ml = new MLContext(sc)
+
+// Demonstrates how to pass a simple scala UDF to SystemML
+def addOne(x:Double):Double = x + 1
+ml.udf.register("addOne", addOne)
+val script1 = dml("v = addOne(2.0); print(v)")
+ml.execute(script1)
+
+// Demonstrates operation on local matrices (double[][])
+def addOneToDiagonal(x:Array[Array[Double]]):Array[Array[Double]] = {  for(i <- 0 to x.length-1) x(i)(i) = x(i)(i) + 1; x }
+ml.udf.register("addOneToDiagonal", addOneToDiagonal)
+val script2 = dml("m1 = matrix(0, rows=3, cols=3); m2 = addOneToDiagonal(m1); print(toString(m2));")
+ml.execute(script2)
+
+// Demonstrates multi-return function
+def multiReturnFn(x:Double):(Double, Int) = (x + 1, (x * 2).toInt)
+ml.udf.register("multiReturnFn", multiReturnFn)
+val script3 = dml("[v1, v2] = multiReturnFn(2.0); print(v1)")
+ml.execute(script3)
+
+// Demonstrates multi-argument multi-return function
+def multiArgReturnFn(x:Double, y:Int):(Double, Int) = (x + 1, (x * y).toInt)
+ml.udf.register("multiArgReturnFn", multiArgReturnFn _)
+val script4 = dml("[v1, v2] = multiArgReturnFn(2.0, 1); print(v2)")
+ml.execute(script4)
+{% endhighlight %}
+
 ---
 
 # Jupyter (PySpark) Notebook Example - Poisson Nonnegative Matrix Factorization

--- a/docs/spark-mlcontext-programming-guide.md
+++ b/docs/spark-mlcontext-programming-guide.md
@@ -1652,19 +1652,19 @@ val ml = new MLContext(sc)
 
 // Demonstrates how to pass a simple scala UDF to SystemML
 def addOne(x:Double):Double = x + 1
-ml.udf.register("addOne", addOne)
+ml.udf.register("addOne", addOne _)
 val script1 = dml("v = addOne(2.0); print(v)")
 ml.execute(script1)
 
 // Demonstrates operation on local matrices (double[][])
 def addOneToDiagonal(x:Array[Array[Double]]):Array[Array[Double]] = {  for(i <- 0 to x.length-1) x(i)(i) = x(i)(i) + 1; x }
-ml.udf.register("addOneToDiagonal", addOneToDiagonal)
+ml.udf.register("addOneToDiagonal", addOneToDiagonal _)
 val script2 = dml("m1 = matrix(0, rows=3, cols=3); m2 = addOneToDiagonal(m1); print(toString(m2));")
 ml.execute(script2)
 
 // Demonstrates multi-return function
 def multiReturnFn(x:Double):(Double, Int) = (x + 1, (x * 2).toInt)
-ml.udf.register("multiReturnFn", multiReturnFn)
+ml.udf.register("multiReturnFn", multiReturnFn _)
 val script3 = dml("[v1, v2] = multiReturnFn(2.0); print(v1)")
 ml.execute(script3)
 

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
@@ -122,6 +122,7 @@ public class MLContext {
 	
 	/**
 	 * Allows users to register external scala UDFs.
+	 * The design is explained in ExternalUDFRegistration.scala.
 	 */
 	public ExternalUDFRegistration udf = null;
 

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
@@ -298,7 +298,6 @@ public class MLContext {
 	 */
 	public MLResults execute(Script script, ScriptExecutor scriptExecutor) {
 		try {
-			udf.addHeaders(script);
 			executingScript = script;
 
 			Long time = new Long((new Date()).getTime());
@@ -306,6 +305,7 @@ public class MLContext {
 				script.setName(time.toString());
 			}
 
+			scriptExecutor.udf = udf;
 			MLResults results = scriptExecutor.execute(script);
 
 			String history = MLContextUtil.createHistoryForScript(script, time);

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
@@ -123,7 +123,7 @@ public class MLContext {
 	/**
 	 * Allows users to register external scala UDFs.
 	 */
-	private ExternalUDFRegistration udf = null;
+	public ExternalUDFRegistration udf = null;
 
 	/**
 	 * The different explain levels supported by SystemML.

--- a/src/main/java/org/apache/sysml/api/mlcontext/ScriptExecutor.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/ScriptExecutor.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sysml.api.DMLScript;
+import org.apache.sysml.api.ExternalUDFRegistration;
 import org.apache.sysml.api.jmlc.JMLCUtils;
 import org.apache.sysml.api.mlcontext.MLContext.ExplainLevel;
 import org.apache.sysml.api.monitoring.SparkMonitoringUtil;
@@ -119,6 +120,7 @@ public class ScriptExecutor {
 	protected boolean statistics = false;
 	protected ExplainLevel explainLevel;
 	protected int statisticsMaxHeavyHitters = 10;
+	public ExternalUDFRegistration udf;
 
 	/**
 	 * ScriptExecutor constructor.
@@ -450,6 +452,12 @@ public class ScriptExecutor {
 					inputParameters, script.getScriptType());
 
 			String scriptExecutionString = script.getScriptExecutionString();
+			if(udf != null) {
+				// Append the headers from Scala UDF.
+				String externalHeaders = udf.getExternalHeaders();
+				if(!externalHeaders.equals(""))
+					scriptExecutionString = externalHeaders + scriptExecutionString;
+			}
 			dmlProgram = parser.parse(null, scriptExecutionString, inputParametersStringMaps);
 		} catch (ParseException e) {
 			throw new MLContextException("Exception occurred while parsing script", e);

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ExternalFunctionProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ExternalFunctionProgramBlock.java
@@ -601,6 +601,11 @@ public class ExternalFunctionProgramBlock extends FunctionProgramBlock
 		func.setConfiguration(configFile);
 		func.setBaseDir(_baseDir);
 		
+		if(className.equals("org.apache.sysml.udf.lib.GenericFunction")) {
+			((org.apache.sysml.udf.lib.GenericFunction)func)._functionName = this._functionName;
+			((org.apache.sysml.udf.lib.GenericFunction)func)._namespace = this._namespace;
+		}
+		
 		//executes function
 		func.execute();
 		

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ExternalFunctionProgramBlockCP.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ExternalFunctionProgramBlockCP.java
@@ -100,6 +100,8 @@ public class ExternalFunctionProgramBlockCP extends ExternalFunctionProgramBlock
 		{
 			try {
 				inst = (ExternalFunctionInvocationInstruction)_inst.get(i);
+				inst._namespace = _namespace;
+				inst._functionName = _functionName;
 				executeInstruction( ec, inst );
 			}
 			catch (Exception e){

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/FunctionProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/FunctionProgramBlock.java
@@ -34,7 +34,8 @@ import org.apache.sysml.utils.Statistics;
 
 public class FunctionProgramBlock extends ProgramBlock 
 {
-	
+	public String _functionName;
+	public String _namespace;
 	protected ArrayList<ProgramBlock> _childBlocks;
 	protected ArrayList<DataIdentifier> _inputParams;
 	protected ArrayList<DataIdentifier> _outputParams;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/FunctionCallCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/FunctionCallCPInstruction.java
@@ -167,6 +167,8 @@ public class FunctionCallCPInstruction extends CPInstruction
 		
 		// execute the function block
 		try {
+			fpb._functionName = this._functionName;
+			fpb._namespace = this._namespace;
 			fpb.execute(fn_ec);
 		}
 		catch (DMLScriptException e) {

--- a/src/main/java/org/apache/sysml/udf/ExternalFunctionInvocationInstruction.java
+++ b/src/main/java/org/apache/sysml/udf/ExternalFunctionInvocationInstruction.java
@@ -34,6 +34,8 @@ public class ExternalFunctionInvocationInstruction extends Instruction
 	
 	public static final String ELEMENT_DELIM = ":";
 	
+	public String _namespace;
+	public String _functionName;
 	protected String className; // name of class that contains the function
 	protected String configFile; // optional configuration file parameter
 	protected String inputParams; // string representation of input parameters

--- a/src/main/java/org/apache/sysml/udf/lib/GenericFunction.java
+++ b/src/main/java/org/apache/sysml/udf/lib/GenericFunction.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.sysml.udf.lib;
 
 import java.io.IOException;

--- a/src/main/java/org/apache/sysml/udf/lib/GenericFunction.java
+++ b/src/main/java/org/apache/sysml/udf/lib/GenericFunction.java
@@ -1,31 +1,42 @@
 package org.apache.sysml.udf.lib;
 
 import java.io.IOException;
-import java.util.ArrayList;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.sysml.api.ExternalUDFRegistration;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.udf.FunctionParameter;
 import org.apache.sysml.udf.Matrix;
 import org.apache.sysml.udf.PackageFunction;
 import org.apache.sysml.udf.Scalar;
+
 import scala.Function0;
 
 public class GenericFunction extends PackageFunction {
 	private static final long serialVersionUID = -195996547505886575L;
 	String [] fnSignature;
 	FunctionParameter [] returnVals;
-	Function0<FunctionParameter []> scalaUDF; 
+	Function0<FunctionParameter []> scalaUDF;
+	public String _functionName;
+	public String _namespace;
 	
-	public GenericFunction(String [] fnSignature) {
-		this.fnSignature = fnSignature;
-	}
-	public void setScalaUDF(Function0<FunctionParameter []> scalaUDF) {
-		this.scalaUDF = scalaUDF;
+	public void initialize() {
+		if(_namespace != null && !_namespace.equals(".defaultNS")) {
+			throw new RuntimeException("Expected the function in default namespace");
+		}
+		if(_functionName == null) {
+			throw new RuntimeException("Expected the function name to be set");
+		}
+		if(fnSignature == null) {
+			fnSignature = ExternalUDFRegistration.fnSignatureMapping().get(_functionName);
+			scalaUDF = ExternalUDFRegistration.fnMapping().get(_functionName);
+			ExternalUDFRegistration.udfMapping().put(_functionName, this);
+		}
 	}
 	
 	@Override
 	public int getNumFunctionOutputs() {
+		initialize();
 		String retSignature = fnSignature[fnSignature.length -1];
 		if(!retSignature.startsWith("("))
 			return 1;
@@ -36,6 +47,7 @@ public class GenericFunction extends PackageFunction {
 
 	@Override
 	public FunctionParameter getFunctionOutput(int pos) {
+		initialize();
 		if(returnVals == null || returnVals.length <= pos)
 			throw new RuntimeException("Incorrect number of outputs or function not executed");
 		return returnVals[pos];
@@ -43,21 +55,9 @@ public class GenericFunction extends PackageFunction {
 
 	@Override
 	public void execute() {
+		initialize();
 		returnVals = scalaUDF.apply();
 	}
-	
-//	public Object constructOutput(Object ret) throws DMLRuntimeException, IOException {
-//		if(ret instanceof Integer)
-//			return new Scalar(ScalarValueType.Integer, String.valueOf(ret));
-//		else if(ret instanceof Double)
-//			return new Scalar(ScalarValueType.Double, String.valueOf(ret));
-//		else if(ret instanceof String)
-//			return new Scalar(ScalarValueType.Text, String.valueOf(ret));
-//		else if(ret instanceof Boolean)
-//			return new Scalar(ScalarValueType.Boolean, String.valueOf(ret));
-//		else if(ret instanceof Boolean)
-//			
-//	}
 	
 	public Object getInput(String type, int pos) throws DMLRuntimeException, IOException {
 		if(type.equals("Int") || type.equals("java.lang.Integer")) {

--- a/src/main/java/org/apache/sysml/udf/lib/GenericFunction.java
+++ b/src/main/java/org/apache/sysml/udf/lib/GenericFunction.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.sysml.api.ExternalUDFRegistration;
+import org.apache.sysml.parser.DMLProgram;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.udf.FunctionParameter;
 import org.apache.sysml.udf.Matrix;
@@ -40,7 +41,7 @@ public class GenericFunction extends PackageFunction {
 	public String _namespace;
 	
 	public void initialize() {
-		if(_namespace != null && !_namespace.equals(".defaultNS")) {
+		if(_namespace != null && !_namespace.equals(DMLProgram.DEFAULT_NAMESPACE)) {
 			throw new RuntimeException("Expected the function in default namespace");
 		}
 		if(_functionName == null) {

--- a/src/main/java/org/apache/sysml/udf/lib/GenericFunction.java
+++ b/src/main/java/org/apache/sysml/udf/lib/GenericFunction.java
@@ -1,0 +1,82 @@
+package org.apache.sysml.udf.lib;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.sysml.runtime.DMLRuntimeException;
+import org.apache.sysml.udf.FunctionParameter;
+import org.apache.sysml.udf.Matrix;
+import org.apache.sysml.udf.PackageFunction;
+import org.apache.sysml.udf.Scalar;
+import scala.Function0;
+
+public class GenericFunction extends PackageFunction {
+	private static final long serialVersionUID = -195996547505886575L;
+	String [] fnSignature;
+	FunctionParameter [] returnVals;
+	Function0<FunctionParameter []> scalaUDF; 
+	
+	public GenericFunction(String [] fnSignature) {
+		this.fnSignature = fnSignature;
+	}
+	public void setScalaUDF(Function0<FunctionParameter []> scalaUDF) {
+		this.scalaUDF = scalaUDF;
+	}
+	
+	@Override
+	public int getNumFunctionOutputs() {
+		String retSignature = fnSignature[fnSignature.length -1];
+		if(!retSignature.startsWith("("))
+			return 1;
+		else {
+			return StringUtils.countMatches(retSignature, ",") + 1;
+		}
+	}
+
+	@Override
+	public FunctionParameter getFunctionOutput(int pos) {
+		if(returnVals == null || returnVals.length <= pos)
+			throw new RuntimeException("Incorrect number of outputs or function not executed");
+		return returnVals[pos];
+	}
+
+	@Override
+	public void execute() {
+		returnVals = scalaUDF.apply();
+	}
+	
+//	public Object constructOutput(Object ret) throws DMLRuntimeException, IOException {
+//		if(ret instanceof Integer)
+//			return new Scalar(ScalarValueType.Integer, String.valueOf(ret));
+//		else if(ret instanceof Double)
+//			return new Scalar(ScalarValueType.Double, String.valueOf(ret));
+//		else if(ret instanceof String)
+//			return new Scalar(ScalarValueType.Text, String.valueOf(ret));
+//		else if(ret instanceof Boolean)
+//			return new Scalar(ScalarValueType.Boolean, String.valueOf(ret));
+//		else if(ret instanceof Boolean)
+//			
+//	}
+	
+	public Object getInput(String type, int pos) throws DMLRuntimeException, IOException {
+		if(type.equals("Int") || type.equals("java.lang.Integer")) {
+			return Integer.parseInt(((Scalar)getFunctionInput(pos)).getValue());
+		}
+		else if(type.equals("Double") || type.equals("java.lang.Double")) {
+			return Double.parseDouble(((Scalar)getFunctionInput(pos)).getValue());
+		}
+		else if(type.equals("java.lang.String")) {
+			return ((Scalar)getFunctionInput(pos)).getValue();
+		}
+		else if(type.equals("boolean") || type.equals("java.lang.Boolean")) {
+			return Boolean.parseBoolean(((Scalar)getFunctionInput(pos)).getValue());
+		}
+		else if(type.equals("scala.Array[scala.Array[Double]]")) {
+			return ((Matrix) getFunctionInput(pos)).getMatrixAsDoubleArray();
+		}
+		
+		throw new RuntimeException("Unsupported type: " + type);
+	}
+
+}

--- a/src/main/scala/org/apache/sysml/api/ExternalUDFRegistration.scala
+++ b/src/main/scala/org/apache/sysml/api/ExternalUDFRegistration.scala
@@ -50,7 +50,8 @@ class ExternalUDFRegistration {
     val header = scriptHeader.toString() 
     if(!header.equals("")) {
 			script.setScriptString(scriptHeader + "\n" + script.getScriptString());
-			System.out.println(script.getScriptString)
+			// Useful for debugging:
+			// System.out.println(script.getScriptString)
     }
   }
   

--- a/src/main/scala/org/apache/sysml/api/ExternalUDFRegistration.scala
+++ b/src/main/scala/org/apache/sysml/api/ExternalUDFRegistration.scala
@@ -67,7 +67,33 @@ class ExternalUDFRegistration {
       case _ => throw new RuntimeException("Unsupported type of parameter: " + t)
     }
   }
-   
+  
+  def getReturnType(t: String):String = {
+    if(t.startsWith("(")) {
+      val t1 = t.substring(1, t.length()-1).split(",").map(_.trim)
+      val ret = new StringBuilder
+      for(i <- 0 until t1.length) {
+        if(i != 0) ret.append(", ")
+        ret.append(getType(t1(i)) + " output" + i)
+      }
+      ret.toString
+    }
+    else
+      getType(t) + " output0"
+  }
+  
+  def appendHead(name:String): Unit = {
+    scriptHeader.append(name + " = externalFunction(")
+  }
+  def appendTail(typeRet:String): Unit = {
+    scriptHeader.append(") return (")
+    scriptHeader.append(getReturnType(typeRet))
+    scriptHeader.append(") implemented in (classname=\"org.apache.sysml.udf.lib.GenericFunction\", exectype=\"mem\");\n")
+  }
+  
+  // ------------------------------------------------------------------------------------------
+  // Overloaded register function for 1 to 10 inputs:
+  
    // zero-input function unsupported by SystemML
 //  def register[RT: TypeTag](name: String, func: Function0[RT]): Unit = {
 //    println(getType(typeOf[RT].toString()))
@@ -82,21 +108,276 @@ class ExternalUDFRegistration {
     }
     ExternalUDFRegistration.fnSignatureMapping.put(name, Array(typeOf[A1].toString(), typeOf[RT].toString()))
     ExternalUDFRegistration.fnMapping.put(name, anonfun0);
-    scriptHeader.append(name + " = externalFunction(")
-    scriptHeader.append(getType(typeOf[A1].toString()) + " input1")
-    scriptHeader.append(") return (")
-    // TODO: Support multiple return types
-    scriptHeader.append(getType(typeOf[RT].toString())  + " output1")
-    scriptHeader.append(") implemented in (classname=\"org.apache.sysml.udf.lib.GenericFunction\", exectype=\"mem\");\n")
+    appendHead(name)
+    scriptHeader.append(getType(typeOf[A1].toString()) + " input0")
+    appendTail(typeOf[RT].toString())
   }
+  
+  def register[A1: TypeTag, A2: TypeTag, RT: TypeTag](name: String, func: Function2[A1, A2, RT]): Unit = {
+    val anonfun0 = new Function0[Array[FunctionParameter]] {
+       def apply(): Array[FunctionParameter] = {
+         val udf = ExternalUDFRegistration.udfMapping.get(name);
+         return convertReturnToOutput(func.apply(udf.getInput(typeOf[A1].toString(), 0).asInstanceOf[A1],
+             udf.getInput(typeOf[A2].toString(), 1).asInstanceOf[A2]))
+       }
+    }
+    ExternalUDFRegistration.fnSignatureMapping.put(name, Array(typeOf[A1].toString(), typeOf[A2].toString(), typeOf[RT].toString()))
+    ExternalUDFRegistration.fnMapping.put(name, anonfun0);
+    appendHead(name)
+    scriptHeader.append(getType(typeOf[A1].toString()) + " input0, ")
+    scriptHeader.append(getType(typeOf[A2].toString()) + " input1")
+    appendTail(typeOf[RT].toString())
+  }
+  
+  def register[A1: TypeTag, A2: TypeTag, A3: TypeTag, RT: TypeTag](name: String, func: Function3[A1, A2, A3, RT]): Unit = {
+    val anonfun0 = new Function0[Array[FunctionParameter]] {
+       def apply(): Array[FunctionParameter] = {
+         val udf = ExternalUDFRegistration.udfMapping.get(name);
+         return convertReturnToOutput(func.apply(udf.getInput(typeOf[A1].toString(), 0).asInstanceOf[A1],
+             udf.getInput(typeOf[A2].toString(), 1).asInstanceOf[A2], 
+             udf.getInput(typeOf[A3].toString(), 2).asInstanceOf[A3]))
+       }
+    }
+    ExternalUDFRegistration.fnSignatureMapping.put(name, Array(
+        typeOf[A1].toString(), typeOf[A2].toString(), typeOf[A3].toString(), 
+        typeOf[RT].toString()))
+    ExternalUDFRegistration.fnMapping.put(name, anonfun0);
+    appendHead(name)
+    scriptHeader.append(getType(typeOf[A1].toString()) + " input0, ")
+    scriptHeader.append(getType(typeOf[A2].toString()) + " input1, ")
+    scriptHeader.append(getType(typeOf[A3].toString()) + " input2")
+    appendTail(typeOf[RT].toString())
+  }
+  
+  def register[A1: TypeTag, A2: TypeTag, A3: TypeTag, A4: TypeTag, RT: TypeTag](name: String, func: Function4[A1, A2, A3, A4, RT]): Unit = {
+    val anonfun0 = new Function0[Array[FunctionParameter]] {
+       def apply(): Array[FunctionParameter] = {
+         val udf = ExternalUDFRegistration.udfMapping.get(name);
+         return convertReturnToOutput(func.apply(udf.getInput(typeOf[A1].toString(), 0).asInstanceOf[A1],
+             udf.getInput(typeOf[A2].toString(), 1).asInstanceOf[A2], 
+             udf.getInput(typeOf[A3].toString(), 2).asInstanceOf[A3],
+             udf.getInput(typeOf[A4].toString(), 3).asInstanceOf[A4]))
+       }
+    }
+    ExternalUDFRegistration.fnSignatureMapping.put(name, Array(
+        typeOf[A1].toString(), typeOf[A2].toString(), typeOf[A3].toString(), typeOf[A4].toString(), 
+        typeOf[RT].toString()))
+    ExternalUDFRegistration.fnMapping.put(name, anonfun0);
+    appendHead(name)
+    scriptHeader.append(getType(typeOf[A1].toString()) + " input0, ")
+    scriptHeader.append(getType(typeOf[A2].toString()) + " input1, ")
+    scriptHeader.append(getType(typeOf[A3].toString()) + " input2, ")
+    scriptHeader.append(getType(typeOf[A4].toString()) + " input3")
+    appendTail(typeOf[RT].toString())
+  }
+  
+  def register[A1: TypeTag, A2: TypeTag, A3: TypeTag, A4: TypeTag, A5: TypeTag, RT: TypeTag](name: String, 
+      func: Function5[A1, A2, A3, A4, A5, RT]): Unit = {
+    val anonfun0 = new Function0[Array[FunctionParameter]] {
+       def apply(): Array[FunctionParameter] = {
+         val udf = ExternalUDFRegistration.udfMapping.get(name);
+         return convertReturnToOutput(func.apply(udf.getInput(typeOf[A1].toString(), 0).asInstanceOf[A1],
+             udf.getInput(typeOf[A2].toString(), 1).asInstanceOf[A2], 
+             udf.getInput(typeOf[A3].toString(), 2).asInstanceOf[A3],
+             udf.getInput(typeOf[A4].toString(), 3).asInstanceOf[A4], 
+             udf.getInput(typeOf[A5].toString(), 4).asInstanceOf[A5]))
+       }
+    }
+    ExternalUDFRegistration.fnSignatureMapping.put(name, Array(
+        typeOf[A1].toString(), typeOf[A2].toString(), typeOf[A3].toString(), typeOf[A4].toString(),
+        typeOf[A5].toString(),
+        typeOf[RT].toString()))
+    ExternalUDFRegistration.fnMapping.put(name, anonfun0);
+    appendHead(name)
+    scriptHeader.append(getType(typeOf[A1].toString()) + " input0, ")
+    scriptHeader.append(getType(typeOf[A2].toString()) + " input1, ")
+    scriptHeader.append(getType(typeOf[A3].toString()) + " input2, ")
+    scriptHeader.append(getType(typeOf[A4].toString()) + " input3, ")
+    scriptHeader.append(getType(typeOf[A5].toString()) + " input4")
+    appendTail(typeOf[RT].toString())
+  }
+  
+  def register[A1: TypeTag, A2: TypeTag, A3: TypeTag, A4: TypeTag, A5: TypeTag, A6: TypeTag, RT: TypeTag](name: String, 
+      func: Function6[A1, A2, A3, A4, A5, A6, RT]): Unit = {
+    val anonfun0 = new Function0[Array[FunctionParameter]] {
+       def apply(): Array[FunctionParameter] = {
+         val udf = ExternalUDFRegistration.udfMapping.get(name);
+         return convertReturnToOutput(func.apply(udf.getInput(typeOf[A1].toString(), 0).asInstanceOf[A1],
+             udf.getInput(typeOf[A2].toString(), 1).asInstanceOf[A2], 
+             udf.getInput(typeOf[A3].toString(), 2).asInstanceOf[A3],
+             udf.getInput(typeOf[A4].toString(), 3).asInstanceOf[A4], 
+             udf.getInput(typeOf[A5].toString(), 4).asInstanceOf[A5], 
+             udf.getInput(typeOf[A6].toString(), 5).asInstanceOf[A6]))
+       }
+    }
+    ExternalUDFRegistration.fnSignatureMapping.put(name, Array(
+        typeOf[A1].toString(), typeOf[A2].toString(), typeOf[A3].toString(), typeOf[A4].toString(),
+        typeOf[A5].toString(), typeOf[A6].toString(),
+        typeOf[RT].toString()))
+    ExternalUDFRegistration.fnMapping.put(name, anonfun0);
+    appendHead(name)
+    scriptHeader.append(getType(typeOf[A1].toString()) + " input0, ")
+    scriptHeader.append(getType(typeOf[A2].toString()) + " input1, ")
+    scriptHeader.append(getType(typeOf[A3].toString()) + " input2, ")
+    scriptHeader.append(getType(typeOf[A4].toString()) + " input3, ")
+    scriptHeader.append(getType(typeOf[A5].toString()) + " input4, ")
+    scriptHeader.append(getType(typeOf[A6].toString()) + " input5")
+    appendTail(typeOf[RT].toString())
+  }
+  
+  def register[A1: TypeTag, A2: TypeTag, A3: TypeTag, A4: TypeTag, A5: TypeTag, A6: TypeTag, A7: TypeTag, RT: TypeTag](name: String, 
+      func: Function7[A1, A2, A3, A4, A5, A6, A7, RT]): Unit = {
+    val anonfun0 = new Function0[Array[FunctionParameter]] {
+       def apply(): Array[FunctionParameter] = {
+         val udf = ExternalUDFRegistration.udfMapping.get(name);
+         return convertReturnToOutput(func.apply(udf.getInput(typeOf[A1].toString(), 0).asInstanceOf[A1],
+             udf.getInput(typeOf[A2].toString(), 1).asInstanceOf[A2], 
+             udf.getInput(typeOf[A3].toString(), 2).asInstanceOf[A3],
+             udf.getInput(typeOf[A4].toString(), 3).asInstanceOf[A4], 
+             udf.getInput(typeOf[A5].toString(), 4).asInstanceOf[A5], 
+             udf.getInput(typeOf[A6].toString(), 5).asInstanceOf[A6],
+             udf.getInput(typeOf[A7].toString(), 6).asInstanceOf[A7]))
+       }
+    }
+    ExternalUDFRegistration.fnSignatureMapping.put(name, Array(
+        typeOf[A1].toString(), typeOf[A2].toString(), typeOf[A3].toString(), typeOf[A4].toString(),
+        typeOf[A5].toString(), typeOf[A6].toString(), typeOf[A7].toString(),
+        typeOf[RT].toString()))
+    ExternalUDFRegistration.fnMapping.put(name, anonfun0);
+    appendHead(name)
+    scriptHeader.append(getType(typeOf[A1].toString()) + " input0, ")
+    scriptHeader.append(getType(typeOf[A2].toString()) + " input1, ")
+    scriptHeader.append(getType(typeOf[A3].toString()) + " input2, ")
+    scriptHeader.append(getType(typeOf[A4].toString()) + " input3, ")
+    scriptHeader.append(getType(typeOf[A5].toString()) + " input4, ")
+    scriptHeader.append(getType(typeOf[A6].toString()) + " input5, ")
+    scriptHeader.append(getType(typeOf[A7].toString()) + " input6")
+    appendTail(typeOf[RT].toString())
+  }
+  
+  def register[A1: TypeTag, A2: TypeTag, A3: TypeTag, A4: TypeTag, A5: TypeTag, A6: TypeTag, A7: TypeTag, 
+    A8: TypeTag, RT: TypeTag](name: String, 
+      func: Function8[A1, A2, A3, A4, A5, A6, A7, A8, RT]): Unit = {
+    val anonfun0 = new Function0[Array[FunctionParameter]] {
+       def apply(): Array[FunctionParameter] = {
+         val udf = ExternalUDFRegistration.udfMapping.get(name);
+         return convertReturnToOutput(func.apply(udf.getInput(typeOf[A1].toString(), 0).asInstanceOf[A1],
+             udf.getInput(typeOf[A2].toString(), 1).asInstanceOf[A2], 
+             udf.getInput(typeOf[A3].toString(), 2).asInstanceOf[A3],
+             udf.getInput(typeOf[A4].toString(), 3).asInstanceOf[A4], 
+             udf.getInput(typeOf[A5].toString(), 4).asInstanceOf[A5], 
+             udf.getInput(typeOf[A6].toString(), 5).asInstanceOf[A6],
+             udf.getInput(typeOf[A7].toString(), 6).asInstanceOf[A7], 
+             udf.getInput(typeOf[A8].toString(), 7).asInstanceOf[A8]))
+       }
+    }
+    ExternalUDFRegistration.fnSignatureMapping.put(name, Array(
+        typeOf[A1].toString(), typeOf[A2].toString(), typeOf[A3].toString(), typeOf[A4].toString(),
+        typeOf[A5].toString(), typeOf[A6].toString(), typeOf[A7].toString(), typeOf[A8].toString(),
+        typeOf[RT].toString()))
+    ExternalUDFRegistration.fnMapping.put(name, anonfun0);
+    appendHead(name)
+    scriptHeader.append(getType(typeOf[A1].toString()) + " input0, ")
+    scriptHeader.append(getType(typeOf[A2].toString()) + " input1, ")
+    scriptHeader.append(getType(typeOf[A3].toString()) + " input2, ")
+    scriptHeader.append(getType(typeOf[A4].toString()) + " input3, ")
+    scriptHeader.append(getType(typeOf[A5].toString()) + " input4, ")
+    scriptHeader.append(getType(typeOf[A6].toString()) + " input5, ")
+    scriptHeader.append(getType(typeOf[A7].toString()) + " input6, ")
+    scriptHeader.append(getType(typeOf[A8].toString()) + " input7")
+    appendTail(typeOf[RT].toString())
+  }
+  
+  def register[A1: TypeTag, A2: TypeTag, A3: TypeTag, A4: TypeTag, A5: TypeTag, A6: TypeTag, A7: TypeTag, 
+    A8: TypeTag, A9: TypeTag, RT: TypeTag](name: String, 
+      func: Function9[A1, A2, A3, A4, A5, A6, A7, A8, A9, RT]): Unit = {
+    val anonfun0 = new Function0[Array[FunctionParameter]] {
+       def apply(): Array[FunctionParameter] = {
+         val udf = ExternalUDFRegistration.udfMapping.get(name);
+         return convertReturnToOutput(func.apply(udf.getInput(typeOf[A1].toString(), 0).asInstanceOf[A1],
+             udf.getInput(typeOf[A2].toString(), 1).asInstanceOf[A2], 
+             udf.getInput(typeOf[A3].toString(), 2).asInstanceOf[A3],
+             udf.getInput(typeOf[A4].toString(), 3).asInstanceOf[A4], 
+             udf.getInput(typeOf[A5].toString(), 4).asInstanceOf[A5], 
+             udf.getInput(typeOf[A6].toString(), 5).asInstanceOf[A6],
+             udf.getInput(typeOf[A7].toString(), 6).asInstanceOf[A7], 
+             udf.getInput(typeOf[A8].toString(), 7).asInstanceOf[A8], 
+             udf.getInput(typeOf[A9].toString(), 8).asInstanceOf[A9]))
+       }
+    }
+    ExternalUDFRegistration.fnSignatureMapping.put(name, Array(
+        typeOf[A1].toString(), typeOf[A2].toString(), typeOf[A3].toString(), typeOf[A4].toString(),
+        typeOf[A5].toString(), typeOf[A6].toString(), typeOf[A7].toString(), typeOf[A8].toString(),
+        typeOf[A9].toString(),
+        typeOf[RT].toString()))
+    ExternalUDFRegistration.fnMapping.put(name, anonfun0);
+    appendHead(name)
+    scriptHeader.append(getType(typeOf[A1].toString()) + " input0, ")
+    scriptHeader.append(getType(typeOf[A2].toString()) + " input1, ")
+    scriptHeader.append(getType(typeOf[A3].toString()) + " input2, ")
+    scriptHeader.append(getType(typeOf[A4].toString()) + " input3, ")
+    scriptHeader.append(getType(typeOf[A5].toString()) + " input4, ")
+    scriptHeader.append(getType(typeOf[A6].toString()) + " input5, ")
+    scriptHeader.append(getType(typeOf[A7].toString()) + " input6, ")
+    scriptHeader.append(getType(typeOf[A8].toString()) + " input7, ")
+    scriptHeader.append(getType(typeOf[A9].toString()) + " input8")
+    appendTail(typeOf[RT].toString())
+  }
+  
+  def register[A1: TypeTag, A2: TypeTag, A3: TypeTag, A4: TypeTag, A5: TypeTag, A6: TypeTag, A7: TypeTag, 
+    A8: TypeTag, A9: TypeTag, A10: TypeTag, RT: TypeTag](name: String, 
+      func: Function10[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, RT]): Unit = {
+    val anonfun0 = new Function0[Array[FunctionParameter]] {
+       def apply(): Array[FunctionParameter] = {
+         val udf = ExternalUDFRegistration.udfMapping.get(name);
+         return convertReturnToOutput(func.apply(udf.getInput(typeOf[A1].toString(), 0).asInstanceOf[A1],
+             udf.getInput(typeOf[A2].toString(), 1).asInstanceOf[A2], 
+             udf.getInput(typeOf[A3].toString(), 2).asInstanceOf[A3],
+             udf.getInput(typeOf[A4].toString(), 3).asInstanceOf[A4], 
+             udf.getInput(typeOf[A5].toString(), 4).asInstanceOf[A5], 
+             udf.getInput(typeOf[A6].toString(), 5).asInstanceOf[A6],
+             udf.getInput(typeOf[A7].toString(), 6).asInstanceOf[A7], 
+             udf.getInput(typeOf[A8].toString(), 7).asInstanceOf[A8], 
+             udf.getInput(typeOf[A9].toString(), 8).asInstanceOf[A9],
+             udf.getInput(typeOf[A10].toString(), 9).asInstanceOf[A10]))
+       }
+    }
+    ExternalUDFRegistration.fnSignatureMapping.put(name, Array(
+        typeOf[A1].toString(), typeOf[A2].toString(), typeOf[A3].toString(), typeOf[A4].toString(),
+        typeOf[A5].toString(), typeOf[A6].toString(), typeOf[A7].toString(), typeOf[A8].toString(),
+        typeOf[A9].toString(), typeOf[A10].toString(),
+        typeOf[RT].toString()))
+    ExternalUDFRegistration.fnMapping.put(name, anonfun0);
+    appendHead(name)
+    scriptHeader.append(getType(typeOf[A1].toString()) + " input0, ")
+    scriptHeader.append(getType(typeOf[A2].toString()) + " input1, ")
+    scriptHeader.append(getType(typeOf[A3].toString()) + " input2, ")
+    scriptHeader.append(getType(typeOf[A4].toString()) + " input3, ")
+    scriptHeader.append(getType(typeOf[A5].toString()) + " input4, ")
+    scriptHeader.append(getType(typeOf[A6].toString()) + " input5, ")
+    scriptHeader.append(getType(typeOf[A7].toString()) + " input6, ")
+    scriptHeader.append(getType(typeOf[A8].toString()) + " input7, ")
+    scriptHeader.append(getType(typeOf[A9].toString()) + " input8, ")
+    scriptHeader.append(getType(typeOf[A10].toString()) + " input9")
+    appendTail(typeOf[RT].toString())
+  }
+  
+  // ------------------------------------------------------------------------------------------
   
   def convertReturnToOutput(ret:Any): Array[FunctionParameter] = {
     ret match {
        case x:Tuple1[Any] => Array(convertToOutput(x._1))
        case x:Tuple2[Any, Any] => Array(convertToOutput(x._1), convertToOutput(x._2))
-//       case x:Tuple3[B1, B2, B3] => Array(convertToOutput(x._1), convertToOutput(x._2))
-//       case x:Tuple4[B1, B2, B3, B4] => Array(convertToOutput(x._1), convertToOutput(x._2))
-//       case x:Tuple5[B1, B2, B3, B4, B5] => Array(convertToOutput(x._1), convertToOutput(x._2))
+       case x:Tuple3[Any, Any, Any] => Array(convertToOutput(x._1), convertToOutput(x._2), convertToOutput(x._3))
+       case x:Tuple4[Any, Any, Any, Any] => Array(convertToOutput(x._1), convertToOutput(x._2), convertToOutput(x._3), convertToOutput(x._4))
+       case x:Tuple5[Any, Any, Any, Any, Any] => Array(convertToOutput(x._1), convertToOutput(x._2), convertToOutput(x._3), convertToOutput(x._4), convertToOutput(x._5))
+       case x:Tuple6[Any, Any, Any, Any, Any, Any] => Array(convertToOutput(x._1), convertToOutput(x._2), convertToOutput(x._3), convertToOutput(x._4), convertToOutput(x._5), convertToOutput(x._6))
+       case x:Tuple7[Any, Any, Any, Any, Any, Any, Any] => Array(convertToOutput(x._1), convertToOutput(x._2), convertToOutput(x._3), convertToOutput(x._4), convertToOutput(x._5), convertToOutput(x._6), convertToOutput(x._7))
+       case x:Tuple8[Any, Any, Any, Any, Any, Any, Any, Any] => Array(convertToOutput(x._1), convertToOutput(x._2), convertToOutput(x._3), convertToOutput(x._4), convertToOutput(x._5), convertToOutput(x._6), convertToOutput(x._7), convertToOutput(x._8))
+       case x:Tuple9[Any, Any, Any, Any, Any, Any, Any, Any, Any] => Array(convertToOutput(x._1), convertToOutput(x._2), convertToOutput(x._3), convertToOutput(x._4), convertToOutput(x._5), convertToOutput(x._6), convertToOutput(x._7), 
+                                                                 convertToOutput(x._8), convertToOutput(x._9))
+       case x:Tuple10[Any, Any, Any, Any, Any, Any, Any, Any, Any, Any] => Array(convertToOutput(x._1), convertToOutput(x._2), convertToOutput(x._3), convertToOutput(x._4), convertToOutput(x._5), convertToOutput(x._6), convertToOutput(x._7), 
+                                                                 convertToOutput(x._8), convertToOutput(x._9), convertToOutput(x._10))                                                          
        case _ => Array(convertToOutput(ret))
      }
   }

--- a/src/main/scala/org/apache/sysml/api/ExternalUDFRegistration.scala
+++ b/src/main/scala/org/apache/sysml/api/ExternalUDFRegistration.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.api;
+
+import scala.reflect.runtime.universe._
+import java.util.ArrayList
+import org.apache.sysml.udf.FunctionParameter
+import org.apache.sysml.udf.Scalar
+import org.apache.sysml.udf.Matrix
+import org.apache.sysml.udf.Matrix.ValueType
+import org.apache.sysml.api.mlcontext.Script
+import org.apache.sysml.udf.PackageFunction
+import org.apache.sysml.udf.FunctionParameter
+import org.apache.sysml.udf.lib.GenericFunction
+import org.apache.sysml.udf.Scalar.ScalarValueType
+
+object ExternalUDFRegistration {
+
+}
+
+/**
+ * This class handles the registration of external Scala UDFs via MLContext.
+ */
+class ExternalUDFRegistration {
+  var ml:MLContext = null
+  def setMLContext(ml1:MLContext) = { this.ml = ml }
+  
+  val scriptHeader:StringBuilder = new StringBuilder
+  def addHeaders(script:Script): Unit = {
+    val header = scriptHeader.toString() 
+    if(!header.equals(""))
+			script.setScriptString(scriptHeader + "\n" + script.getScriptString());
+  }
+  
+  def getType(t: String):String = {
+    t match {
+      case "java.lang.String" => "string"
+      case "Double" => "double"
+      case "Int" => "integer"
+      case "Boolean" => "boolean"
+      // Support only pass by value for now.
+      // case "org.apache.sysml.runtime.matrix.data.MatrixBlock" => "matrix[double]"
+      // case "scala.Array[Double]" => "matrix[double]"
+      case "scala.Array[scala.Array[Double]]" => "matrix[double]"
+      case _ => throw new RuntimeException("Unsupported type of parameter: " + t)
+    }
+  }
+   
+   // zero-input function unsupported by SystemML
+//  def register[RT: TypeTag](name: String, func: Function0[RT]): Unit = {
+//    println(getType(typeOf[RT].toString()))
+//  }
+   
+   def register[A1: TypeTag, RT: TypeTag](ml: MLContext, name: String, func: Function1[A1, RT]): Unit = {
+    val udf = new GenericFunction(Array(typeOf[A1].toString(), typeOf[RT].toString()));
+    val anonfun0 = new Function0[Array[FunctionParameter]] {
+       def apply(): Array[FunctionParameter] = {
+         return convertReturnToOutput(func.apply(udf.getInput(typeOf[A1].toString(), 0).asInstanceOf[A1]))
+       }
+    }
+    udf.setScalaUDF(anonfun0)
+    scriptHeader.append(name + " = externalFunction(")
+    scriptHeader.append(getType(typeOf[A1].toString()))
+    scriptHeader.append(") return (")
+    // TODO: Support multiple return types
+    
+  }
+  
+  def convertReturnToOutput(ret:Any): Array[FunctionParameter] = {
+    ret match {
+       case x:Tuple1[Any] => Array(convertToOutput(x._1))
+       case x:Tuple2[Any, Any] => Array(convertToOutput(x._1), convertToOutput(x._2))
+//       case x:Tuple3[B1, B2, B3] => Array(convertToOutput(x._1), convertToOutput(x._2))
+//       case x:Tuple4[B1, B2, B3, B4] => Array(convertToOutput(x._1), convertToOutput(x._2))
+//       case x:Tuple5[B1, B2, B3, B4, B5] => Array(convertToOutput(x._1), convertToOutput(x._2))
+       case _ => Array(convertToOutput(ret))
+     }
+  }
+   val rand = new java.util.Random()
+   def convertToOutput(x:Any): FunctionParameter = {
+     x match {
+       case x1:Int => return new Scalar(ScalarValueType.Integer, String.valueOf(x))
+       case x1:java.lang.Integer => return new Scalar(ScalarValueType.Integer, String.valueOf(x))
+       case x1:Double => return new Scalar(ScalarValueType.Double, String.valueOf(x))
+       case x1:java.lang.Double => return new Scalar(ScalarValueType.Double, String.valueOf(x))
+       case x1:java.lang.String => return new Scalar(ScalarValueType.Text, String.valueOf(x))
+       case x1:java.lang.Boolean => return new Scalar(ScalarValueType.Boolean, String.valueOf(x))
+       case x1:Boolean => return new Scalar(ScalarValueType.Boolean, String.valueOf(x))
+       case x1:scala.Array[scala.Array[Double]] => {
+         val mat = new Matrix( "temp" + rand.nextLong, x1.length, x1(0).length, ValueType.Double );
+			   mat.setMatrixDoubleArray(x1)
+			   return mat
+       }
+       case _ => throw new RuntimeException("Unsupported output type:" + x.getClass().getName)
+     }
+   }
+}


### PR DESCRIPTION
The registration mechanism is inspired from Spark SQLContext's UDF. The key construct is `ml.udf.register("fn to be used in DML", scala UDF)`.

```scala
import org.apache.sysml.api.mlcontext._
import org.apache.sysml.api.mlcontext.ScriptFactory._
val ml = new MLContext(sc)

// Demonstrates how to pass a simple scala UDF to SystemML
def addOne(x:Double):Double = x + 1
ml.udf.register("addOne", addOne)
val script1 = dml("v = addOne(2.0); print(v)")
ml.execute(script1)

// Demonstrates operation on local matrices (double[][])
def addOneToDiagonal(x:Array[Array[Double]]):Array[Array[Double]] = {  for(i <- 0 to x.length-1) x(i)(i) = x(i)(i) + 1; x }
ml.udf.register("addOneToDiagonal", addOneToDiagonal)
val script2 = dml("m1 = matrix(0, rows=3, cols=3); m2 = addOneToDiagonal(m1); print(toString(m2));")
ml.execute(script2)


// Demonstrates multi-return function
def multiReturnFn(x:Double):(Double, Int) = (x + 1, (x * 2).toInt)
ml.udf.register("multiReturnFn", multiReturnFn)
val script3 = dml("[v1, v2] = multiReturnFn(2.0); print(v1)")
ml.execute(script3)

// Demonstrates multi-argument multi-return function
def multiArgReturnFn(x:Double, y:Int):(Double, Int) = (x + 1, (x * y).toInt)
ml.udf.register("multiArgReturnFn", multiArgReturnFn _)
val script4 = dml("[v1, v2] = multiArgReturnFn(2.0, 1); print(v2)")
ml.execute(script4)
```

The restrictions for Scala UDF are as follows:
1. Only types specified by DML language is supported for parameters and return types (i.e. Int, Double, Boolean, String, double[][]).
2. At minimum, the function should have 1 argument and 1 return value.
3. At max, the function can have 10 arguments and 10 return values.

@dusenberrymw @deroneriksson @bertholdreinwald @nakul02 @mboehm7 @fschueler @frreiss 