### PR TITLE
[SYSTEMML-1155] Use artifact versions from parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.4</version><!--$NO-MVN-MAN-VER$-->
 				<executions>
 					<execution>
 						<id>unpack</id>
@@ -249,13 +248,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.4</version><!--$NO-MVN-MAN-VER$-->
 				<configuration>
 					<archive>
 						<index>true</index>
-						<!-- <manifest> -->
-						<!-- <addClasspath>true</addClasspath> -->
-						<!-- </manifest> -->
 						<manifestEntries>
 							<Build-Timestamp>${maven.build.timestamp}</Build-Timestamp>
 							<Main-Class>org.apache.sysml.api.DMLScript</Main-Class>
@@ -395,7 +390,6 @@
 
 			<plugin>
 				<artifactId>maven-clean-plugin</artifactId>
-				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>clean-original-jar</id>
@@ -502,7 +496,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.8</version>
 				<executions>
 					<execution>
 						<id>copy</id>


### PR DESCRIPTION
Use Apache parent pom artifact versions for maven-dependency-plugin, maven-jar-plugin, maven-clean-plugin, and maven-antrun-plugin.

Did not switch versions for maven-surefire-plugin and maven-failsafe-plugin since switching these with existing plugin configurations resulted in slower test suite run times.
