### PR TITLE
[SYSTEMML-1197] Eliminates collision of regularization and tolerance parameters

### DIFF
--- a/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLClassifier.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLClassifier.scala
@@ -60,7 +60,7 @@ trait HasTol extends Params {
   final def getTol: Double = $(tol)
 }
 trait HasRegParam extends Params {
-  final val regParam: DoubleParam = new DoubleParam(this, "tol", "the convergence tolerance for iterative algorithms")
+  final val regParam: DoubleParam = new DoubleParam(this, "regParam", "regularization parameter")
   setDefault(regParam, 0.000001)
   final def getRegParam: Double = $(regParam)
 }


### PR DESCRIPTION
Behavior post-fix (behaves as expected):

scala> val lr = new LogisticRegression("logReg", sc)
lr: org.apache.sysml.api.ml.LogisticRegression = logReg

scala> lr.setTol(0.1)
res1: org.apache.sysml.api.ml.LogisticRegression = logReg

scala> lr.getTol
res2: Double = 0.1

scala> lr.getRegParam
res3: Double = 1.0E-6

scala> lr.setRegParam(0.12345)
res4: org.apache.sysml.api.ml.LogisticRegression = logReg

scala> lr.getRegParam
res5: Double = 0.12345

scala> lr.getTol
res6: Double = 0.1