### PR TITLE
[SYSTEMML-1271] Increment minimum Spark version in MLContext

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
@@ -58,7 +58,7 @@ public class MLContext {
 	/**
 	 * Minimum Spark version supported by SystemML.
 	 */
-	public static final String SYSTEMML_MINIMUM_SPARK_VERSION = "1.4.0";
+	public static final String SYSTEMML_MINIMUM_SPARK_VERSION = "2.1.0";
 
 	/**
 	 * SparkContext object.
@@ -211,12 +211,13 @@ public class MLContext {
 	 */
 	private void initMLContext(SparkContext sc, boolean monitorPerformance) {
 
+		MLContextUtil.verifySparkVersionSupported(sc);
+
 		if (activeMLContext == null) {
 			System.out.println(MLContextUtil.welcomeMessage());
 		}
 
 		this.sc = sc;
-		MLContextUtil.verifySparkVersionSupported(sc);
 		// by default, run in hybrid Spark mode for optimal performance
 		DMLScript.rtplatform = RUNTIME_PLATFORM.HYBRID_SPARK;
 

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
@@ -169,7 +169,7 @@ public final class MLContextUtil {
 	public static void verifySparkVersionSupported(SparkContext sc) {
 		if (!MLContextUtil.isSparkVersionSupported(sc.version())) {
 			throw new MLContextException(
-					"SystemML requires Spark " + MLContext.SYSTEMML_MINIMUM_SPARK_VERSION + " or greater");
+					"This version of SystemML requires Spark " + MLContext.SYSTEMML_MINIMUM_SPARK_VERSION + " or greater.");
 		}
 	}
 
@@ -502,6 +502,7 @@ public final class MLContextUtil {
 			FrameBlock frameBlock = (FrameBlock) value;
 			return MLContextConversionUtil.frameBlockToFrameObject(name, frameBlock, (FrameMetadata) metadata);
 		} else if (value instanceof Dataset<?>) {
+			@SuppressWarnings("unchecked")
 			Dataset<Row> dataFrame = (Dataset<Row>) value;
 
 			if (hasMatrixMetadata) {


### PR DESCRIPTION
Increment MLContext minimum Spark version to 2.1.0.
Don't display welcome message if minimum Spark version not supported.