### PR TITLE
[SYSTEMML-1160] [WIP] Enable prefetching of batches via for loop iterator

### DIFF
--- a/src/main/java/org/apache/sysml/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysml/conf/DMLConfig.java
@@ -76,6 +76,7 @@ public class DMLConfig
 	public static final String GPU_MEMORY_UTILIZATION_FACTOR    = "gpu.memory.util.factor";
 	// Invoke cudaMemGetInfo to get available memory information. Useful if GPU is shared among multiple application.
 	public static final String REFRESH_AVAILABLE_MEMORY_EVERY_TIME    = "gpu.memory.refresh";
+	public static final String PREFETCH_MEM_BUDGET    = "prefetch.budget.mb";
 
 	// supported prefixes for custom map/reduce configurations
 	public static final String PREFIX_MAPRED = "mapred";
@@ -109,6 +110,7 @@ public class DMLConfig
 		_defaultVals.put(COMPRESSED_LINALG,      "false" );
 		_defaultVals.put(GPU_MEMORY_UTILIZATION_FACTOR,      "0.9" );
 		_defaultVals.put(REFRESH_AVAILABLE_MEMORY_EVERY_TIME,      "true" );
+		_defaultVals.put(PREFETCH_MEM_BUDGET,      "0" );
 	}
 	
 	public DMLConfig()

--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteForLoopVectorization.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteForLoopVectorization.java
@@ -64,25 +64,27 @@ public class RewriteForLoopVectorization extends StatementBlockRewriteRule
 		if( sb instanceof ForStatementBlock )
 		{
 			ForStatementBlock fsb = (ForStatementBlock) sb;
-			ForStatement fs = (ForStatement) fsb.getStatement(0);
-			Hop from = fsb.getFromHops();
-			Hop to = fsb.getToHops();
-			Hop incr = fsb.getIncrementHops();
-			String iterVar = fsb.getIterPredicate().getIterVar().getName();
-			
-			if( fs.getBody()!=null && fs.getBody().size()==1 ) //single child block
-			{
-				StatementBlock csb = (StatementBlock) fs.getBody().get(0);
-				if( !(   csb instanceof WhileStatementBlock  //last level block
-					  || csb instanceof IfStatementBlock 
-					  || csb instanceof ForStatementBlock ) )
+			if(fsb.getIterPredicate().getIterVar().size() == 1) {
+				ForStatement fs = (ForStatement) fsb.getStatement(0);
+				Hop from = fsb.getFromHops();
+				Hop to = fsb.getToHops();
+				Hop incr = fsb.getIncrementHops();
+				String iterVar = fsb.getIterPredicate().getIterVar().get(0).getName();
+				
+				if( fs.getBody()!=null && fs.getBody().size()==1 ) //single child block
 				{
-					//auto vectorization pattern
-					sb = vectorizeScalarAggregate(sb, csb, from, to, incr, iterVar);           //e.g., for(i){s = s + as.scalar(X[i,2])}
-					sb = vectorizeElementwiseBinary(sb, csb, from, to, incr, iterVar);
-					sb = vectorizeElementwiseUnary(sb, csb, from, to, incr, iterVar);
-				}	
-			}	
+					StatementBlock csb = (StatementBlock) fs.getBody().get(0);
+					if( !(   csb instanceof WhileStatementBlock  //last level block
+						  || csb instanceof IfStatementBlock 
+						  || csb instanceof ForStatementBlock ) )
+					{
+						//auto vectorization pattern
+						sb = vectorizeScalarAggregate(sb, csb, from, to, incr, iterVar);           //e.g., for(i){s = s + as.scalar(X[i,2])}
+						sb = vectorizeElementwiseBinary(sb, csb, from, to, incr, iterVar);
+						sb = vectorizeElementwiseUnary(sb, csb, from, to, incr, iterVar);
+					}	
+				}
+			}
 		}	
 		
 		//if no rewrite applied sb is the original for loop otherwise a last level statement block

--- a/src/main/java/org/apache/sysml/parser/DMLProgram.java
+++ b/src/main/java/org/apache/sysml/parser/DMLProgram.java
@@ -379,7 +379,7 @@ public class DMLProgram
 			String sbName = null;
 			ForProgramBlock rtpb = null;
 			IterablePredicate iterPred = fsb.getIterPredicate();
-			String [] iterPredData= IterablePredicate.createIterablePredicateVariables(iterPred.getIterVar().getName(),
+			String [] iterPredData= IterablePredicate.createIterablePredicateVariables(iterPred.getIterVar(),
 					                                                                   fsb.getFromLops(), fsb.getToLops(), fsb.getIncrementLops()); 
 			
 			if( sb instanceof ParForStatementBlock )

--- a/src/main/java/org/apache/sysml/parser/ForStatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/ForStatementBlock.java
@@ -332,8 +332,9 @@ public class ForStatementBlock extends StatementBlock
 		
 		// for now just print the warn set
 		for (String varName : _warnSet.getVariableNames()) {
-			if( !ip.getIterVar().getName().equals( varName)  )
-				LOG.warn(_warnSet.getVariable(varName).printWarningLocation() + "Initialization of " + varName + " depends on for execution");
+			for(DataIdentifier v : ip.getIterVar())
+				if( !v.getName().equals( varName)  )
+					LOG.warn(_warnSet.getVariable(varName).printWarningLocation() + "Initialization of " + varName + " depends on for execution");
 		}
 		
 		// Cannot remove kill variables

--- a/src/main/java/org/apache/sysml/parser/IterablePredicate.java
+++ b/src/main/java/org/apache/sysml/parser/IterablePredicate.java
@@ -172,9 +172,11 @@ public class IterablePredicate extends Expression
 			_incrementExpr.validateExpression(ids, constVars, conditional);
 		
 		//check for scalar expression output
-		checkNumericScalarOutput( _fromExpr );
-		checkNumericScalarOutput( _toExpr );
-		checkNumericScalarOutput( _incrementExpr );
+		if(!_isIterVarMatrix) {
+			checkNumericScalarOutput( _fromExpr );
+			checkNumericScalarOutput( _toExpr );
+			checkNumericScalarOutput( _incrementExpr );
+		}
 	}
 		
 	public ArrayList<DataIdentifier> getIterVar() {
@@ -240,15 +242,15 @@ public class IterablePredicate extends Expression
 		if( expr == null || expr.getOutput() == null )
 			return;
 		
-//		Identifier ident = expr.getOutput();
-//		if( ident.getDataType() == DataType.MATRIX || ident.getDataType() == DataType.OBJECT ||
-//			(ident.getDataType() == DataType.SCALAR && (ident.getValueType() == ValueType.BOOLEAN || 
-//					                                    ident.getValueType() == ValueType.STRING || 
-//					                                    ident.getValueType() == ValueType.OBJECT)) )
-//		{
-//			LOG.error(this.printErrorLocation() + "expression in iterable predicate in for loop '" + expr.toString() + "' must return a numeric scalar");
-//			throw new LanguageException(this.printErrorLocation() + "expression in iterable predicate in for loop '" + expr.toString() + "' must return a numeric scalar");
-//		}
+		Identifier ident = expr.getOutput();
+		if( ident.getDataType() == DataType.MATRIX || ident.getDataType() == DataType.OBJECT ||
+			(ident.getDataType() == DataType.SCALAR && (ident.getValueType() == ValueType.BOOLEAN || 
+					                                    ident.getValueType() == ValueType.STRING || 
+					                                    ident.getValueType() == ValueType.OBJECT)) )
+		{
+			LOG.error(this.printErrorLocation() + "expression in iterable predicate in for loop '" + expr.toString() + "' must return a numeric scalar");
+			throw new LanguageException(this.printErrorLocation() + "expression in iterable predicate in for loop '" + expr.toString() + "' must return a numeric scalar");
+		}
 	}
 
 } // end class

--- a/src/main/java/org/apache/sysml/parser/ParForStatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/ParForStatementBlock.java
@@ -1016,13 +1016,15 @@ public class ParForStatementBlock extends ForStatementBlock
 				
 				if( lFlag || rIsParent(sb,this) ) //add only if in subtree of this
 				{
+					String name = ip.getIterVar().get(0)._name;
+					
 					//check for internal names
-					if(   ip.getIterVar()._name.equals( INTERAL_FN_INDEX_ROW )
-					   || ip.getIterVar()._name.equals( INTERAL_FN_INDEX_COL ))
+					if(   name.equals( INTERAL_FN_INDEX_ROW )
+					   || name.equals( INTERAL_FN_INDEX_COL ))
 					{
 						
 						throw new LanguageException(" The iteration variable must not use the " +
-								"internal iteration variable name prefix '"+ip.getIterVar()._name+"'.");
+								"internal iteration variable name prefix '"+name+"'.");
 					}
 					
 					long low = Integer.MIN_VALUE;
@@ -1040,11 +1042,11 @@ public class ParForStatementBlock extends ForStatementBlock
 					else 
 						incr = ( low <= up ) ? 1 : -1;
 
-					_bounds._lower.put(ip.getIterVar()._name, low);
-					_bounds._upper.put(ip.getIterVar()._name, up);
-					_bounds._increment.put(ip.getIterVar()._name, incr);
+					_bounds._lower.put(name, low);
+					_bounds._upper.put(name, up);
+					_bounds._increment.put(name, incr);
 					if( lFlag ) //if local (required for constant check)
-						_bounds._local.add(ip.getIterVar()._name);
+						_bounds._local.add(name);
 				}	
 				
 				//recursive invocation (but not for nested parfors due to constant check)

--- a/src/main/java/org/apache/sysml/parser/dml/Dml.g4
+++ b/src/main/java/org/apache/sysml/parser/dml/Dml.g4
@@ -75,6 +75,7 @@ statement returns [ org.apache.sysml.parser.common.StatementInfo info ]
     // ------------------------------------------
     // ForStatement & ParForStatement
     | 'for' '(' iterVar=ID 'in' iterPred=iterablePredicate (',' parForParams+=strictParameterizedExpression)* ')' (body+=statement ';'* | '{' (body+=statement ';'* )*  '}')  # ForStatement
+    | 'for' '(' '[' iterVars+=ID  ( ',' iterVars+=ID )* ']' 'in' '[' iterPreds+=expression  ( ',' iterPreds+=expression )* ']'  (',' paramExprs+=parameterizedExpression)*  ')' (body+=statement ';'* | '{' (body+=statement ';'* )*  '}')  # IterableForStatement
     // Convert strictParameterizedExpression to HashMap<String, String> for parForParams
     | 'parfor' '(' iterVar=ID 'in' iterPred=iterablePredicate (',' parForParams+=strictParameterizedExpression)* ')' (body+=statement ';'* | '{' (body+=statement ';'*)*  '}')  # ParForStatement
     | 'while' '(' predicate=expression ')' (body+=statement ';'* | '{' (body+=statement ';'*)* '}')  # WhileStatement

--- a/src/main/java/org/apache/sysml/parser/dml/Dml.g4
+++ b/src/main/java/org/apache/sysml/parser/dml/Dml.g4
@@ -75,7 +75,7 @@ statement returns [ org.apache.sysml.parser.common.StatementInfo info ]
     // ------------------------------------------
     // ForStatement & ParForStatement
     | 'for' '(' iterVar=ID 'in' iterPred=iterablePredicate (',' parForParams+=strictParameterizedExpression)* ')' (body+=statement ';'* | '{' (body+=statement ';'* )*  '}')  # ForStatement
-    | 'for' '(' '[' iterVars+=ID  ( ',' iterVars+=ID )* ']' 'in' '[' iterPreds+=expression  ( ',' iterPreds+=expression )* ']'  (',' paramExprs+=parameterizedExpression)*  ')' (body+=statement ';'* | '{' (body+=statement ';'* )*  '}')  # IterableForStatement
+    | 'for' '(' iterVars+=ID  ( ',' iterVars+=ID )* 'in'  iterPreds+=expression  ( ',' iterPreds+=expression )*  (',' paramExprs+=parameterizedExpression)*  ')' (body+=statement ';'* | '{' (body+=statement ';'* )*  '}')  # IterableForStatement
     // Convert strictParameterizedExpression to HashMap<String, String> for parForParams
     | 'parfor' '(' iterVar=ID 'in' iterPred=iterablePredicate (',' parForParams+=strictParameterizedExpression)* ')' (body+=statement ';'* | '{' (body+=statement ';'*)*  '}')  # ParForStatement
     | 'while' '(' predicate=expression ')' (body+=statement ';'* | '{' (body+=statement ';'*)* '}')  # WhileStatement

--- a/src/main/java/org/apache/sysml/parser/dml/DmlPreprocessor.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlPreprocessor.java
@@ -51,6 +51,7 @@ import org.apache.sysml.parser.dml.DmlParser.IfdefAssignmentStatementContext;
 import org.apache.sysml.parser.dml.DmlParser.ImportStatementContext;
 import org.apache.sysml.parser.dml.DmlParser.IndexedExpressionContext;
 import org.apache.sysml.parser.dml.DmlParser.InternalFunctionDefExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.IterableForStatementContext;
 import org.apache.sysml.parser.dml.DmlParser.IterablePredicateColonExpressionContext;
 import org.apache.sysml.parser.dml.DmlParser.IterablePredicateSeqExpressionContext;
 import org.apache.sysml.parser.dml.DmlParser.MatrixDataTypeCheckContext;
@@ -396,5 +397,11 @@ public class DmlPreprocessor implements DmlListener {
 
 	@Override
 	public void exitMultiIdExpression(MultiIdExpressionContext ctx) {}
+
+	@Override
+	public void enterIterableForStatement(IterableForStatementContext ctx) { }
+	
+	@Override
+	public void exitIterableForStatement(IterableForStatementContext ctx) { }
 
 }

--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -674,20 +674,27 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 				else if(iterPreds.size() == 0) {
 					notifyErrorListeners("invalid syntax: at minimum, we allow iterating over 1 variables", ctx.start);
 				}
-				else if(iterPreds.size() > 2) {
-					notifyErrorListeners("invalid syntax: at maximum, we allow iterating over two variables", ctx.start);
+				else if(iterPreds.size() >= 2) {
+					notifyErrorListeners("invalid syntax: in current version, we allow iterating over only 1 variables", ctx.start);
+					// notifyErrorListeners("invalid syntax: at maximum, we allow iterating over two variables", ctx.start);
 				}
 				else {
 					// TODO:
 					HashMap<String, String> parForParamValues = null;
 					forStmt.setAllPositions(currentFile, line, col, line, col);
 					ArrayList<ParameterExpression> paramExpression = getParameterExpressionList(ctx.paramExprs);
+					if(paramExpression != null && paramExpression.size() > 0 && !paramExpression.get(0).getName().equals("nrow")) {
+						notifyErrorListeners("invalid syntax: expected \'nrow\' instead of " + paramExpression.get(0).getName(), ctx.start);
+						return;
+					}
+					
 					Expression incrementExpr = null;
 					if(paramExpression == null || paramExpression.size() == 0) {
 						incrementExpr = new IntIdentifier(1, currentFile, line, col, line, col);
 					}
 					else if(paramExpression.size() >= 2) {
 						notifyErrorListeners("invalid syntax: more than 2 parameters not allowed in for", ctx.start);
+						return;
 					}
 					else {
 						incrementExpr = paramExpression.get(0).getExpr();

--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -48,6 +48,7 @@ import org.apache.sysml.parser.FunctionStatement;
 import org.apache.sysml.parser.IfStatement;
 import org.apache.sysml.parser.ImportStatement;
 import org.apache.sysml.parser.IndexedIdentifier;
+import org.apache.sysml.parser.IntIdentifier;
 import org.apache.sysml.parser.IterablePredicate;
 import org.apache.sysml.parser.LanguageException;
 import org.apache.sysml.parser.ParForStatement;
@@ -88,6 +89,7 @@ import org.apache.sysml.parser.dml.DmlParser.IfdefAssignmentStatementContext;
 import org.apache.sysml.parser.dml.DmlParser.ImportStatementContext;
 import org.apache.sysml.parser.dml.DmlParser.IndexedExpressionContext;
 import org.apache.sysml.parser.dml.DmlParser.InternalFunctionDefExpressionContext;
+import org.apache.sysml.parser.dml.DmlParser.IterableForStatementContext;
 import org.apache.sysml.parser.dml.DmlParser.IterablePredicateColonExpressionContext;
 import org.apache.sysml.parser.dml.DmlParser.IterablePredicateSeqExpressionContext;
 import org.apache.sysml.parser.dml.DmlParser.MatrixDataTypeCheckContext;
@@ -649,6 +651,77 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		ctx.info.stmt = whileStmt;
 		setFileLineColumn(ctx.info.stmt, ctx);
 	}
+	
+	@Override
+	public void exitIterableForStatement(IterableForStatementContext ctx) {
+		ForStatement forStmt = new ForStatement();
+		int line = ctx.start.getLine();
+		int col = ctx.start.getCharPositionInLine();
+		
+		if(ctx.iterVars != null && ctx.iterVars.size() > 0) {
+			if(ctx.iterPreds != null && ctx.iterPreds.size() > 0) {
+				ArrayList<DataIdentifier> iterVars = new ArrayList<DataIdentifier>();
+				for(Token iterVar : ctx.iterVars) {
+					iterVars.add(new DataIdentifier(iterVar.getText()));
+				}
+				ArrayList<Expression> iterPreds = new ArrayList<Expression>();
+				for(ExpressionContext iterPred : ctx.iterPreds) {
+					iterPreds.add(iterPred.info.expr);
+				}
+				if(iterVars.size() != iterPreds.size()) {
+					notifyErrorListeners("invalid syntax: the number of iter variables should match: " + iterVars + " != " + iterPreds, ctx.start);
+				}
+				else if(iterPreds.size() == 0) {
+					notifyErrorListeners("invalid syntax: at minimum, we allow iterating over 1 variables", ctx.start);
+				}
+				else if(iterPreds.size() > 2) {
+					notifyErrorListeners("invalid syntax: at maximum, we allow iterating over two variables", ctx.start);
+				}
+				else {
+					// TODO:
+					HashMap<String, String> parForParamValues = null;
+					forStmt.setAllPositions(currentFile, line, col, line, col);
+					ArrayList<ParameterExpression> paramExpression = getParameterExpressionList(ctx.paramExprs);
+					Expression incrementExpr = null;
+					if(paramExpression == null || paramExpression.size() == 0) {
+						incrementExpr = new IntIdentifier(1, currentFile, line, col, line, col);
+					}
+					else if(paramExpression.size() >= 2) {
+						notifyErrorListeners("invalid syntax: more than 2 parameters not allowed in for", ctx.start);
+					}
+					else {
+						incrementExpr = paramExpression.get(0).getExpr();
+					}
+					
+					IterablePredicate predicate = null;
+					if(iterPreds.size() == 1)
+						predicate = new IterablePredicate(iterVars, iterPreds.get(0), new IntIdentifier(1, currentFile, line, col, line, col), incrementExpr, parForParamValues, currentFile, line, col, line, col, true);
+					else if(iterPreds.size() == 2)
+						predicate = new IterablePredicate(iterVars, iterPreds.get(0), iterPreds.get(1), incrementExpr, parForParamValues, currentFile, line, col, line, col, true);
+					else
+						notifyErrorListeners("invalid syntax: at maximum, we allow iterating over two variables", ctx.start);
+					
+					forStmt.setPredicate(predicate);
+					
+					if(ctx.body.size() > 0) {
+						for(StatementContext stmtCtx : ctx.body) {
+							forStmt.addStatementBlock(getStatementBlock(stmtCtx.info.stmt));
+						}
+						forStmt.mergeStatementBlocks();
+					}
+					ctx.info.stmt = forStmt;
+					setFileLineColumn(ctx.info.stmt, ctx);
+				}
+			}
+			else {
+				notifyErrorListeners("invalid syntax: the matrices to be iterated on cannot be empty", ctx.start);
+			}
+		}
+		else {
+			notifyErrorListeners("invalid syntax: atleast one iteration variable required", ctx.start);
+		}
+		
+	}
 
 	@Override
 	public void exitForStatement(ForStatementContext ctx) {
@@ -657,12 +730,15 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		int col = ctx.start.getCharPositionInLine();
 
 		DataIdentifier iterVar = new DataIdentifier(ctx.iterVar.getText());
+		ArrayList<DataIdentifier> iterVars = new ArrayList<DataIdentifier>(); 
+		iterVars.add(iterVar);
+		
 		HashMap<String, String> parForParamValues = null;
 		Expression incrementExpr = null; //1/-1
 		if(ctx.iterPred.info.increment != null) {
 			incrementExpr = ctx.iterPred.info.increment;
 		}
-		IterablePredicate predicate = new IterablePredicate(iterVar, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col);
+		IterablePredicate predicate = new IterablePredicate(iterVars, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col, false);
 		forStmt.setPredicate(predicate);
 
 		if(ctx.body.size() > 0) {
@@ -682,6 +758,9 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		int col = ctx.start.getCharPositionInLine();
 
 		DataIdentifier iterVar = new DataIdentifier(ctx.iterVar.getText());
+		ArrayList<DataIdentifier> iterVars = new ArrayList<DataIdentifier>(); 
+		iterVars.add(iterVar);
+		
 		HashMap<String, String> parForParamValues = new HashMap<String, String>();
 		if(ctx.parForParams != null && ctx.parForParams.size() > 0) {
 			for(StrictParameterizedExpressionContext parForParamCtx : ctx.parForParams) {
@@ -693,7 +772,7 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		if( ctx.iterPred.info.increment != null ) {
 			incrementExpr = ctx.iterPred.info.increment;
 		}
-		IterablePredicate predicate = new IterablePredicate(iterVar, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col);
+		IterablePredicate predicate = new IterablePredicate(iterVars, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col, false);
 		parForStmt.setPredicate(predicate);
 		if(ctx.body.size() > 0) {
 			for(StatementContext stmtCtx : ctx.body) {
@@ -1056,5 +1135,10 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 		}
 		ctx.info.expr = new ExpressionList(values);
 	}
+
+	@Override
+	public void enterIterableForStatement(IterableForStatementContext ctx) { }
+
+	
 
 }

--- a/src/main/java/org/apache/sysml/parser/pydml/Pydml.g4
+++ b/src/main/java/org/apache/sysml/parser/pydml/Pydml.g4
@@ -182,6 +182,7 @@ statement returns [ org.apache.sysml.parser.common.StatementInfo info ]
     // ------------------------------------------
     // ForStatement & ParForStatement
     | 'for' (OPEN_PAREN iterVar=ID 'in' iterPred=iterablePredicate (',' parForParams+=strictParameterizedExpression)* CLOSE_PAREN |  iterVar=ID 'in' iterPred=iterablePredicate (',' parForParams+=strictParameterizedExpression)* ) ':'  NEWLINE INDENT (body+=statement)+  DEDENT  # ForStatement
+    | 'for' (OPEN_PAREN iterVars+=ID  ( ',' iterVars+=ID )* 'in' iterPreds+=expression  ( ',' iterPreds+=expression )* (',' paramExprs+=parameterizedExpression)* CLOSE_PAREN |  iterVars+=ID  ( ',' iterVars+=ID )* 'in' iterPreds+=expression  ( ',' iterPreds+=expression )* (',' paramExprs+=parameterizedExpression)* ) ':'  NEWLINE INDENT (body+=statement)+  DEDENT  # IterableForStatement
     // Convert strictParameterizedExpression to HashMap<String, String> for parForParams
     | 'parfor' (OPEN_PAREN iterVar=ID 'in' iterPred=iterablePredicate (',' parForParams+=strictParameterizedExpression)* CLOSE_PAREN | iterVar=ID 'in' iterPred=iterablePredicate (',' parForParams+=strictParameterizedExpression)* ) ':' NEWLINE INDENT (body+=statement)+  DEDENT  # ParForStatement
     | 'while' ( OPEN_PAREN predicate=expression CLOSE_PAREN | predicate=expression ) ':' NEWLINE INDENT (body+=statement)+  DEDENT  # WhileStatement

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlPreprocessor.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlPreprocessor.java
@@ -53,6 +53,7 @@ import org.apache.sysml.parser.pydml.PydmlParser.IgnoreNewLineContext;
 import org.apache.sysml.parser.pydml.PydmlParser.ImportStatementContext;
 import org.apache.sysml.parser.pydml.PydmlParser.IndexedExpressionContext;
 import org.apache.sysml.parser.pydml.PydmlParser.InternalFunctionDefExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.IterableForStatementContext;
 import org.apache.sysml.parser.pydml.PydmlParser.IterablePredicateColonExpressionContext;
 import org.apache.sysml.parser.pydml.PydmlParser.IterablePredicateSeqExpressionContext;
 import org.apache.sysml.parser.pydml.PydmlParser.MatrixDataTypeCheckContext;
@@ -396,5 +397,11 @@ public class PydmlPreprocessor implements PydmlListener {
 
 	@Override
 	public void exitElifBranch(ElifBranchContext ctx) {}
+
+	@Override
+	public void enterIterableForStatement(IterableForStatementContext ctx) {}
+
+	@Override
+	public void exitIterableForStatement(IterableForStatementContext ctx) {}
 
 }

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -1325,12 +1325,15 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		int col = ctx.start.getCharPositionInLine();
 
 		DataIdentifier iterVar = new DataIdentifier(ctx.iterVar.getText());
+		ArrayList<DataIdentifier> iterVars = new ArrayList<DataIdentifier>(); 
+		iterVars.add(iterVar);
+		
 		HashMap<String, String> parForParamValues = null;
 		Expression incrementExpr = null; //1/-1
 		if(ctx.iterPred.info.increment != null) {
 			incrementExpr = ctx.iterPred.info.increment;
 		}
-		IterablePredicate predicate = new IterablePredicate(iterVar, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col);
+		IterablePredicate predicate = new IterablePredicate(iterVars, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col, false);
 		forStmt.setPredicate(predicate);
 
 		if(ctx.body.size() > 0) {
@@ -1350,6 +1353,9 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		int col = ctx.start.getCharPositionInLine();
 
 		DataIdentifier iterVar = new DataIdentifier(ctx.iterVar.getText());
+		ArrayList<DataIdentifier> iterVars = new ArrayList<DataIdentifier>(); 
+		iterVars.add(iterVar);
+		
 		HashMap<String, String> parForParamValues = new HashMap<String, String>();
 		if(ctx.parForParams != null && ctx.parForParams.size() > 0) {
 			for(StrictParameterizedExpressionContext parForParamCtx : ctx.parForParams) {
@@ -1361,7 +1367,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		if( ctx.iterPred.info.increment != null ) {
 			incrementExpr = ctx.iterPred.info.increment;
 		}
-		IterablePredicate predicate = new IterablePredicate(iterVar, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col);
+		IterablePredicate predicate = new IterablePredicate(iterVars, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col, false);
 		parForStmt.setPredicate(predicate);
 		if(ctx.body.size() > 0) {
 			for(StatementContext stmtCtx : ctx.body) {

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -95,6 +95,7 @@ import org.apache.sysml.parser.pydml.PydmlParser.IgnoreNewLineContext;
 import org.apache.sysml.parser.pydml.PydmlParser.ImportStatementContext;
 import org.apache.sysml.parser.pydml.PydmlParser.IndexedExpressionContext;
 import org.apache.sysml.parser.pydml.PydmlParser.InternalFunctionDefExpressionContext;
+import org.apache.sysml.parser.pydml.PydmlParser.IterableForStatementContext;
 import org.apache.sysml.parser.pydml.PydmlParser.IterablePredicateColonExpressionContext;
 import org.apache.sysml.parser.pydml.PydmlParser.IterablePredicateSeqExpressionContext;
 import org.apache.sysml.parser.pydml.PydmlParser.MatrixDataTypeCheckContext;
@@ -1317,6 +1318,83 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		ctx.info.stmt = whileStmt;
 		setFileLineColumn(ctx.info.stmt, ctx);
 	}
+	
+	@Override
+	public void exitIterableForStatement(IterableForStatementContext ctx) {
+		ForStatement forStmt = new ForStatement();
+		int line = ctx.start.getLine();
+		int col = ctx.start.getCharPositionInLine();
+		
+		if(ctx.iterVars != null && ctx.iterVars.size() > 0) {
+			if(ctx.iterPreds != null && ctx.iterPreds.size() > 0) {
+				ArrayList<DataIdentifier> iterVars = new ArrayList<DataIdentifier>();
+				for(Token iterVar : ctx.iterVars) {
+					iterVars.add(new DataIdentifier(iterVar.getText()));
+				}
+				ArrayList<Expression> iterPreds = new ArrayList<Expression>();
+				for(ExpressionContext iterPred : ctx.iterPreds) {
+					iterPreds.add(iterPred.info.expr);
+				}
+				if(iterVars.size() != iterPreds.size()) {
+					notifyErrorListeners("invalid syntax: the number of iter variables should match: " + iterVars + " != " + iterPreds, ctx.start);
+				}
+				else if(iterPreds.size() == 0) {
+					notifyErrorListeners("invalid syntax: at minimum, we allow iterating over 1 variables", ctx.start);
+				}
+				else if(iterPreds.size() >= 2) {
+					notifyErrorListeners("invalid syntax: in current version, we allow iterating over only 1 variables", ctx.start);
+					// notifyErrorListeners("invalid syntax: at maximum, we allow iterating over two variables", ctx.start);
+				}
+				else {
+					HashMap<String, String> parForParamValues = null;
+					forStmt.setAllPositions(currentFile, line, col, line, col);
+					ArrayList<ParameterExpression> paramExpression = getParameterExpressionList(ctx.paramExprs);
+					if(paramExpression != null && paramExpression.size() > 0 && !paramExpression.get(0).getName().equals("nrow")) {
+						notifyErrorListeners("invalid syntax: expected \'nrow\' instead of " + paramExpression.get(0).getName(), ctx.start);
+						return;
+					}
+					
+					Expression incrementExpr = null;
+					if(paramExpression == null || paramExpression.size() == 0) {
+						incrementExpr = new IntIdentifier(1, currentFile, line, col, line, col);
+					}
+					else if(paramExpression.size() >= 2) {
+						notifyErrorListeners("invalid syntax: more than 2 parameters not allowed in for", ctx.start);
+						return;
+					}
+					else {
+						incrementExpr = paramExpression.get(0).getExpr();
+					}
+					
+					IterablePredicate predicate = null;
+					if(iterPreds.size() == 1)
+						predicate = new IterablePredicate(iterVars, iterPreds.get(0), new IntIdentifier(1, currentFile, line, col, line, col), incrementExpr, parForParamValues, currentFile, line, col, line, col, true);
+					else if(iterPreds.size() == 2)
+						predicate = new IterablePredicate(iterVars, iterPreds.get(0), iterPreds.get(1), incrementExpr, parForParamValues, currentFile, line, col, line, col, true);
+					else
+						notifyErrorListeners("invalid syntax: at maximum, we allow iterating over two variables", ctx.start);
+					
+					forStmt.setPredicate(predicate);
+					
+					if(ctx.body.size() > 0) {
+						for(StatementContext stmtCtx : ctx.body) {
+							forStmt.addStatementBlock(getStatementBlock(stmtCtx.info.stmt));
+						}
+						forStmt.mergeStatementBlocks();
+					}
+					ctx.info.stmt = forStmt;
+					setFileLineColumn(ctx.info.stmt, ctx);
+				}
+			}
+			else {
+				notifyErrorListeners("invalid syntax: the matrices to be iterated on cannot be empty", ctx.start);
+			}
+		}
+		else {
+			notifyErrorListeners("invalid syntax: atleast one iteration variable required", ctx.start);
+		}
+		
+	}
 
 	@Override
 	public void exitForStatement(ForStatementContext ctx) {
@@ -1767,4 +1845,8 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 	@Override public void enterSimpleDataIdentifierExpression(SimpleDataIdentifierExpressionContext ctx) {}
 
 	@Override public void enterBooleanOrExpression(BooleanOrExpressionContext ctx) {}
+
+	@Override
+	public void enterIterableForStatement(IterableForStatementContext ctx) { }
+	
 }

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ForProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ForProgramBlock.java
@@ -28,8 +28,12 @@ import org.apache.sysml.parser.ForStatementBlock;
 import org.apache.sysml.parser.Expression.ValueType;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.DMLScriptException;
+import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysml.runtime.controlprogram.caching.MatrixObject.UpdateType;
 import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysml.runtime.controlprogram.context.SparkExecutionContext;
+import org.apache.sysml.runtime.controlprogram.util.CPBatchIterator;
+import org.apache.sysml.runtime.controlprogram.util.SPBatchIterator;
 import org.apache.sysml.runtime.instructions.Instruction;
 import org.apache.sysml.runtime.instructions.cp.Data;
 import org.apache.sysml.runtime.instructions.cp.IntObject;
@@ -116,16 +120,34 @@ public class ForProgramBlock extends ProgramBlock
 	{
 		// add the iterable predicate variable to the variable set
 		String iterVarName = _iterablePredicateVars[0];
-
-		// evaluate from, to, incr only once (assumption: known at for entry)
-		IntObject from = executePredicateInstructions( 1, _fromInstructions, ec );
-		IntObject to   = executePredicateInstructions( 2, _toInstructions, ec );
-		IntObject incr = (_incrementInstructions == null || _incrementInstructions.isEmpty()) && _iterablePredicateVars[3]==null ? 
-				new IntObject((from.getLongValue()<=to.getLongValue()) ? 1 : -1) :
-				executePredicateInstructions( 3, _incrementInstructions, ec );
 		
-		if ( incr.getLongValue() == 0 ) //would produce infinite loop
-			throw new DMLRuntimeException(this.printBlockErrorLocation() + "Expression for increment of variable '" + iterVarName + "' must evaluate to a non-zero value.");
+		Iterable<Data> genericIterator = null;
+				
+		if( _iterablePredicateVars[1] != null ) {
+			//probe for matrix variables
+			Data ldat = ec.getVariable( _iterablePredicateVars[1] );
+			if( ldat != null && ldat instanceof MatrixObject ) {
+				// Iterable for loop
+				if(ec instanceof SparkExecutionContext) {
+					genericIterator = (Iterable<Data>) (new SPBatchIterator(ec, _iterablePredicateVars));
+				}
+				else {
+					genericIterator = (Iterable<Data>)(new CPBatchIterator(ec, _iterablePredicateVars));
+				}
+			}
+		}		
+
+		if(genericIterator == null) {
+			// evaluate from, to, incr only once (assumption: known at for entry)
+			IntObject from = executePredicateInstructions( 1, _fromInstructions, ec );
+			IntObject to   = executePredicateInstructions( 2, _toInstructions, ec );
+			IntObject incr = (_incrementInstructions == null || _incrementInstructions.isEmpty()) && _iterablePredicateVars[3]==null ? 
+					new IntObject((from.getLongValue()<=to.getLongValue()) ? 1 : -1) :
+					executePredicateInstructions( 3, _incrementInstructions, ec );
+			if ( incr.getLongValue() == 0 ) //would produce infinite loop
+				throw new DMLRuntimeException(this.printBlockErrorLocation() + "Expression for increment of variable '" + iterVarName + "' must evaluate to a non-zero value.");
+			genericIterator = (Iterable<Data>)(new SequenceIterator(iterVarName, from, to, incr));
+		}
 		
 		// execute for loop
 		try 
@@ -133,10 +155,8 @@ public class ForProgramBlock extends ProgramBlock
 			// prepare update in-place variables
 			UpdateType[] flags = prepareUpdateInPlaceVariables(ec, _tid);
 			
-			// run for loop body for each instance of predicate sequence 
-			SequenceIterator seqIter = new SequenceIterator(iterVarName, from, to, incr);
-			for( IntObject iterVar : seqIter ) 
-			{
+			// run for loop body for each instance of predicate sequence
+			for( Data iterVar : genericIterator )  {
 				//set iteration variable
 				ec.setVariable(iterVarName, iterVar); 
 				
@@ -238,7 +258,7 @@ public class ForProgramBlock extends ProgramBlock
 	/**
 	 * Utility class for iterating over positive or negative predicate sequences.
 	 */
-	protected class SequenceIterator implements Iterator<IntObject>, Iterable<IntObject>
+	protected class SequenceIterator implements Iterator<Data>, Iterable<Data>
 	{
 		private String _varName = null;
 		private long _cur = -1;
@@ -266,7 +286,7 @@ public class ForProgramBlock extends ProgramBlock
 		}
 
 		@Override
-		public Iterator<IntObject> iterator() {
+		public Iterator<Data> iterator() {
 			if( _inuse )
 				throw new RuntimeException("Unsupported reuse of iterator.");				
 			_inuse = true;

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ParForProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ParForProgramBlock.java
@@ -94,6 +94,7 @@ import org.apache.sysml.runtime.controlprogram.parfor.stat.StatisticMonitor;
 import org.apache.sysml.runtime.controlprogram.parfor.stat.Timing;
 import org.apache.sysml.runtime.controlprogram.parfor.util.IDHandler;
 import org.apache.sysml.runtime.controlprogram.parfor.util.IDSequence;
+import org.apache.sysml.runtime.controlprogram.util.CPBatchIterator;
 import org.apache.sysml.runtime.instructions.cp.BooleanObject;
 import org.apache.sysml.runtime.instructions.cp.Data;
 import org.apache.sysml.runtime.instructions.cp.DoubleObject;
@@ -517,10 +518,14 @@ public class ParForProgramBlock extends ForProgramBlock
 		ALLOW_REUSE_MR_PAR_WORKER = ALLOW_REUSE_MR_JVMS;
 	}
 	
+	static int numParForLoops = 0;
+	
 	@Override	
 	public void execute(ExecutionContext ec)
 		throws DMLRuntimeException
 	{	
+		numParForLoops++;
+		
 		ParForStatementBlock sb = (ParForStatementBlock)getStatementBlock();
 		
 		// add the iterable predicate variable to the variable set
@@ -669,7 +674,13 @@ public class ParForProgramBlock extends ForProgramBlock
 		resetOptimizerFlags(); //after release, deletes dp_varnames
 		
 		//execute exit instructions (usually empty)
-		executeInstructions(_exitInstructions, ec);			
+		executeInstructions(_exitInstructions, ec);		
+		
+		numParForLoops--;
+	}
+	
+	public static boolean isInParForLoop() {
+		return numParForLoops != 0;
 	}
 
 

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.mapred.ClusterStatus;
 import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.sysml.conf.ConfigurationManager;
+import org.apache.sysml.conf.DMLConfig;
 import org.apache.sysml.runtime.matrix.mapred.MRConfigurationNames;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
@@ -145,7 +146,17 @@ public class InfrastructureAnalyzer
 	 */
 	public static long getLocalMaxMemory()
 	{
-		return _localJVMMaxMem;
+		double prefetchMemoryBudgetInMB = ConfigurationManager.getDMLConfig().getDoubleValue(DMLConfig.PREFETCH_MEM_BUDGET);
+		if(prefetchMemoryBudgetInMB <= 0) {
+			return _localJVMMaxMem;
+		}
+		else {
+			long MBInBytes = 1000000;
+			// Ensure that prefetch memory budget is no larger than 20% of available memory
+			if(_localJVMMaxMem*0.2 <= prefetchMemoryBudgetInMB*MBInBytes)
+				throw new RuntimeException("ERROR: Prefetch memory budget (" + prefetchMemoryBudgetInMB + " mb) cannot be greater than 20% of available memory (" + (((double)_localJVMMaxMem)/MBInBytes) + " mb)");
+			return _localJVMMaxMem - ((long)(prefetchMemoryBudgetInMB*MBInBytes));
+		}
 	}
 
 	public static void setLocalMaxMemory( long localMem )

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/util/CPBatchIterator.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/util/CPBatchIterator.java
@@ -1,0 +1,35 @@
+package org.apache.sysml.runtime.controlprogram.util;
+
+import java.util.Iterator;
+
+import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
+import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysml.runtime.instructions.cp.Data;
+
+// TODO: Before I go ahead an implement prefetching with this approach
+// I want to ensure if this functionality is OK with everyone
+public class CPBatchIterator implements Iterator<Data>, Iterable<Data> {
+	
+	public CPBatchIterator(ExecutionContext ec, String[] iterablePredicateVars) {
+		
+	}
+
+	@Override
+	public Iterator<Data> iterator() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean hasNext() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public MatrixObject next() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/util/CPBatchIterator.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/util/CPBatchIterator.java
@@ -1,35 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.sysml.runtime.controlprogram.util;
 
 import java.util.Iterator;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysml.conf.ConfigurationManager;
+import org.apache.sysml.conf.DMLConfig;
+import org.apache.sysml.hops.OptimizerUtils;
+import org.apache.sysml.parser.Expression.ValueType;
+import org.apache.sysml.runtime.DMLRuntimeException;
+import org.apache.sysml.runtime.controlprogram.ParForProgramBlock;
 import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysml.runtime.controlprogram.context.SparkExecutionContext;
+import org.apache.sysml.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
 import org.apache.sysml.runtime.instructions.cp.Data;
+import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
+import org.apache.sysml.runtime.matrix.MatrixFormatMetaData;
+import org.apache.sysml.runtime.matrix.data.InputInfo;
+import org.apache.sysml.runtime.matrix.data.MatrixBlock;
+import org.apache.sysml.runtime.matrix.data.OutputInfo;
+import org.apache.sysml.runtime.util.IndexRange;
 
-// TODO: Before I go ahead an implement prefetching with this approach
-// I want to ensure if this functionality is OK with everyone
 public class CPBatchIterator implements Iterator<Data>, Iterable<Data> {
 	
-	public CPBatchIterator(ExecutionContext ec, String[] iterablePredicateVars) {
+	protected MatrixObject X = null;
+	protected long batchSize;
+	protected long numBatches;
+	protected long currentBatchIndex = 0;
+	protected long N;
+	protected boolean isPrefetchEnabled = false;
+	protected String XName;
+	
+	private static final Log LOG = LogFactory.getLog(CPBatchIterator.class.getName());
+	
+	public static Iterable<Data> getBatchIterator(ExecutionContext ec, String[] iterablePredicateVars) throws DMLRuntimeException {
+		MatrixObject X = (MatrixObject) ec.getVariable( iterablePredicateVars[1] );
+		long maxNNZ = X.getNumRows()*X.getNumColumns();
+		long batchSize = Long.parseLong(iterablePredicateVars[3]); 
+		boolean canFitInCP = (maxNNZ+batchSize)*8 < InfrastructureAnalyzer.getLocalMaxMemory();
 		
+		if(ec instanceof SparkExecutionContext) {
+			if(canFitInCP && !ParForProgramBlock.isInParForLoop())
+				return (Iterable<Data>) (new CPBatchIterator(ec, iterablePredicateVars));
+			else
+				return (Iterable<Data>) (new SPBatchIterator(ec, iterablePredicateVars));
+		}
+		else {
+			return (Iterable<Data>) (new CPBatchIterator(ec, iterablePredicateVars));
+		}
+	}
+	
+	
+	public CPBatchIterator(ExecutionContext ec, String[] iterablePredicateVars) {
+		X = (MatrixObject) ec.getVariable( iterablePredicateVars[1] );
+		// assumption: known at runtime
+		N = X.getNumRows();
+		batchSize = Long.parseLong(iterablePredicateVars[3]); // ((ScalarObject) ec.getVariable( iterablePredicateVars[3] )).getLongValue();
+		numBatches = (long) Math.ceil(  ((double)N) / batchSize);
+		double prefetchMemoryBudgetInMB = ConfigurationManager.getDMLConfig().getDoubleValue(DMLConfig.PREFETCH_MEM_BUDGET);
+		double requiredBudgetInMB = (batchSize*X.getNumColumns()*8)/1000000;
+		if(ParForProgramBlock.isInParForLoop()) {
+			LOG.warn("Prefetching is disabled if executed inside a parfor program block");
+		}
+		else if(prefetchMemoryBudgetInMB >= requiredBudgetInMB) {
+			isPrefetchEnabled = true;
+			LOG.info("Prefetching is enabled");
+			System.out.println("Prefetching is enabled");
+		}
+		else if(prefetchMemoryBudgetInMB != 0) {
+			LOG.warn("Prefetching is disabled as prefetch memory budget (" + prefetchMemoryBudgetInMB + " mb) is smaller than " + requiredBudgetInMB);
+		}
 	}
 
 	@Override
 	public Iterator<Data> iterator() {
-		// TODO Auto-generated method stub
-		return null;
+		return this;
 	}
 
 	@Override
 	public boolean hasNext() {
-		// TODO Auto-generated method stub
-		return false;
+		return currentBatchIndex < numBatches;
 	}
 
 	@Override
 	public MatrixObject next() {
-		// TODO Auto-generated method stub
-		return null;
+		long beg = (currentBatchIndex * batchSize) % N + 1;
+		currentBatchIndex++;
+		long end = Math.min(N, beg + batchSize - 1);
+		IndexRange ixrange = new IndexRange(beg-1, end-1, 0, X.getNumColumns()-1);
+		MatrixObject ret = null;
+		try {
+			// Perform the operation (no prefetching for CP as X.acquireRead() might or might not fit on memory): 
+			// # Get next batch
+		    // beg = ((i-1) * batch_size) %% N + 1
+		    // end = min(N, beg + batch_size - 1)
+		    // X_batch = X[beg:end,]
+			MatrixBlock matBlock = X.acquireRead();
+			MatrixBlock resultBlock = matBlock.sliceOperations(ixrange, new MatrixBlock());
+			X.release();
+			// Return X_batch as MatrixObject
+			MatrixCharacteristics mc = new MatrixCharacteristics(end - beg + 1, 
+					X.getNumColumns(), ConfigurationManager.getBlocksize(), ConfigurationManager.getBlocksize());
+			ret = new MatrixObject(ValueType.DOUBLE, OptimizerUtils.getUniqueTempFileName(), 
+					new MatrixFormatMetaData(mc, OutputInfo.BinaryBlockOutputInfo, InputInfo.BinaryBlockInputInfo));
+			ret.acquireModify(resultBlock);
+			ret.release();
+		} catch (DMLRuntimeException e) {
+			throw new RuntimeException("Error while fetching a batch", e);
+		}
+		return ret;
 	}
-
 }

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/util/SPBatchIterator.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/util/SPBatchIterator.java
@@ -1,10 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.sysml.runtime.controlprogram.util;
 
-import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+import java.util.List;
 
-//TODO:
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.storage.StorageLevel;
+import org.apache.sysml.conf.ConfigurationManager;
+import org.apache.sysml.hops.OptimizerUtils;
+import org.apache.sysml.parser.Expression.ValueType;
+import org.apache.sysml.runtime.DMLRuntimeException;
+import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
+import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysml.runtime.controlprogram.context.SparkExecutionContext;
+import org.apache.sysml.runtime.instructions.spark.functions.ExtractBlockForBinaryReblock;
+import org.apache.sysml.runtime.instructions.spark.utils.RDDAggregateUtils;
+import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
+import org.apache.sysml.runtime.matrix.MatrixFormatMetaData;
+import org.apache.sysml.runtime.matrix.data.InputInfo;
+import org.apache.sysml.runtime.matrix.data.MatrixBlock;
+import org.apache.sysml.runtime.matrix.data.OutputInfo;
+import org.apache.sysml.runtime.util.IndexRange;
+import org.apache.sysml.runtime.util.UtilFunctions;
+import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
+
 public class SPBatchIterator extends CPBatchIterator {
-	public SPBatchIterator(ExecutionContext ec, String[] iterablePredicateVars) {
+	MatrixCharacteristics mcIn;
+	JavaPairRDD<MatrixIndexes,MatrixBlock> in1;
+	SparkExecutionContext sec;
+	
+	public SPBatchIterator(ExecutionContext ec, String[] iterablePredicateVars) throws DMLRuntimeException {
 		super(ec, iterablePredicateVars);
+		sec = ((SparkExecutionContext)ec);
+		mcIn = new MatrixCharacteristics(X.getNumRows(), X.getNumColumns(), (int)batchSize, (int)X.getNumColumns());
+		in1 = getReblockedMatrix( iterablePredicateVars[1], mcIn ).persist(StorageLevel.MEMORY_AND_DISK());
+		if(isPrefetchEnabled)
+			startPrefetch();
 	}
+	
+	private JavaPairRDD<MatrixIndexes,MatrixBlock> getReblockedMatrix(String varName, MatrixCharacteristics mcOut) throws DMLRuntimeException {
+		JavaPairRDD<MatrixIndexes,MatrixBlock> temp = sec.getBinaryBlockRDDHandleForVariable( varName );
+		MatrixCharacteristics mcIn = sec.getMatrixCharacteristics(varName);
+		temp = RDDAggregateUtils.mergeByKey(temp.flatMapToPair(new ExtractBlockForBinaryReblock(mcIn, mcOut)));
+		return temp;
+	}
+	
+	MatrixObject nextBatch = null;
+	Thread prefetchThread = null;
+	
+	public void startPrefetch() {
+		if(hasNext()) {
+			prefetchThread = new Thread(new PrefetchingThread(this));
+			prefetchThread.start();
+		}
+		else
+			prefetchThread = null;
+	}
+	
+	class PrefetchingThread implements Runnable {
+		SPBatchIterator iter;
+		public PrefetchingThread(SPBatchIterator iter) {
+			this.iter = iter;
+		}
+		@Override
+		public void run() {
+			long beg = (iter.currentBatchIndex * iter.batchSize) % iter.N + 1;
+			iter.currentBatchIndex++;
+			long end = Math.min(iter.N, beg + iter.batchSize - 1);
+			iter.nextBatch = getNextBatch(beg, end);
+		}
+	}
+	
+	@Override
+	public MatrixObject next() {
+		if(isPrefetchEnabled) {
+			if(prefetchThread != null) {
+				// Prefetching in-progress
+				try {
+					prefetchThread.join();
+				} catch (InterruptedException e) {
+					throw new RuntimeException("Prefetching thread is interrupter.", e);
+				}
+				if(nextBatch != null) {
+					MatrixObject currentBatch = nextBatch;
+					nextBatch = null;
+					startPrefetch();
+					return currentBatch;
+				}
+				else {
+					throw new RuntimeException("No block returned by prefetching thread.");
+				}
+			}
+			else {
+				throw new RuntimeException("No prefetching thread set.");
+			}
+		}
+		else {
+			long beg = (currentBatchIndex * batchSize) % N + 1;
+			currentBatchIndex++;
+			long end = Math.min(N, beg + batchSize - 1);
+			return getNextBatch(beg, end);
+		}
+	}
+	
+	
+	private MatrixObject getNextBatch(long beg, long end) {
+		IndexRange ixrange = new IndexRange(beg-1, end-1, 0, X.getNumColumns()-1);
+		MatrixObject ret = null;
+		
+		try {
+			// Perform the operation (no prefetching for CP as X.acquireRead() might or might not fit on memory): 
+			// # Get next batch
+		    // beg = ((i-1) * batch_size) %% N + 1
+		    // end = min(N, beg + batch_size - 1)
+		    // X_batch = X[beg:end,]
+			
+			//single block output via lookup (on partitioned inputs, this allows for single partition
+			//access to avoid a full scan of the input; note that this is especially important for 
+			//out-of-core datasets as entire partitions are read, not just keys as in the in-memory setting.
+			long rix = UtilFunctions.computeBlockIndex(ixrange.rowStart, mcIn.getRowsPerBlock());
+			long cix = UtilFunctions.computeBlockIndex(ixrange.colStart, mcIn.getColsPerBlock());
+			List<MatrixBlock> list = in1.lookup(new MatrixIndexes(rix, cix));
+			if( list.size() != 1 )
+				throw new DMLRuntimeException("Block lookup returned "+list.size()+" blocks (expected 1).");
+			
+			MatrixBlock tmp = list.get(0);
+//			MatrixBlock mbout = (tmp.getNumRows()==mcOut.getRows() && tmp.getNumColumns()==mcOut.getCols()) ? 
+//					tmp : tmp.sliceOperations( //reference full block or slice out sub-block
+//					UtilFunctions.computeCellInBlock(ixrange.rowStart, mcIn.getRowsPerBlock()), 
+//					UtilFunctions.computeCellInBlock(ixrange.rowEnd, mcIn.getRowsPerBlock()), 
+//					UtilFunctions.computeCellInBlock(ixrange.colStart, mcIn.getColsPerBlock()), 
+//					UtilFunctions.computeCellInBlock(ixrange.colEnd, mcIn.getColsPerBlock()), new MatrixBlock());
+			
+			
+			// Return X_batch as MatrixObject
+			MatrixCharacteristics mc = new MatrixCharacteristics(end - beg + 1, 
+					X.getNumColumns(), ConfigurationManager.getBlocksize(), ConfigurationManager.getBlocksize());
+			ret = new MatrixObject(ValueType.DOUBLE, OptimizerUtils.getUniqueTempFileName(), 
+					new MatrixFormatMetaData(mc, OutputInfo.BinaryBlockOutputInfo, InputInfo.BinaryBlockInputInfo));
+			ret.acquireModify(tmp);
+			ret.release();
+		} catch (DMLRuntimeException e) {
+			throw new RuntimeException("Error while fetching a batch", e);
+		}
+		return ret;
+	}
+	
 }

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/util/SPBatchIterator.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/util/SPBatchIterator.java
@@ -1,0 +1,10 @@
+package org.apache.sysml.runtime.controlprogram.util;
+
+import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+
+//TODO:
+public class SPBatchIterator extends CPBatchIterator {
+	public SPBatchIterator(ExecutionContext ec, String[] iterablePredicateVars) {
+		super(ec, iterablePredicateVars);
+	}
+}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixIndexingSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixIndexingSPInstruction.java
@@ -92,6 +92,8 @@ public class MatrixIndexingSPInstruction  extends IndexingSPInstruction
 		SparkExecutionContext sec = (SparkExecutionContext)ec;
 		String opcode = getOpcode();
 		
+		System.out.println(this.instString);
+		
 		//get indexing range
 		long rl = ec.getScalarInput(rowLower.getName(), rowLower.getValueType(), rowLower.isLiteral()).getLongValue();
 		long ru = ec.getScalarInput(rowUpper.getName(), rowUpper.getValueType(), rowUpper.isLiteral()).getLongValue();

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixIndexingSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixIndexingSPInstruction.java
@@ -92,8 +92,6 @@ public class MatrixIndexingSPInstruction  extends IndexingSPInstruction
 		SparkExecutionContext sec = (SparkExecutionContext)ec;
 		String opcode = getOpcode();
 		
-		System.out.println(this.instString);
-		
 		//get indexing range
 		long rl = ec.getScalarInput(rowLower.getName(), rowLower.getValueType(), rowLower.isLiteral()).getLongValue();
 		long ru = ec.getScalarInput(rowUpper.getName(), rowUpper.getValueType(), rowUpper.isLiteral()).getLongValue();

--- a/src/main/java/org/apache/sysml/utils/Statistics.java
+++ b/src/main/java/org/apache/sysml/utils/Statistics.java
@@ -113,6 +113,9 @@ public class Statistics
 	public static AtomicLong cudaFromDevCount = new AtomicLong(0);
 	public static AtomicLong cudaEvictionCount = new AtomicLong(0);
 	
+	public static long batchFetchingTimeInNext = 0;
+	public static long batchFetchingTimeInIndexing = 0;
+	
 	public static synchronized void setNoOfExecutedMRJobs(int iNoOfExecutedMRJobs) {
 		Statistics.iNoOfExecutedMRJobs = iNoOfExecutedMRJobs;
 	}
@@ -374,6 +377,8 @@ public class Statistics
 		cudaFromDevCount.set(0);
 		cudaEvictionCount.set(0);
 		LibMatrixDNN.resetStatistics();
+		batchFetchingTimeInIndexing = 0;
+		batchFetchingTimeInNext = 0;
 	}
 
 	public static void resetJITCompileTime(){
@@ -634,6 +639,10 @@ public class Statistics
 		//show extended caching/compilation statistics
 		if( DMLScript.STATISTICS ) 
 		{
+			if(batchFetchingTimeInIndexing > 0) {
+				sb.append("Batch fetching time (next, indexing):\t" + String.format("%.3f", batchFetchingTimeInNext*1e-9) + "/"
+						+ String.format("%.3f", batchFetchingTimeInIndexing*1e-9) + " sec.\n");
+			}
 			sb.append("Cache hits (Mem, WB, FS, HDFS):\t" + CacheStatistics.displayHits() + ".\n");
 			sb.append("Cache writes (WB, FS, HDFS):\t" + CacheStatistics.displayWrites() + ".\n");
 			sb.append("Cache times (ACQr/m, RLS, EXP):\t" + CacheStatistics.displayTime() + " sec.\n");

--- a/src/test/java/org/apache/sysml/test/integration/functions/parfor/ForLoopPredicateTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/parfor/ForLoopPredicateTest.java
@@ -38,6 +38,7 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 	private final static String TEST_NAME5 = "for_pred3a"; //expression
 	private final static String TEST_NAME6 = "for_pred3b"; //expression seq
 	private final static String TEST_NAME7 = "for_pred1a_seq"; //const seq two parameters (this tests is only for parser)
+	private final static String TEST_NAME8 = "for_iterator1"; //iterator
 	private final static String TEST_DIR = "functions/parfor/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + ForLoopPredicateTest.class.getSimpleName() + "/";
 	
@@ -55,6 +56,7 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 		addTestConfiguration(TEST_NAME5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5, new String[]{"R"}));
 		addTestConfiguration(TEST_NAME6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6, new String[]{"R"}));
 		addTestConfiguration(TEST_NAME7, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME7, new String[]{"R"}));
+		addTestConfiguration(TEST_NAME8, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME8, new String[]{"R"}));
 	}
 
 	@Test
@@ -112,6 +114,12 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 	}
 	
 	@Test
+	public void testForIterator1() 
+	{
+		runForPredicateTest(8, false);
+	}
+	
+	@Test
 	public void testForConstDoubleSeqPredicate() 
 	{
 		runForPredicateTest(2, false);
@@ -158,6 +166,7 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 			case 5: TEST_NAME = TEST_NAME5; break;
 			case 6: TEST_NAME = TEST_NAME6; break;
 			case 7: TEST_NAME = TEST_NAME7; break;
+			case 8: TEST_NAME = TEST_NAME8; break;
 		}
 		
 		getAndLoadTestConfiguration(TEST_NAME);

--- a/src/test/java/org/apache/sysml/test/integration/functions/parfor/ForLoopPredicateTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/parfor/ForLoopPredicateTest.java
@@ -43,7 +43,7 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 	private final static String TEST_CLASS_DIR = TEST_DIR + ForLoopPredicateTest.class.getSimpleName() + "/";
 	
 	private final static double from = 1;
-	private final static double to = 10.2;
+	private final static double to = 450.2;
 	private final static int increment = 1;
 	
 	@Override
@@ -116,7 +116,7 @@ public class ForLoopPredicateTest extends AutomatedTestBase
 	@Test
 	public void testForIterator1() 
 	{
-		runForPredicateTest(8, false);
+		runForPredicateTest(8, true);
 	}
 	
 	@Test

--- a/src/test/scripts/functions/parfor/for_iterator1.dml
+++ b/src/test/scripts/functions/parfor/for_iterator1.dml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+sum = 0;
+X = matrix(seq(1, 9), rows=3, cols=3);
+for( [ Xb ] in [ X ] ) 
+{
+   sum = sum + sum(Xb); 
+}  
+
+R = matrix(1, rows=1, cols=1);
+R = R * sum;
+write(R, $4);       

--- a/src/test/scripts/functions/parfor/for_iterator1.dml
+++ b/src/test/scripts/functions/parfor/for_iterator1.dml
@@ -22,7 +22,7 @@
 
 sum = 0;
 X = matrix(1, rows=18, cols=25);
-for( [ Xb ] in [ X ], nrow = 4) 
+for(Xb in X, nrow = 4) 
 {
    sum = sum + sum(Xb); 
 }  

--- a/src/test/scripts/functions/parfor/for_iterator1.dml
+++ b/src/test/scripts/functions/parfor/for_iterator1.dml
@@ -21,8 +21,8 @@
 
 
 sum = 0;
-X = matrix(seq(1, 9), rows=3, cols=3);
-for( [ Xb ] in [ X ] ) 
+X = matrix(1, rows=18, cols=25);
+for( [ Xb ] in [ X ], nrow = 4) 
 {
    sum = sum + sum(Xb); 
 }  


### PR DESCRIPTION
This PR extends current for construct to support iterating over batch. The current version only supports iterating over batches of rows.

The syntax

```bash
for(X_batch in X, nrow=batch_size) {
  ...
}
```

is equivalent to

```bash
i = 0
for(i in 1:iters) {
	i = i + 1
	# Get next batch
	beg = ((i-1) * batch_size) %% N + 1
	end = min(N, beg + batch_size - 1)
	X_batch = X[beg:end,]
}
```

Experiment 1: **shows improvement using iterator for loop, but no significant improvement using prefetching**.

Dataset: 200K columns and Script: softmax_clf.dml

```bash
source("softmax_clf.dml") as clf
X = read("data/systemml/X_0.01_sample_256_3_binary")
Y = read("data/systemml/Y_0.01_sample_256_3_binary")
X_val = read("data/systemml/X_val_0.01_sample_256_3_binary")
Y_val = read("data/systemml/Y_val_0.01_sample_256_3_binary")
# Hyperparameters & Settings
lr = 5e-7  # learning rate
mu = 0.5  # momentum
decay = 0.999  # learning rate decay constant
batch_size = 50
epochs = 1
log_interval = 10
# Train
[W, b] = clf::train(X, Y, X_val, Y_val, lr, mu, decay, batch_size, epochs, log_interval)
```

A. Allocating prefetching budget (ml.setConfigProperty("prefetch.budget.mb", "300");) and iterable for loop:
```bash
Starting optimization
Start: Val Loss: 1.1936831561067827, Val Accuracy: 0.2855572653330402
Prefetching is enabled
Epoch: 1/1, Iter: 10/753.0, Train Loss: 1.1769918772735315, Train Accuracy: 0.24, Val Loss: 1.1662513221033104, Val Accuracy: 0.2975379204220708, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 20/753.0, Train Loss: 1.1226852777011096, Train Accuracy: 0.32, Val Loss: 1.1479864055092552, Val Accuracy: 0.3110573752473071, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 30/753.0, Train Loss: 1.069322506921968, Train Accuracy: 0.5, Val Loss: 1.1322553271688824, Val Accuracy: 0.3307320290173665, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 40/753.0, Train Loss: 1.1663166364466497, Train Accuracy: 0.26, Val Loss: 1.124131768587981, Val Accuracy: 0.3419432842382941, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 50/753.0, Train Loss: 1.1114673931690822, Train Accuracy: 0.4, Val Loss: 1.1110893916426992, Val Accuracy: 0.36183776654209715, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 60/753.0, Train Loss: 1.0944892736169403, Train Accuracy: 0.38, Val Loss: 1.104486857533245, Val Accuracy: 0.3710705649593317, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 70/753.0, Train Loss: 1.0699260059012738, Train Accuracy: 0.48, Val Loss: 1.1017615349975651, Val Accuracy: 0.3789843921741042, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 80/753.0, Train Loss: 1.2523247068918866, Train Accuracy: 0.26, Val Loss: 1.095198210877992, Val Accuracy: 0.3965706748735986, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 90/753.0, Train Loss: 1.0801937762762095, Train Accuracy: 0.46, Val Loss: 1.0890881087244735, Val Accuracy: 0.40855132996262916, lr: 5.0E-7, mu 0.5
SystemML Statistics:
Total elapsed time:             0.000 sec.
Total compilation time:         0.000 sec.
Total execution time:           0.000 sec.
Number of compiled Spark inst:  26.
Number of executed Spark inst:  3.
Batch fetching time (next, indexing):   7.623/9.084 sec.
Cache hits (Mem, WB, FS, HDFS): 4690/0/0/3.
Cache writes (WB, FS, HDFS):    848/0/0.
Cache times (ACQr/m, RLS, EXP): 126.553/0.004/0.027/0.000 sec.
HOP DAGs recompiled (PRED, SB): 0/108.
HOP DAGs recompile time:        0.308 sec.
Functions recompiled:           1.
Functions recompile time:       0.048 sec.
Spark ctx create time (lazy):   0.012 sec.
Spark trans counts (par,bc,col):0/0/0.
Spark trans times (par,bc,col): 0.000/0.000/0.000 secs.
Total JIT compile time:         23.416 sec.
Total JVM GC count:             21.
Total JVM GC time:              7.189 sec.
Heavy hitter instructions (name, time, count):
-- 1)   ba+*    139.701 sec     208
-- 2)   -       0.475 sec       722
-- 3)   -*      0.465 sec       198
-- 4)   sp_chkpoint     0.459 sec       3
-- 5)   *       0.442 sec       714
-- 6)   +*      0.419 sec       198
-- 7)   r'      0.165 sec       198
-- 8)   rand    0.061 sec       4
-- 9)   rangeReIndex    0.040 sec       99
-- 10)  exp     0.021 sec       109
```

Without allocating prefetching budget, but with iterable for loop:
```bash
Starting optimization
Start: Val Loss: 1.1002874077535665, Val Accuracy: 0.386018905253902
Epoch: 1/1, Iter: 10/753.0, Train Loss: 1.1448219097586048, Train Accuracy: 0.38, Val Loss: 1.088115106859373, Val Accuracy: 0.40657287315893603, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 20/753.0, Train Loss: 1.1456017339577074, Train Accuracy: 0.34, Val Loss: 1.0776543660411997, Val Accuracy: 0.42031215651791604, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 30/753.0, Train Loss: 1.2204002443773825, Train Accuracy: 0.34, Val Loss: 1.0701524768078519, Val Accuracy: 0.43196306880633106, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 40/753.0, Train Loss: 1.1296899921306, Train Accuracy: 0.46, Val Loss: 1.0673096215473679, Val Accuracy: 0.43526049681248624, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 50/753.0, Train Loss: 1.1049162219258544, Train Accuracy: 0.42, Val Loss: 1.0617350430268768, Val Accuracy: 0.44713123763464496, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 60/753.0, Train Loss: 1.1250952765796836, Train Accuracy: 0.27999999999999997, Val Loss: 1.0585163464816625, Val Accuracy: 0.45218729391074963, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 70/753.0, Train Loss: 1.273810265393501, Train Accuracy: 0.34, Val Loss: 1.0582418932050905, Val Accuracy: 0.4518575511101341, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 80/753.0, Train Loss: 1.2337767700979507, Train Accuracy: 0.32, Val Loss: 1.0553643341927361, Val Accuracy: 0.45702352165311055, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 90/753.0, Train Loss: 1.1335224225559153, Train Accuracy: 0.34, Val Loss: 1.0537834430747839, Val Accuracy: 0.4614200923279842, lr: 5.0E-7, mu 0.5
SystemML Statistics:
Total elapsed time:             0.000 sec.
Total compilation time:         0.000 sec.
Total execution time:           0.000 sec.
Number of compiled Spark inst:  26.
Number of executed Spark inst:  3.
Batch fetching time (next, indexing):   7.986/7.986 sec.
Cache hits (Mem, WB, FS, HDFS): 4690/0/0/3.
Cache writes (WB, FS, HDFS):    847/0/0.
Cache times (ACQr/m, RLS, EXP): 126.741/0.003/0.028/0.000 sec.
HOP DAGs recompiled (PRED, SB): 0/108.
HOP DAGs recompile time:        0.290 sec.
Functions recompiled:           1.
Functions recompile time:       0.046 sec.
Spark ctx create time (lazy):   0.012 sec.
Spark trans counts (par,bc,col):0/0/0.
Spark trans times (par,bc,col): 0.000/0.000/0.000 secs.
Total JIT compile time:         30.092 sec.
Total JVM GC count:             19.
Total JVM GC time:              7.293 sec.
Heavy hitter instructions (name, time, count):
-- 1)   ba+*    140.645 sec     208
-- 2)   -*      0.593 sec       198
-- 3)   +*      0.583 sec       198
-- 4)   -       0.475 sec       722
-- 5)   sp_chkpoint     0.441 sec       3
-- 6)   *       0.431 sec       714
-- 7)   r'      0.163 sec       198
-- 8)   rand    0.056 sec       4
-- 9)   rangeReIndex    0.030 sec       99
-- 10)  exp     0.020 sec       109
```


Without allocating prefetching budget and without iterable for loop:

```bash
Start: Val Loss: 1.1123706015939019, Val Accuracy: 0.36018905253901956
Epoch: 1/1, Iter: 10/753.0, Train Loss: 1.1457694414221513, Train Accuracy: 0.34, Val Loss: 1.1014415740752954, Val Accuracy: 0.3770059353704111, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 20/753.0, Train Loss: 1.1674865349022234, Train Accuracy: 0.32, Val Loss: 1.0913889553810663, Val Accuracy: 0.39690041767421413, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 30/753.0, Train Loss: 1.1339756964825467, Train Accuracy: 0.36, Val Loss: 1.0820898247467619, Val Accuracy: 0.41657507144427347, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 40/753.0, Train Loss: 1.082324381567407, Train Accuracy: 0.36, Val Loss: 1.0791439656997772, Val Accuracy: 0.4252582985271488, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 50/753.0, Train Loss: 1.0859172978403482, Train Accuracy: 0.36, Val Loss: 1.0739702698152656, Val Accuracy: 0.4348208397449989, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 60/753.0, Train Loss: 1.056797726485013, Train Accuracy: 0.46, Val Loss: 1.070153357384688, Val Accuracy: 0.44438338096284896, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 70/753.0, Train Loss: 1.1675601611133164, Train Accuracy: 0.3, Val Loss: 1.0688888106187338, Val Accuracy: 0.4483402945702352, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 80/753.0, Train Loss: 1.0243891087114836, Train Accuracy: 0.5, Val Loss: 1.0652748546034296, Val Accuracy: 0.45416575071444276, lr: 5.0E-7, mu 0.5
Epoch: 1/1, Iter: 90/753.0, Train Loss: 1.101844838180936, Train Accuracy: 0.4, Val Loss: 1.0625042848051243, Val Accuracy: 0.4606506924598813, lr: 5.0E-7, mu 0.5
SystemML Statistics:
Total elapsed time:             0.000 sec.
Total compilation time:         0.000 sec.
Total execution time:           0.000 sec.
Number of compiled Spark inst:  17.
Number of executed Spark inst:  101.
Cache hits (Mem, WB, FS, HDFS): 4548/0/0/101.
Cache writes (WB, FS, HDFS):    839/0/0.
Cache times (ACQr/m, RLS, EXP): 323.247/0.003/0.030/0.000 sec.
HOP DAGs recompiled (PRED, SB): 0/98.
HOP DAGs recompile time:        0.264 sec.
Functions recompiled:           1.
Functions recompile time:       0.047 sec.
Spark ctx create time (lazy):   0.012 sec.
Spark trans counts (par,bc,col):0/0/98.
Spark trans times (par,bc,col): 0.000/0.000/196.674 secs.
Total JIT compile time:         26.47 sec.
Total JVM GC count:             21.
Total JVM GC time:              4.137 sec.
Heavy hitter instructions (name, time, count):
-- 1)   ba+*    336.563 sec     206
-- 2)   sp_chkpoint     0.484 sec       3
-- 3)   -       0.457 sec       715
-- 4)   -*      0.433 sec       196
-- 5)   +*      0.417 sec       196
-- 6)   *       0.399 sec       707
-- 7)   sp_rangeReIndex         0.290 sec       98
-- 8)   r'      0.159 sec       196
-- 9)   rand    0.059 sec       4
-- 10)  rangeReIndex    0.023 sec       98
```

Experiment 2: TODO after discussion: Try with larger network to exploit prefetching.

Note: `Batch fetching time (next, indexing):   .../... sec.` time. If both are equal, then no benefits was observed with prefetching (or prefetching was disabled).  When indexing time > next, we might likely observe some benefits with prefetching.

@dusenberrymw @mboehm7 @bertholdreinwald @frreiss @asurve 