### PR TITLE
[SYSTEMML-1237] Add input float support to MLContext

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/Script.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/Script.java
@@ -324,6 +324,10 @@ public class Script {
 			// convert Long to Integer since Long not a supported value type
 			Long lng = (Long) value;
 			value = lng.intValue();
+		} else if ((value != null) && (value instanceof Float)) {
+			// convert Float to Double since Float not a supported value type
+			Float flt = (Float) value;
+			value = flt.doubleValue();
 		}
 
 		MLContextUtil.checkInputValueType(name, value);

--- a/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
@@ -2527,6 +2527,26 @@ public class MLContextTest extends AutomatedTestBase {
 		ml.execute(script);
 	}
 
+	@Test
+	public void testInputVariablesAddFloatsDML() {
+		System.out.println("MLContextTest - input variables add floats DML");
+
+		String s = "print('x + y = ' + (x + y));";
+		Script script = dml(s).in("x", 3F).in("y", 4F);
+		setExpectedStdOut("x + y = 7.0");
+		ml.execute(script);
+	}
+
+	@Test
+	public void testInputVariablesAddFloatsPYDML() {
+		System.out.println("MLContextTest - input variables add floats PYDML");
+
+		String s = "print('x + y = ' + (x + y))";
+		Script script = pydml(s).in("x", 3F).in("y", 4F);
+		setExpectedStdOut("x + y = 7.0");
+		ml.execute(script);
+	}
+
 	// NOTE: Uncomment these tests once they work
 
 	// @SuppressWarnings({ "rawtypes", "unchecked" })


### PR DESCRIPTION
Implicitly cast float to double in in(String, Object, Metadata) method
of Script class.