### PR TITLE
[SYSTEMML-951] Remove unnecessary reblock of binary blocks

### DIFF
--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteBlockSizeAndReblock.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteBlockSizeAndReblock.java
@@ -73,7 +73,6 @@ public class RewriteBlockSizeAndReblock extends HopRewriteRule
 				// Donot reblock if the data is read as preblocked binary blocks.
 				canReblock = false;
 			}
-			System.out.println(">>" + canReblock + " " + dop.getDataOpType().name() + " " + dop.getInputFormatType().name());
 		}
 		if(canReblock)
 			rule_BlockSizeAndReblock(h, blockSize);

--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteBlockSizeAndReblock.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteBlockSizeAndReblock.java
@@ -62,6 +62,7 @@ public class RewriteBlockSizeAndReblock extends HopRewriteRule
 		return roots;
 	}
 	
+	// ALternatively, we can move this to rule_BlockSizeAndReblock
 	private void applyRuleBlockSizeAndReblock(Hop h, int blockSize) throws HopsException {
 		boolean canReblock = true;
 		if ( h instanceof DataOp ) {


### PR DESCRIPTION
Currently, we always force the reblocking of binary blocks into squared 1K x 1K. Though allowing 1K x 1K block size by default is a good decision, we should allow expert users to reblock the binary block to a non-squared blocks or blocks of different sizes (without changing the default block size). In this case, if SystemML reads the data in binary block format, we should respect the original blocking.

@bertholdreinwald @mboehm7 @dusenberrymw 