### PR TITLE
[SYSTEMML-1192] Delete rmvar instructions via MLContext

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
@@ -116,6 +116,12 @@ public class MLContext {
 	 */
 	private ProjectInfo projectInfo = null;
 
+	/**
+	 * Whether or not all values should be maintained in the symbol table
+	 * after execution.
+	 */
+	private boolean maintainSymbolTable = false;
+
 	private List<String> scriptHistoryStrings = new ArrayList<String>();
 	private Map<String, Script> scripts = new LinkedHashMap<String, Script>();
 
@@ -273,6 +279,7 @@ public class MLContext {
 		scriptExecutor.setStatistics(statistics);
 		scriptExecutor.setStatisticsMaxHeavyHitters(statisticsMaxHeavyHitters);
 		scriptExecutor.setInit(scriptHistoryStrings.isEmpty());
+		scriptExecutor.setMaintainSymbolTable(maintainSymbolTable);
 		return execute(script, scriptExecutor);
 	}
 
@@ -357,6 +364,30 @@ public class MLContext {
 	 */
 	public void setExplain(boolean explain) {
 		this.explain = explain;
+	}
+
+
+	/**
+	 * Obtain whether or not all values should be maintained in the symbol table
+	 * after execution.
+	 * 
+	 * @return {@code true} if all values should be maintained in the symbol
+	 *         table, {@code false} otherwise
+	 */
+	public boolean isMaintainSymbolTable() {
+		return maintainSymbolTable;
+	}
+
+	/**
+	 * Set whether or not all values should be maintained in the symbol table
+	 * after execution.
+	 * 
+	 * @param maintainSymbolTable
+	 *            {@code true} if all values should be maintained in the symbol
+	 *            table, {@code false} otherwise
+	 */
+	public void setMaintainSymbolTable(boolean maintainSymbolTable) {
+		this.maintainSymbolTable = maintainSymbolTable;
 	}
 
 	/**

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.net.URL;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -52,14 +53,22 @@ import org.apache.sysml.conf.ConfigurationManager;
 import org.apache.sysml.conf.DMLConfig;
 import org.apache.sysml.parser.ParseException;
 import org.apache.sysml.parser.Statement;
+import org.apache.sysml.runtime.controlprogram.ForProgramBlock;
+import org.apache.sysml.runtime.controlprogram.FunctionProgramBlock;
+import org.apache.sysml.runtime.controlprogram.IfProgramBlock;
 import org.apache.sysml.runtime.controlprogram.LocalVariableMap;
+import org.apache.sysml.runtime.controlprogram.Program;
+import org.apache.sysml.runtime.controlprogram.ProgramBlock;
+import org.apache.sysml.runtime.controlprogram.WhileProgramBlock;
 import org.apache.sysml.runtime.controlprogram.caching.FrameObject;
 import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
+import org.apache.sysml.runtime.instructions.Instruction;
 import org.apache.sysml.runtime.instructions.cp.BooleanObject;
 import org.apache.sysml.runtime.instructions.cp.Data;
 import org.apache.sysml.runtime.instructions.cp.DoubleObject;
 import org.apache.sysml.runtime.instructions.cp.IntObject;
 import org.apache.sysml.runtime.instructions.cp.StringObject;
+import org.apache.sysml.runtime.instructions.cp.VariableCPInstruction;
 import org.apache.sysml.runtime.matrix.data.FrameBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
@@ -988,5 +997,72 @@ public final class MLContextUtil {
 	public static boolean doesSymbolTableContainMatrixObject(LocalVariableMap symbolTable, String variableName) {
 		return (symbolTable != null && symbolTable.keySet().contains(variableName)
 				&& symbolTable.get(variableName) instanceof MatrixObject);
+	}
+
+	/**
+	 * Delete the 'remove variable' instructions from a runtime program.
+	 * 
+	 * @param progam
+	 *            runtime program
+	 */
+	public static void deleteRemoveVariableInstructions(Program progam) {
+		Map<String, FunctionProgramBlock> fpbs = progam.getFunctionProgramBlocks();
+		if (fpbs != null && !fpbs.isEmpty()) {
+			for (Entry<String, FunctionProgramBlock> e : fpbs.entrySet()) {
+				FunctionProgramBlock fpb = e.getValue();
+				for (ProgramBlock pb : fpb.getChildBlocks()) {
+					deleteRemoveVariableInstructions(pb);
+				}
+			}
+		}
+
+		for (ProgramBlock pb : progam.getProgramBlocks()) {
+			deleteRemoveVariableInstructions(pb);
+		}
+	}
+
+	/**
+	 * Recursively traverse program block to delete 'remove variable'
+	 * instructions.
+	 * 
+	 * @param pb
+	 *            Program block
+	 */
+	private static void deleteRemoveVariableInstructions(ProgramBlock pb) {
+		if (pb instanceof WhileProgramBlock) {
+			WhileProgramBlock wpb = (WhileProgramBlock) pb;
+			for (ProgramBlock pbc : wpb.getChildBlocks())
+				deleteRemoveVariableInstructions(pbc);
+		} else if (pb instanceof IfProgramBlock) {
+			IfProgramBlock ipb = (IfProgramBlock) pb;
+			for (ProgramBlock pbc : ipb.getChildBlocksIfBody())
+				deleteRemoveVariableInstructions(pbc);
+			for (ProgramBlock pbc : ipb.getChildBlocksElseBody())
+				deleteRemoveVariableInstructions(pbc);
+		} else if (pb instanceof ForProgramBlock) {
+			ForProgramBlock fpb = (ForProgramBlock) pb;
+			for (ProgramBlock pbc : fpb.getChildBlocks())
+				deleteRemoveVariableInstructions(pbc);
+		} else {
+			ArrayList<Instruction> instructions = pb.getInstructions();
+			deleteRemoveVariableInstructions(instructions);
+		}
+	}
+
+	/**
+	 * Delete 'remove variable' instructions.
+	 * 
+	 * @param instructions
+	 *            list of instructions
+	 */
+	private static void deleteRemoveVariableInstructions(ArrayList<Instruction> instructions) {
+		for (int i = 0; i < instructions.size(); i++) {
+			Instruction linst = instructions.get(i);
+			if (linst instanceof VariableCPInstruction && ((VariableCPInstruction) linst).isRemoveVariable()) {
+				VariableCPInstruction varinst = (VariableCPInstruction) linst;
+				instructions.remove(varinst);
+				i--;
+			}
+		}
 	}
 }

--- a/src/main/java/org/apache/sysml/api/mlcontext/ScriptExecutor.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/ScriptExecutor.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sysml.api.DMLScript;
-import org.apache.sysml.api.jmlc.JMLCUtils;
 import org.apache.sysml.api.mlcontext.MLContext.ExplainLevel;
 import org.apache.sysml.api.monitoring.SparkMonitoringUtil;
 import org.apache.sysml.conf.ConfigurationManager;
@@ -373,12 +372,12 @@ public class ScriptExecutor {
 	}
 
 	/**
-	 * Remove rmvar instructions so as to maintain registered outputs after the
-	 * program terminates.
+	 * Delete 'remove variable' instructions so as to maintain the values in the
+	 * symbol table, which are useful when working interactively in an
+	 * environment such as the Spark Shell.
 	 */
 	protected void cleanupRuntimeProgram() {
-		JMLCUtils.cleanupRuntimeProgram(runtimeProgram, (script.getOutputVariables() == null) ? new String[0] : script
-				.getOutputVariables().toArray(new String[0]));
+		MLContextUtil.deleteRemoveVariableInstructions(runtimeProgram);
 	}
 
 	/**


### PR DESCRIPTION
Remove all rmvar instructions so that variables are maintained in the symbol
table, which is useful in an interactive environment such as the Spark Shell.