### PR TITLE
[SYSTEMML-1222] MLContext input long to int cast

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
@@ -247,7 +247,7 @@ public final class MLContextUtil {
 			}
 		}
 		if (!supported) {
-			throw new MLContextException("Input name (\"" + value + "\") value type not supported: " + o.getClass());
+			throw new MLContextException("Input name (\"" + name + "\") value type not supported: " + o.getClass());
 		}
 	}
 

--- a/src/main/java/org/apache/sysml/api/mlcontext/Script.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/Script.java
@@ -319,6 +319,12 @@ public class Script {
 	 * @return {@code this} Script object to allow chaining of methods
 	 */
 	public Script in(String name, Object value, Metadata metadata) {
+
+		if ((value != null) && (value instanceof Long)) {
+			// convert Long to Integer since Long not a supported value type
+			value = (int) (long) value;
+		}
+
 		MLContextUtil.checkInputValueType(name, value);
 		if (inputs == null) {
 			inputs = new LinkedHashMap<String, Object>();

--- a/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
@@ -2507,6 +2507,26 @@ public class MLContextTest extends AutomatedTestBase {
 		ml.execute(script);
 	}
 
+	@Test
+	public void testInputVariablesAddLongsDML() {
+		System.out.println("MLContextTest - input variables add longs DML");
+
+		String s = "print('x + y = ' + (x + y));";
+		Script script = dml(s).in("x", 3L).in("y", 4L);
+		setExpectedStdOut("x + y = 7");
+		ml.execute(script);
+	}
+
+	@Test
+	public void testInputVariablesAddLongsPYDML() {
+		System.out.println("MLContextTest - input variables add longs PYDML");
+
+		String s = "print('x + y = ' + (x + y))";
+		Script script = pydml(s).in("x", 3L).in("y", 4L);
+		setExpectedStdOut("x + y = 7");
+		ml.execute(script);
+	}
+
 	// NOTE: Uncomment these tests once they work
 
 	// @SuppressWarnings({ "rawtypes", "unchecked" })


### PR DESCRIPTION
Convert MLContext long input to int since long not a supported value type.
Fix input value type error message to display input name rather than value.