### PR TITLE
[SYSTEMML-1160] [WIP] Enable prefetching of batches via for loop iterator

### DIFF
--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteForLoopVectorization.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteForLoopVectorization.java
@@ -64,25 +64,27 @@ public class RewriteForLoopVectorization extends StatementBlockRewriteRule
 		if( sb instanceof ForStatementBlock )
 		{
 			ForStatementBlock fsb = (ForStatementBlock) sb;
-			ForStatement fs = (ForStatement) fsb.getStatement(0);
-			Hop from = fsb.getFromHops();
-			Hop to = fsb.getToHops();
-			Hop incr = fsb.getIncrementHops();
-			String iterVar = fsb.getIterPredicate().getIterVar().getName();
-			
-			if( fs.getBody()!=null && fs.getBody().size()==1 ) //single child block
-			{
-				StatementBlock csb = (StatementBlock) fs.getBody().get(0);
-				if( !(   csb instanceof WhileStatementBlock  //last level block
-					  || csb instanceof IfStatementBlock 
-					  || csb instanceof ForStatementBlock ) )
+			if(fsb.getIterPredicate().getIterVar().size() == 1) {
+				ForStatement fs = (ForStatement) fsb.getStatement(0);
+				Hop from = fsb.getFromHops();
+				Hop to = fsb.getToHops();
+				Hop incr = fsb.getIncrementHops();
+				String iterVar = fsb.getIterPredicate().getIterVar().get(0).getName();
+				
+				if( fs.getBody()!=null && fs.getBody().size()==1 ) //single child block
 				{
-					//auto vectorization pattern
-					sb = vectorizeScalarAggregate(sb, csb, from, to, incr, iterVar);           //e.g., for(i){s = s + as.scalar(X[i,2])}
-					sb = vectorizeElementwiseBinary(sb, csb, from, to, incr, iterVar);
-					sb = vectorizeElementwiseUnary(sb, csb, from, to, incr, iterVar);
-				}	
-			}	
+					StatementBlock csb = (StatementBlock) fs.getBody().get(0);
+					if( !(   csb instanceof WhileStatementBlock  //last level block
+						  || csb instanceof IfStatementBlock 
+						  || csb instanceof ForStatementBlock ) )
+					{
+						//auto vectorization pattern
+						sb = vectorizeScalarAggregate(sb, csb, from, to, incr, iterVar);           //e.g., for(i){s = s + as.scalar(X[i,2])}
+						sb = vectorizeElementwiseBinary(sb, csb, from, to, incr, iterVar);
+						sb = vectorizeElementwiseUnary(sb, csb, from, to, incr, iterVar);
+					}	
+				}
+			}
 		}	
 		
 		//if no rewrite applied sb is the original for loop otherwise a last level statement block

--- a/src/main/java/org/apache/sysml/parser/DMLProgram.java
+++ b/src/main/java/org/apache/sysml/parser/DMLProgram.java
@@ -371,7 +371,7 @@ public class DMLProgram
 			String sbName = null;
 			ForProgramBlock rtpb = null;
 			IterablePredicate iterPred = fsb.getIterPredicate();
-			String [] iterPredData= IterablePredicate.createIterablePredicateVariables(iterPred.getIterVar().getName(),
+			String [] iterPredData= IterablePredicate.createIterablePredicateVariables(iterPred.getIterVar(),
 					                                                                   fsb.getFromLops(), fsb.getToLops(), fsb.getIncrementLops()); 
 			
 			if( sb instanceof ParForStatementBlock )

--- a/src/main/java/org/apache/sysml/parser/ForStatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/ForStatementBlock.java
@@ -332,8 +332,9 @@ public class ForStatementBlock extends StatementBlock
 		
 		// for now just print the warn set
 		for (String varName : _warnSet.getVariableNames()) {
-			if( !ip.getIterVar().getName().equals( varName)  )
-				LOG.warn(_warnSet.getVariable(varName).printWarningLocation() + "Initialization of " + varName + " depends on for execution");
+			for(DataIdentifier v : ip.getIterVar())
+				if( !v.getName().equals( varName)  )
+					LOG.warn(_warnSet.getVariable(varName).printWarningLocation() + "Initialization of " + varName + " depends on for execution");
 		}
 		
 		// Cannot remove kill variables

--- a/src/main/java/org/apache/sysml/parser/IterablePredicate.java
+++ b/src/main/java/org/apache/sysml/parser/IterablePredicate.java
@@ -172,9 +172,11 @@ public class IterablePredicate extends Expression
 			_incrementExpr.validateExpression(ids, constVars, conditional);
 		
 		//check for scalar expression output
-		checkNumericScalarOutput( _fromExpr );
-		checkNumericScalarOutput( _toExpr );
-		checkNumericScalarOutput( _incrementExpr );
+		if(!_isIterVarMatrix) {
+			checkNumericScalarOutput( _fromExpr );
+			checkNumericScalarOutput( _toExpr );
+			checkNumericScalarOutput( _incrementExpr );
+		}
 	}
 		
 	public ArrayList<DataIdentifier> getIterVar() {
@@ -240,15 +242,15 @@ public class IterablePredicate extends Expression
 		if( expr == null || expr.getOutput() == null )
 			return;
 		
-//		Identifier ident = expr.getOutput();
-//		if( ident.getDataType() == DataType.MATRIX || ident.getDataType() == DataType.OBJECT ||
-//			(ident.getDataType() == DataType.SCALAR && (ident.getValueType() == ValueType.BOOLEAN || 
-//					                                    ident.getValueType() == ValueType.STRING || 
-//					                                    ident.getValueType() == ValueType.OBJECT)) )
-//		{
-//			LOG.error(this.printErrorLocation() + "expression in iterable predicate in for loop '" + expr.toString() + "' must return a numeric scalar");
-//			throw new LanguageException(this.printErrorLocation() + "expression in iterable predicate in for loop '" + expr.toString() + "' must return a numeric scalar");
-//		}
+		Identifier ident = expr.getOutput();
+		if( ident.getDataType() == DataType.MATRIX || ident.getDataType() == DataType.OBJECT ||
+			(ident.getDataType() == DataType.SCALAR && (ident.getValueType() == ValueType.BOOLEAN || 
+					                                    ident.getValueType() == ValueType.STRING || 
+					                                    ident.getValueType() == ValueType.OBJECT)) )
+		{
+			LOG.error(this.printErrorLocation() + "expression in iterable predicate in for loop '" + expr.toString() + "' must return a numeric scalar");
+			throw new LanguageException(this.printErrorLocation() + "expression in iterable predicate in for loop '" + expr.toString() + "' must return a numeric scalar");
+		}
 	}
 
 } // end class

--- a/src/main/java/org/apache/sysml/parser/ParForStatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/ParForStatementBlock.java
@@ -1016,13 +1016,15 @@ public class ParForStatementBlock extends ForStatementBlock
 				
 				if( lFlag || rIsParent(sb,this) ) //add only if in subtree of this
 				{
+					String name = ip.getIterVar().get(0)._name;
+					
 					//check for internal names
-					if(   ip.getIterVar()._name.equals( INTERAL_FN_INDEX_ROW )
-					   || ip.getIterVar()._name.equals( INTERAL_FN_INDEX_COL ))
+					if(   name.equals( INTERAL_FN_INDEX_ROW )
+					   || name.equals( INTERAL_FN_INDEX_COL ))
 					{
 						
 						throw new LanguageException(" The iteration variable must not use the " +
-								"internal iteration variable name prefix '"+ip.getIterVar()._name+"'.");
+								"internal iteration variable name prefix '"+name+"'.");
 					}
 					
 					long low = Integer.MIN_VALUE;
@@ -1040,11 +1042,11 @@ public class ParForStatementBlock extends ForStatementBlock
 					else 
 						incr = ( low <= up ) ? 1 : -1;
 
-					_bounds._lower.put(ip.getIterVar()._name, low);
-					_bounds._upper.put(ip.getIterVar()._name, up);
-					_bounds._increment.put(ip.getIterVar()._name, incr);
+					_bounds._lower.put(name, low);
+					_bounds._upper.put(name, up);
+					_bounds._increment.put(name, incr);
 					if( lFlag ) //if local (required for constant check)
-						_bounds._local.add(ip.getIterVar()._name);
+						_bounds._local.add(name);
 				}	
 				
 				//recursive invocation (but not for nested parfors due to constant check)

--- a/src/main/java/org/apache/sysml/parser/dml/Dml.g4
+++ b/src/main/java/org/apache/sysml/parser/dml/Dml.g4
@@ -75,6 +75,7 @@ statement returns [ org.apache.sysml.parser.common.StatementInfo info ]
     // ------------------------------------------
     // ForStatement & ParForStatement
     | 'for' '(' iterVar=ID 'in' iterPred=iterablePredicate (',' parForParams+=strictParameterizedExpression)* ')' (body+=statement ';'* | '{' (body+=statement ';'* )*  '}')  # ForStatement
+    | 'for' '(' '[' iterVars+=ID  ( ',' iterVars+=ID )* ']' 'in' '[' iterPreds+=expression  ( ',' iterPreds+=expression )* ']'  (',' paramExprs+=parameterizedExpression)*  ')' (body+=statement ';'* | '{' (body+=statement ';'* )*  '}')  # IterableForStatement
     // Convert strictParameterizedExpression to HashMap<String, String> for parForParams
     | 'parfor' '(' iterVar=ID 'in' iterPred=iterablePredicate (',' parForParams+=strictParameterizedExpression)* ')' (body+=statement ';'* | '{' (body+=statement ';'*)*  '}')  # ParForStatement
     | 'while' '(' predicate=expression ')' (body+=statement ';'* | '{' (body+=statement ';'*)* '}')  # WhileStatement

--- a/src/main/java/org/apache/sysml/parser/dml/DmlPreprocessor.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlPreprocessor.java
@@ -51,6 +51,7 @@ import org.apache.sysml.parser.dml.DmlParser.IfdefAssignmentStatementContext;
 import org.apache.sysml.parser.dml.DmlParser.ImportStatementContext;
 import org.apache.sysml.parser.dml.DmlParser.IndexedExpressionContext;
 import org.apache.sysml.parser.dml.DmlParser.InternalFunctionDefExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.IterableForStatementContext;
 import org.apache.sysml.parser.dml.DmlParser.IterablePredicateColonExpressionContext;
 import org.apache.sysml.parser.dml.DmlParser.IterablePredicateSeqExpressionContext;
 import org.apache.sysml.parser.dml.DmlParser.MatrixDataTypeCheckContext;
@@ -396,5 +397,11 @@ public class DmlPreprocessor implements DmlListener {
 
 	@Override
 	public void exitMultiIdExpression(MultiIdExpressionContext ctx) {}
+
+	@Override
+	public void enterIterableForStatement(IterableForStatementContext ctx) { }
+	
+	@Override
+	public void exitIterableForStatement(IterableForStatementContext ctx) { }
 
 }

--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -48,6 +48,7 @@ import org.apache.sysml.parser.FunctionStatement;
 import org.apache.sysml.parser.IfStatement;
 import org.apache.sysml.parser.ImportStatement;
 import org.apache.sysml.parser.IndexedIdentifier;
+import org.apache.sysml.parser.IntIdentifier;
 import org.apache.sysml.parser.IterablePredicate;
 import org.apache.sysml.parser.LanguageException;
 import org.apache.sysml.parser.ParForStatement;
@@ -88,6 +89,7 @@ import org.apache.sysml.parser.dml.DmlParser.IfdefAssignmentStatementContext;
 import org.apache.sysml.parser.dml.DmlParser.ImportStatementContext;
 import org.apache.sysml.parser.dml.DmlParser.IndexedExpressionContext;
 import org.apache.sysml.parser.dml.DmlParser.InternalFunctionDefExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.IterableForStatementContext;
 import org.apache.sysml.parser.dml.DmlParser.IterablePredicateColonExpressionContext;
 import org.apache.sysml.parser.dml.DmlParser.IterablePredicateSeqExpressionContext;
 import org.apache.sysml.parser.dml.DmlParser.MatrixDataTypeCheckContext;
@@ -649,6 +651,77 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		ctx.info.stmt = whileStmt;
 		setFileLineColumn(ctx.info.stmt, ctx);
 	}
+	
+	@Override
+	public void exitIterableForStatement(IterableForStatementContext ctx) {
+		ForStatement forStmt = new ForStatement();
+		int line = ctx.start.getLine();
+		int col = ctx.start.getCharPositionInLine();
+		
+		if(ctx.iterVars != null && ctx.iterVars.size() > 0) {
+			if(ctx.iterPreds != null && ctx.iterPreds.size() > 0) {
+				ArrayList<DataIdentifier> iterVars = new ArrayList<DataIdentifier>();
+				for(Token iterVar : ctx.iterVars) {
+					iterVars.add(new DataIdentifier(iterVar.getText()));
+				}
+				ArrayList<Expression> iterPreds = new ArrayList<Expression>();
+				for(ExpressionContext iterPred : ctx.iterPreds) {
+					iterPreds.add(iterPred.info.expr);
+				}
+				if(iterVars.size() != iterPreds.size()) {
+					notifyErrorListeners("invalid syntax: the number of iter variables should match: " + iterVars + " != " + iterPreds, ctx.start);
+				}
+				else if(iterPreds.size() == 0) {
+					notifyErrorListeners("invalid syntax: at minimum, we allow iterating over 1 variables", ctx.start);
+				}
+				else if(iterPreds.size() > 2) {
+					notifyErrorListeners("invalid syntax: at maximum, we allow iterating over two variables", ctx.start);
+				}
+				else {
+					// TODO:
+					HashMap<String, String> parForParamValues = null;
+					forStmt.setAllPositions(currentFile, line, col, line, col);
+					ArrayList<ParameterExpression> paramExpression = getParameterExpressionList(ctx.paramExprs);
+					Expression incrementExpr = null;
+					if(paramExpression == null || paramExpression.size() == 0) {
+						incrementExpr = new IntIdentifier(1, currentFile, line, col, line, col);
+					}
+					else if(paramExpression.size() >= 2) {
+						notifyErrorListeners("invalid syntax: more than 2 parameters not allowed in for", ctx.start);
+					}
+					else {
+						incrementExpr = paramExpression.get(0).getExpr();
+					}
+					
+					IterablePredicate predicate = null;
+					if(iterPreds.size() == 1)
+						predicate = new IterablePredicate(iterVars, iterPreds.get(0), new IntIdentifier(1, currentFile, line, col, line, col), incrementExpr, parForParamValues, currentFile, line, col, line, col, true);
+					else if(iterPreds.size() == 2)
+						predicate = new IterablePredicate(iterVars, iterPreds.get(0), iterPreds.get(1), incrementExpr, parForParamValues, currentFile, line, col, line, col, true);
+					else
+						notifyErrorListeners("invalid syntax: at maximum, we allow iterating over two variables", ctx.start);
+					
+					forStmt.setPredicate(predicate);
+					
+					if(ctx.body.size() > 0) {
+						for(StatementContext stmtCtx : ctx.body) {
+							forStmt.addStatementBlock(getStatementBlock(stmtCtx.info.stmt));
+						}
+						forStmt.mergeStatementBlocks();
+					}
+					ctx.info.stmt = forStmt;
+					setFileLineColumn(ctx.info.stmt, ctx);
+				}
+			}
+			else {
+				notifyErrorListeners("invalid syntax: the matrices to be iterated on cannot be empty", ctx.start);
+			}
+		}
+		else {
+			notifyErrorListeners("invalid syntax: atleast one iteration variable required", ctx.start);
+		}
+		
+	}
 
 	@Override
 	public void exitForStatement(ForStatementContext ctx) {
@@ -657,12 +730,15 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		int col = ctx.start.getCharPositionInLine();
 
 		DataIdentifier iterVar = new DataIdentifier(ctx.iterVar.getText());
+		ArrayList<DataIdentifier> iterVars = new ArrayList<DataIdentifier>(); 
+		iterVars.add(iterVar);
+		
 		HashMap<String, String> parForParamValues = null;
 		Expression incrementExpr = null; //1/-1
 		if(ctx.iterPred.info.increment != null) {
 			incrementExpr = ctx.iterPred.info.increment;
 		}
-		IterablePredicate predicate = new IterablePredicate(iterVar, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col);
+		IterablePredicate predicate = new IterablePredicate(iterVars, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col, false);
 		forStmt.setPredicate(predicate);
 
 		if(ctx.body.size() > 0) {
@@ -682,6 +758,9 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		int col = ctx.start.getCharPositionInLine();
 
 		DataIdentifier iterVar = new DataIdentifier(ctx.iterVar.getText());
+		ArrayList<DataIdentifier> iterVars = new ArrayList<DataIdentifier>(); 
+		iterVars.add(iterVar);
+		
 		HashMap<String, String> parForParamValues = new HashMap<String, String>();
 		if(ctx.parForParams != null && ctx.parForParams.size() > 0) {
 			for(StrictParameterizedExpressionContext parForParamCtx : ctx.parForParams) {
@@ -693,7 +772,7 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		if( ctx.iterPred.info.increment != null ) {
 			incrementExpr = ctx.iterPred.info.increment;
 		}
-		IterablePredicate predicate = new IterablePredicate(iterVar, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col);
+		IterablePredicate predicate = new IterablePredicate(iterVars, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col, false);
 		parForStmt.setPredicate(predicate);
 		if(ctx.body.size() > 0) {
 			for(StatementContext stmtCtx : ctx.body) {
@@ -1056,5 +1135,10 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		}
 		ctx.info.expr = new ExpressionList(values);
 	}
+
+	@Override
+	public void enterIterableForStatement(IterableForStatementContext ctx) { }
+
+	
 
 }

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -1325,12 +1325,15 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		int col = ctx.start.getCharPositionInLine();
 
 		DataIdentifier iterVar = new DataIdentifier(ctx.iterVar.getText());
+		ArrayList<DataIdentifier> iterVars = new ArrayList<DataIdentifier>(); 
+		iterVars.add(iterVar);
+		
 		HashMap<String, String> parForParamValues = null;
 		Expression incrementExpr = null; //1/-1
 		if(ctx.iterPred.info.increment != null) {
 			incrementExpr = ctx.iterPred.info.increment;
 		}
-		IterablePredicate predicate = new IterablePredicate(iterVar, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col);
+		IterablePredicate predicate = new IterablePredicate(iterVars, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col, false);
 		forStmt.setPredicate(predicate);
 
 		if(ctx.body.size() > 0) {
@@ -1350,6 +1353,9 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		int col = ctx.start.getCharPositionInLine();
 
 		DataIdentifier iterVar = new DataIdentifier(ctx.iterVar.getText());
+		ArrayList<DataIdentifier> iterVars = new ArrayList<DataIdentifier>(); 
+		iterVars.add(iterVar);
+		
 		HashMap<String, String> parForParamValues = new HashMap<String, String>();
 		if(ctx.parForParams != null && ctx.parForParams.size() > 0) {
 			for(StrictParameterizedExpressionContext parForParamCtx : ctx.parForParams) {
@@ -1361,7 +1367,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		if( ctx.iterPred.info.increment != null ) {
 			incrementExpr = ctx.iterPred.info.increment;
 		}
-		IterablePredicate predicate = new IterablePredicate(iterVar, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col);
+		IterablePredicate predicate = new IterablePredicate(iterVars, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col, false);
 		parForStmt.setPredicate(predicate);
 		if(ctx.body.size() > 0) {
 			for(StatementContext stmtCtx : ctx.body) {

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ForProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ForProgramBlock.java
@@ -28,8 +28,12 @@ import org.apache.sysml.parser.ForStatementBlock;
 import org.apache.sysml.parser.Expression.ValueType;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.DMLScriptException;
+import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysml.runtime.controlprogram.caching.MatrixObject.UpdateType;
 import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysml.runtime.controlprogram.context.SparkExecutionContext;
+import org.apache.sysml.runtime.controlprogram.util.CPBatchIterator;
+import org.apache.sysml.runtime.controlprogram.util.SPBatchIterator;
 import org.apache.sysml.runtime.instructions.Instruction;
 import org.apache.sysml.runtime.instructions.cp.Data;
 import org.apache.sysml.runtime.instructions.cp.IntObject;
@@ -116,16 +120,34 @@ public class ForProgramBlock extends ProgramBlock
 	{
 		// add the iterable predicate variable to the variable set
 		String iterVarName = _iterablePredicateVars[0];
-
-		// evaluate from, to, incr only once (assumption: known at for entry)
-		IntObject from = executePredicateInstructions( 1, _fromInstructions, ec );
-		IntObject to   = executePredicateInstructions( 2, _toInstructions, ec );
-		IntObject incr = (_incrementInstructions == null || _incrementInstructions.isEmpty()) && _iterablePredicateVars[3]==null ? 
-				new IntObject((from.getLongValue()<=to.getLongValue()) ? 1 : -1) :
-				executePredicateInstructions( 3, _incrementInstructions, ec );
 		
-		if ( incr.getLongValue() == 0 ) //would produce infinite loop
-			throw new DMLRuntimeException(this.printBlockErrorLocation() + "Expression for increment of variable '" + iterVarName + "' must evaluate to a non-zero value.");
+		Iterable<Data> genericIterator = null;
+				
+		if( _iterablePredicateVars[1] != null ) {
+			//probe for matrix variables
+			Data ldat = ec.getVariable( _iterablePredicateVars[1] );
+			if( ldat != null && ldat instanceof MatrixObject ) {
+				// Iterable for loop
+				if(ec instanceof SparkExecutionContext) {
+					genericIterator = (Iterable<Data>) (new SPBatchIterator(ec, _iterablePredicateVars));
+				}
+				else {
+					genericIterator = (Iterable<Data>)(new CPBatchIterator(ec, _iterablePredicateVars));
+				}
+			}
+		}		
+
+		if(genericIterator == null) {
+			// evaluate from, to, incr only once (assumption: known at for entry)
+			IntObject from = executePredicateInstructions( 1, _fromInstructions, ec );
+			IntObject to   = executePredicateInstructions( 2, _toInstructions, ec );
+			IntObject incr = (_incrementInstructions == null || _incrementInstructions.isEmpty()) && _iterablePredicateVars[3]==null ? 
+					new IntObject((from.getLongValue()<=to.getLongValue()) ? 1 : -1) :
+					executePredicateInstructions( 3, _incrementInstructions, ec );
+			if ( incr.getLongValue() == 0 ) //would produce infinite loop
+				throw new DMLRuntimeException(this.printBlockErrorLocation() + "Expression for increment of variable '" + iterVarName + "' must evaluate to a non-zero value.");
+			genericIterator = (Iterable<Data>)(new SequenceIterator(iterVarName, from, to, incr));
+		}
 		
 		// execute for loop
 		try 
@@ -133,10 +155,8 @@ public class ForProgramBlock extends ProgramBlock
 			// prepare update in-place variables
 			UpdateType[] flags = prepareUpdateInPlaceVariables(ec, _tid);
 			
-			// run for loop body for each instance of predicate sequence 
-			SequenceIterator seqIter = new SequenceIterator(iterVarName, from, to, incr);
-			for( IntObject iterVar : seqIter ) 
-			{
+			// run for loop body for each instance of predicate sequence
+			for( Data iterVar : genericIterator )  {
 				//set iteration variable
 				ec.setVariable(iterVarName, iterVar); 
 				
@@ -238,7 +258,7 @@ public class ForProgramBlock extends ProgramBlock
 	/**
 	 * Utility class for iterating over positive or negative predicate sequences.
 	 */
-	protected class SequenceIterator implements Iterator<IntObject>, Iterable<IntObject>
+	protected class SequenceIterator implements Iterator<Data>, Iterable<Data>
 	{
 		private String _varName = null;
 		private long _cur = -1;
@@ -266,7 +286,7 @@ public class ForProgramBlock extends ProgramBlock
 		}
 
 		@Override
-		public Iterator<IntObject> iterator() {
+		public Iterator<Data> iterator() {
 			if( _inuse )
 				throw new RuntimeException("Unsupported reuse of iterator.");				
 			_inuse = true;

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/util/CPBatchIterator.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/util/CPBatchIterator.java
@@ -1,0 +1,35 @@
+package org.apache.sysml.runtime.controlprogram.util;
+
+import java.util.Iterator;
+
+import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
+import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysml.runtime.instructions.cp.Data;
+
+// TODO: Before I go ahead an implement prefetching with this approach
+// I want to ensure if this functionality is OK with everyone
+public class CPBatchIterator implements Iterator<Data>, Iterable<Data> {
+	
+	public CPBatchIterator(ExecutionContext ec, String[] iterablePredicateVars) {
+		
+	}
+
+	@Override
+	public Iterator<Data> iterator() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean hasNext() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public MatrixObject next() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/util/SPBatchIterator.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/util/SPBatchIterator.java
@@ -1,0 +1,10 @@
+package org.apache.sysml.runtime.controlprogram.util;
+
+import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+
+//TODO:
+public class SPBatchIterator extends CPBatchIterator {
+	public SPBatchIterator(ExecutionContext ec, String[] iterablePredicateVars) {
+		super(ec, iterablePredicateVars);
+	}
+}

--- a/src/test/java/org/apache/sysml/test/integration/functions/parfor/ForLoopPredicateTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/parfor/ForLoopPredicateTest.java
@@ -38,6 +38,7 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 	private final static String TEST_NAME5 = "for_pred3a"; //expression
 	private final static String TEST_NAME6 = "for_pred3b"; //expression seq
 	private final static String TEST_NAME7 = "for_pred1a_seq"; //const seq two parameters (this tests is only for parser)
+	private final static String TEST_NAME8 = "for_iterator1"; //iterator
 	private final static String TEST_DIR = "functions/parfor/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + ForLoopPredicateTest.class.getSimpleName() + "/";
 	
@@ -55,6 +56,7 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5, new String[]{"R"}));
 		addTestConfiguration(TEST_NAME6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6, new String[]{"R"}));
 		addTestConfiguration(TEST_NAME7, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME7, new String[]{"R"}));
+		addTestConfiguration(TEST_NAME8, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME8, new String[]{"R"}));
 	}
 
 	@Test
@@ -112,6 +114,12 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 	}
 	
 	@Test
+	public void testForIterator1() 
+	{
+		runForPredicateTest(8, false);
+	}
+	
+	@Test
 	public void testForConstDoubleSeqPredicate() 
 	{
 		runForPredicateTest(2, false);
@@ -158,6 +166,7 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 			case 5: TEST_NAME = TEST_NAME5; break;
 			case 6: TEST_NAME = TEST_NAME6; break;
 			case 7: TEST_NAME = TEST_NAME7; break;
+			case 8: TEST_NAME = TEST_NAME8; break;
 		}
 		
 		getAndLoadTestConfiguration(TEST_NAME);

--- a/src/test/scripts/functions/parfor/for_iterator1.dml
+++ b/src/test/scripts/functions/parfor/for_iterator1.dml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+sum = 0;
+X = matrix(seq(1, 9), rows=3, cols=3);
+for( [ Xb ] in [ X ] ) 
+{
+   sum = sum + sum(Xb); 
+}  
+
+R = matrix(1, rows=1, cols=1);
+R = R * sum;
+write(R, $4);       


### PR DESCRIPTION
@mboehm7 @bertholdreinwald @dusenberrymw  To avoid wasting time, I have created this PR to allow committers to raise their concerns about the integration of this approach before we spend a week or two in this direction, rather than when the work is complete. 

The high-level proposal is to extend our for loop to iterate over the rows of matrix as follows:
```python
for( [Xb, yb] in [X, y], batch_size=64) {
  ....
}
```

This construct allows us to perform low-level optimization such as prefetching of blocks without requiring the user to do so via explicit udf `next_batch(X, batch_size=64)`. 

To support this construct without overhauling the engine, we support at max two iterator variables. This allows us to use our existing [IterablePredicate](https://github.com/niketanpansare/incubator-systemml/blob/d94c8799b13682c53bdacdbb876559c4c251332d/src/main/java/org/apache/sysml/parser/IterablePredicate.java) construct. In addition, we have extended [ForProgramBlock](https://github.com/niketanpansare/incubator-systemml/blob/d94c8799b13682c53bdacdbb876559c4c251332d/src/main/java/org/apache/sysml/runtime/controlprogram/ForProgramBlock.java#L132) to support iterating over MatrixObject rather than IntObject.

The alternative to this approach are as follows:
1. The user specifies the prefetch budget (let's say 1G or 10%) and we reserve that for SP/CP `next_batch(X, batch_size=64)`.
2. Refactor breast cancer script to fetch batches in two step: First we extract a big_mini_batch which will likely be a SP Indexing instruction that generates a MatrixBlock which can fit in CP. Then, in a for loop, we perform CP indexing on it.

I will hold off on making progress in this PR until we all agree on this approach.

**PLEASE DONOT MERGE THIS PR YET**