### PR TITLE
[MINOR] prompt for PGP passphrase if not exported

### DIFF
--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -141,12 +141,12 @@ while [ "${1+defined}" ]; do
 done
 
 
-for env in GPG_PASSPHRASE; do
-  if [ -z "${!env}" ]; then
-    echo "ERROR: $env must be set to run this script"
-    exit_with_usage
-  fi
-done
+if [[ -z "$GPG_PASSPHRASE" ]]; then
+    echo 'The environment variable GPG_PASSPHRASE is not set. Enter the passphrase to'
+    echo 'unlock the GPG signing key that will be used to sign the release!'
+    echo
+    stty -echo && printf "GPG passphrase: " && read GPG_PASSPHRASE && printf '\n' && stty echo
+fi
 
 if [[ "$RELEASE_PREPARE" == "true" && -z "$RELEASE_VERSION" ]]; then
     echo "ERROR: --releaseVersion must be passed as an argument to run this script"
@@ -245,7 +245,7 @@ if [[ "$RELEASE_PREPARE" == "true" ]]; then
     cd $RELEASE_WORK_DIR/incubator-systemml
 
     # Build and prepare the release
-    $MVN $PUBLISH_PROFILES release:clean release:prepare $DRY_RUN -Dgpg.passphrase="$GPG_PASSPHRASE" -DskipTests -Darguments="-DskipTests" -DreleaseVersion="$RELEASE_VERSION" -DdevelopmentVersion="$DEVELOPMENT_VERSION" -Dtag="$RELEASE_TAG"
+    $MVN $PUBLISH_PROFILES release:clean release:prepare $DRY_RUN -Darguments="-Dgpg.passphrase=\"$GPG_PASSPHRASE\" -DskipTests" -DreleaseVersion="$RELEASE_VERSION" -DdevelopmentVersion="$DEVELOPMENT_VERSION" -Dtag="$RELEASE_TAG"
 
     cd $RELEASE_WORK_DIR
 

--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -282,7 +282,7 @@ if [[ "$RELEASE_PUBLISH" == "true" ]]; then
     cd $RELEASE_WORK_DIR/incubator-systemml
 
     #Deploy scala 2.10
-    mvn -DaltDeploymentRepository=apache.releases.https::default::https://repository.apache.org/service/local/staging/deploy/maven2 clean package gpg:sign install:install deploy:deploy -DskiptTests -Darguments="-DskipTests" -Dgpg.passphrase=$GPG_PASSPHRASE $PUBLISH_PROFILES
+    mvn -DaltDeploymentRepository=apache.releases.https::default::https://repository.apache.org/service/local/staging/deploy/maven2 clean package gpg:sign install:install deploy:deploy -DskiptTests -Darguments="-DskipTests -Dgpg.passphrase=\"$GPG_PASSPHRASE\"" -Dgpg.passphrase="$GPG_PASSPHRASE" $PUBLISH_PROFILES
 
     cd "$BASE_DIR" #exit target
 
@@ -308,7 +308,7 @@ if [[ "$RELEASE_SNAPSHOT" == "true" ]]; then
     fi
 
     #Deploy scala 2.10
-    $MVN -DaltDeploymentRepository=apache.snapshots.https::default::https://repository.apache.org/content/repositories/snapshots clean package gpg:sign install:install deploy:deploy -DskiptTests -Darguments="-DskipTests" -Dgpg.passphrase=$GPG_PASSPHRASE $PUBLISH_PROFILES
+    $MVN -DaltDeploymentRepository=apache.snapshots.https::default::https://repository.apache.org/content/repositories/snapshots clean package gpg:sign install:install deploy:deploy -DskiptTests -Darguments="-DskipTests -Dgpg.passphrase=\"$GPG_PASSPHRASE\"" -Dgpg.passphrase="$GPG_PASSPHRASE" $PUBLISH_PROFILES
 
     cd "$BASE_DIR" #exit target
     exit 0


### PR DESCRIPTION
**Problem**

When executing the script `dev/release-build.sh --release-prepare ...` the _Maven Release Plugin_ repeatedly prompts for the passphrase to unlock the GPG signing key despite the exported `GPG_PASSPHRASE` environment variable.

**Reason**

The _[Maven GPG Plugin](http://maven.apache.org/plugins/maven-gpg-plugin/index.html)_ accepts a `gpg.passphrase` argument like this:

```Bash
mvn gpg:sign -Dgpg.passphrase="$GPG_PASSPHRASE"
```

However when used in combination with the _[Maven Release Plugin](http://maven.apache.org/maven-release/maven-release-plugin/prepare-mojo.html)_ then the GPG passphrase needs to be passed with the `-Darguments` parameter:

```Shell
mvn release:prepare -Darguments="-Dgpg.passphrase=\"$GPG_PASSPHRASE\""
                    ^^^^^^^^^^^^
```
See http://maven.apache.org/plugins/maven-gpg-plugin/usage.html

**Proposed Changes**

- use the `-Darguments` property to pass on the `gpg.passphrase` and the `skipTest` flag
- if the `GPG_PASSPHRASE` environment variable was not exported, prompt for it (once)

```
$ unset GPG_PASSPHRASE
$ dev/release-build.sh --release-prepare --releaseVersion="2.0.2"  --releaseRc="rc3" ...

The environment variable GPG_PASSPHRASE is not set. Enter the passphrase to
unlock the GPG signing key that will be used to sign the release!

GPG passphrase: ◘
```