### PR TITLE
[SYSTEMML-1228] Fix SparkListener to work with Spark 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 	<properties>
 		<hadoop.version>2.4.1</hadoop.version>
 		<antlr.version>4.5.3</antlr.version>
-		<spark.version>2.0.2</spark.version>
+		<spark.version>2.1.0</spark.version>
 		<scala.version>2.11.8</scala.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<scala.test.version>2.2.6</scala.test.version>

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/SparkListener.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/SparkListener.java
@@ -26,11 +26,13 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.spark.SparkContext;
+import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.scheduler.SparkListenerExecutorMetricsUpdate;
 import org.apache.spark.scheduler.SparkListenerStageCompleted;
 import org.apache.spark.scheduler.SparkListenerStageSubmitted;
 import org.apache.spark.storage.RDDInfo;
 import org.apache.spark.ui.jobs.StagesTab;
+import org.apache.spark.ui.jobs.UIData;
 import org.apache.spark.ui.jobs.UIData.TaskUIData;
 import org.apache.spark.ui.scope.RDDOperationGraphListener;
 import org.apache.sysml.api.MLContextProxy;
@@ -120,7 +122,7 @@ public class SparkListener extends RDDOperationGraphListener {
 			stageTaskMapping.put(stageID, new ArrayList<TaskUIData>());
 		}
 		
-		Option<org.apache.spark.ui.scope.RDDOperationGraph> rddOpGraph = Option.apply(org.apache.spark.ui.scope.RDDOperationGraph.makeOperationGraph(stageSubmitted.stageInfo()));
+		Option<org.apache.spark.ui.scope.RDDOperationGraph> rddOpGraph = Option.apply(org.apache.spark.ui.scope.RDDOperationGraph.makeOperationGraph(stageSubmitted.stageInfo(), Integer.MAX_VALUE));
 		
 		Iterator<RDDInfo> iter = stageSubmitted.stageInfo().rddInfos().toList().toIterator();
 		ArrayList<Integer> rddIDs = new ArrayList<Integer>();
@@ -174,7 +176,7 @@ public class SparkListener extends RDDOperationGraphListener {
 			if(stageTaskMapping.containsKey(stageID)) {
 				//Option<String> errorMessage = Option.apply(null); // TODO
 				//TaskUIData taskData = new TaskUIData(taskEnd.taskInfo(), Option.apply(taskEnd.taskMetrics()), errorMessage);
-				TaskUIData taskData = new TaskUIData(taskEnd.taskInfo(), null); //TODO
+				TaskUIData taskData = UIData.TaskUIData$.MODULE$.apply(taskEnd.taskInfo(), Option.<TaskMetrics>empty()); //TODO
 				stageTaskMapping.get(stageID).add(taskData);
 			}
 			else {


### PR DESCRIPTION
This PR sets the Spark version in the pom.xml to 2.1 and updates the SparkListener to work with Spark 2.1.

The `makeOperationGraph` method now takes a parameter for the number of nodes retained which I set to Integer.MAX_LEVEL, which should retain all nodes. I wasn't sure what the best number should be here...