### PR TITLE
[SYSTEMML-1276] Resolve jersey class with Spark2 for YARN-5271

### DIFF
--- a/src/main/java/org/apache/sysml/conf/ConfigurationManager.java
+++ b/src/main/java/org/apache/sysml/conf/ConfigurationManager.java
@@ -21,7 +21,7 @@ package org.apache.sysml.conf;
 
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.sysml.conf.CompilerConfig.ConfigType;
-
+import org.apache.sysml.hops.OptimizerUtils;
 
 
 /**
@@ -50,6 +50,11 @@ public class ConfigurationManager
     //global static initialization
 	static {
 		_rJob = new JobConf();
+		if (OptimizerUtils.isSparkExecutionMode()) {
+			// Work-around jersey issue in https://issues.apache.org/jira/browse/YARN-5271
+			// and https://issues.apache.org/jira/browse/SPARK-15343.
+			_rJob.set("yarn.timeline-service.enabled", "false");
+		}
 		
 		//initialization after job conf in order to prevent cyclic initialization issues 
 		//ConfigManager -> OptimizerUtils -> InfrastructureAnalyer -> ConfigManager 

--- a/src/main/java/org/apache/sysml/yarn/DMLAppMaster.java
+++ b/src/main/java/org/apache/sysml/yarn/DMLAppMaster.java
@@ -38,10 +38,10 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.conf.ConfigurationManager;
 import org.apache.sysml.conf.DMLConfig;
+import org.apache.sysml.hops.OptimizerUtils;
 import org.apache.sysml.runtime.DMLScriptException;
 
 public class DMLAppMaster 
@@ -64,6 +64,11 @@ public class DMLAppMaster
 		throws YarnException, IOException
 	{
 		_conf = new YarnConfiguration();
+		if (OptimizerUtils.isSparkExecutionMode()) {
+			// Work-around jersey issue in https://issues.apache.org/jira/browse/YARN-5271
+			// and https://issues.apache.org/jira/browse/SPARK-15343.
+			_conf.set("yarn.timeline-service.enabled", "false");
+		}
 		
 		//obtain application ID
 		String containerIdString = System.getenv(Environment.CONTAINER_ID.name());

--- a/src/main/java/org/apache/sysml/yarn/DMLYarnClient.java
+++ b/src/main/java/org/apache/sysml/yarn/DMLYarnClient.java
@@ -53,8 +53,8 @@ import org.apache.hadoop.yarn.client.api.YarnClientApplication;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
-
 import org.apache.sysml.conf.DMLConfig;
+import org.apache.sysml.hops.OptimizerUtils;
 import org.apache.sysml.parser.ParseException;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.DMLScriptException;
@@ -157,6 +157,11 @@ public class DMLYarnClient
 			
 			// load yarn configuration
 			YarnConfiguration yconf = new YarnConfiguration();
+			if (OptimizerUtils.isSparkExecutionMode()) {
+				// Work-around jersey issue in https://issues.apache.org/jira/browse/YARN-5271
+				// and https://issues.apache.org/jira/browse/SPARK-15343.
+				yconf.set("yarn.timeline-service.enabled", "false");
+			}
 			
 			// create yarn client
 			YarnClient yarnClient = YarnClient.createYarnClient();

--- a/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
+++ b/src/main/java/org/apache/sysml/yarn/ropt/YarnClusterAnalyzer.java
@@ -518,6 +518,11 @@ public class YarnClusterAnalyzer
 	
 	public static void analyzeYarnCluster(boolean verbose) {
 		YarnConfiguration conf = new YarnConfiguration();
+		if (OptimizerUtils.isSparkExecutionMode()) {
+			// Work-around jersey issue in https://issues.apache.org/jira/browse/YARN-5271
+			// and https://issues.apache.org/jira/browse/SPARK-15343.
+			conf.set("yarn.timeline-service.enabled", "false");
+		}
 		YarnClient yarnClient = YarnClient.createYarnClient();
 		yarnClient.init(conf);
 		yarnClient.start();


### PR DESCRIPTION
This patch disables ATS via set("yarn.timeline-service.enabled", "false") in Yarn/Hadoop configurations for SystemML in spark mode only.  In this way, a user doesn't have to manually change cluster configuration.