### PR TITLE
[SYSTEMML-1233] Deprecate old MLContext API

### DIFF
--- a/src/main/java/org/apache/sysml/api/MLBlock.java
+++ b/src/main/java/org/apache/sysml/api/MLBlock.java
@@ -34,6 +34,10 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 
 import scala.collection.Seq;
 
+/**
+ * @deprecated This will be removed in SystemML 1.0. Please migrate to {@link org.apache.sysml.api.mlcontext.MLContext}
+ */
+@Deprecated
 public class MLBlock implements Row {
 
 	private static final long serialVersionUID = -770986277854643424L;

--- a/src/main/java/org/apache/sysml/api/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/MLContext.java
@@ -93,10 +93,6 @@ import org.apache.sysml.utils.Explain.ExplainCounts;
 import org.apache.sysml.utils.Statistics;
 
 /**
- * The MLContext API has been redesigned and this API will be deprecated.
- * Please migrate to {@link org.apache.sysml.api.mlcontext.MLContext}.
- * <p>
- * 
  * MLContext is useful for passing RDDs as input/output to SystemML. This API avoids the need to read/write
  * from HDFS (which is another way to pass inputs to SystemML).
  * <p>
@@ -179,7 +175,10 @@ import org.apache.sysml.utils.Statistics;
  * <pre><code>  
  * synchronized(MLContext.class) { ml.execute(...); }
  * </code></pre>
+ * 
+ * @deprecated This will be removed in SystemML 1.0. Please migrate to {@link org.apache.sysml.api.mlcontext.MLContext}
  */
+@Deprecated
 public class MLContext {
 	
 	// ----------------------------------------------------

--- a/src/main/java/org/apache/sysml/api/MLContextProxy.java
+++ b/src/main/java/org/apache/sysml/api/MLContextProxy.java
@@ -48,6 +48,7 @@ public class MLContextProxy
 		return _active;
 	}
 
+	@SuppressWarnings("deprecation")
 	public static ArrayList<Instruction> performCleanupAfterRecompilation(ArrayList<Instruction> tmp) 
 	{
 		if(org.apache.sysml.api.MLContext.getActiveMLContext() != null) {
@@ -58,6 +59,7 @@ public class MLContextProxy
 		return tmp;
 	}
 
+	@SuppressWarnings("deprecation")
 	public static void setAppropriateVarsForRead(Expression source, String targetname) 
 		throws LanguageException 
 	{
@@ -68,6 +70,7 @@ public class MLContextProxy
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	public static Object getActiveMLContext() {
 		if (org.apache.sysml.api.MLContext.getActiveMLContext() != null) {
 			return org.apache.sysml.api.MLContext.getActiveMLContext();
@@ -85,6 +88,7 @@ public class MLContextProxy
 				+ "Hint: in Scala, 'val ml = new MLContext(sc)'", true);
 	}
 
+	@SuppressWarnings("deprecation")
 	public static void setInstructionForMonitoring(Instruction inst) {
 		Location loc = inst.getLocation();
 		if (loc == null) {
@@ -104,6 +108,7 @@ public class MLContextProxy
 		}
 	}
 	
+	@SuppressWarnings("deprecation")
 	public static void addRDDForInstructionForMonitoring(SPInstruction inst, Integer rddID) {
 		
 		if (org.apache.sysml.api.MLContext.getActiveMLContext() != null) {

--- a/src/main/java/org/apache/sysml/api/MLMatrix.java
+++ b/src/main/java/org/apache/sysml/api/MLMatrix.java
@@ -62,7 +62,9 @@ import scala.Tuple2;
  val result = mat1.transpose() %*% mat2
  result.write("Result_small.mtx", "text")
  
+ * @deprecated This will be removed in SystemML 1.0. Please migrate to {@link org.apache.sysml.api.mlcontext.MLContext}
  */
+@Deprecated
 public class MLMatrix extends Dataset<Row> {
 	private static final long serialVersionUID = -7005940673916671165L;
 	

--- a/src/main/java/org/apache/sysml/api/MLOutput.java
+++ b/src/main/java/org/apache/sysml/api/MLOutput.java
@@ -42,7 +42,10 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 /**
  * This is a simple container object that returns the output of execute from MLContext 
  *
+ * @deprecated This will be removed in SystemML 1.0. Please migrate to {@link org.apache.sysml.api.mlcontext.MLContext}
+ * and {@link org.apache.sysml.api.mlcontext.MLResults}
  */
+@Deprecated
 public class MLOutput {
 	
 	Map<String, JavaPairRDD<?,?>> _outputs;

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/context/SparkExecutionContext.java
@@ -170,6 +170,7 @@ public class SparkExecutionContext extends ExecutionContext
 		return LAZY_SPARKCTX_CREATION;
 	}
 
+	@SuppressWarnings("deprecation")
 	private synchronized static void initSparkContext()
 	{
 		//check for redundant spark context init
@@ -1293,6 +1294,7 @@ public class SparkExecutionContext extends ExecutionContext
 	// The most expensive operation here is rdd.toDebugString() which can be a major hit because
 	// of unrolling lazy evaluation of Spark. Hence, it is guarded against it along with flag 'PRINT_EXPLAIN_WITH_LINEAGE' which is 
 	// enabled only through MLContext. This way, it doesnot affect our performance evaluation through non-MLContext path
+	@SuppressWarnings("deprecation")
 	private void setLineageInfoForExplain(SPInstruction inst, 
 			JavaPairRDD<?, ?> out, 
 			JavaPairRDD<?, ?> in1, String in1Name, 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/SPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/SPInstruction.java
@@ -76,6 +76,7 @@ public abstract class SPInstruction extends Instruction
 		return getOpcode();
 	}
 	
+	@SuppressWarnings("deprecation")
 	@Override
 	public Instruction preprocessInstruction(ExecutionContext ec)
 		throws DMLRuntimeException 
@@ -120,6 +121,7 @@ public abstract class SPInstruction extends Instruction
 	public abstract void processInstruction(ExecutionContext ec)
 			throws DMLRuntimeException;
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void postprocessInstruction(ExecutionContext ec)
 			throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/GetMLBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/GetMLBlock.java
@@ -30,6 +30,7 @@ import org.apache.sysml.api.MLBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 
+@SuppressWarnings("deprecation")
 public class GetMLBlock implements Function<Tuple2<MatrixIndexes,MatrixBlock>, Row>, Serializable {
 
 	private static final long serialVersionUID = 8829736765002126985L;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/SparkListener.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/functions/SparkListener.java
@@ -84,6 +84,7 @@ public class SparkListener extends RDDOperationGraphListener {
 	}
 	
 	
+	@SuppressWarnings("deprecation")
 	@Override
 	public void onJobEnd(org.apache.spark.scheduler.SparkListenerJobEnd jobEnd) {
 		super.onJobEnd(jobEnd);
@@ -110,6 +111,7 @@ public class SparkListener extends RDDOperationGraphListener {
 		}
 	}
 	
+	@SuppressWarnings("deprecation")
 	@Override
 	public void onStageSubmitted(SparkListenerStageSubmitted stageSubmitted) {
 		super.onStageSubmitted(stageSubmitted);

--- a/src/test/java/org/apache/sysml/test/integration/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysml/test/integration/AutomatedTestBase.java
@@ -78,6 +78,7 @@ import org.apache.sysml.utils.Statistics;
  * </ul>
  * 
  */
+@SuppressWarnings("deprecation")
 public abstract class AutomatedTestBase 
 {
 	

--- a/src/test/java/org/apache/sysml/test/integration/functions/mlcontext/FrameTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/mlcontext/FrameTest.java
@@ -62,6 +62,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 
+@SuppressWarnings("deprecation")
 public class FrameTest extends AutomatedTestBase 
 {
 	private final static String TEST_DIR = "functions/frame/";

--- a/src/test/java/org/apache/sysml/test/integration/functions/mlcontext/GNMFTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/mlcontext/GNMFTest.java
@@ -57,6 +57,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+@SuppressWarnings("deprecation")
 @RunWith(value = Parameterized.class)
 public class GNMFTest extends AutomatedTestBase 
 {


### PR DESCRIPTION
Deprecate old MLContext API, to be removed in SystemML 1.0.
Ignore references to deprecated MLContext classes in project.