### PR TITLE
[SYSTEMML-1211] Update dependencies for Spark 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 	</mailingLists>
 
 	<properties>
-		<hadoop.version>2.4.1</hadoop.version>
+		<hadoop.version>2.6.0</hadoop.version>
 		<antlr.version>4.5.3</antlr.version>
 		<spark.version>2.1.0</spark.version>
 		<scala.version>2.11.8</scala.version>
@@ -1055,13 +1055,6 @@
 		</dependency>
 		 -->
 		<!-- ************************* -->
-	
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-core_${scala.binary.version}</artifactId>
-			<version>${spark.version}</version>
-			<scope>provided</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>org.apache.spark</groupId>
@@ -1069,23 +1062,6 @@
 			<version>${spark.version}</version>
 			<scope>provided</scope>
 		</dependency>
-
-		<!-- To support dataframe in mlcontext -->
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-sql_${scala.binary.version}</artifactId>
-			<version>${spark.version}</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<!-- Adding Gauva version 14.0.1 to workaround conflict between spark and hadoop dependency -->
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>14.0.1</version>
-			<scope>provided</scope>
-		</dependency>
-
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
@@ -1115,12 +1091,6 @@
 			<artifactId>hadoop-client</artifactId>
 			<version>${hadoop.version}</version>
 			<scope>provided</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>javax.servlet</groupId>
-					<artifactId>servlet-api</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
@@ -1139,23 +1109,17 @@
 			<artifactId>hadoop-mapreduce-client-jobclient</artifactId>
 			<version>${hadoop.version}</version>
 			<scope>provided</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>javax.servlet</groupId>
-					<artifactId>servlet-api</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
-			<version>1.1.1</version>
+			<version>1.1.3</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-math3</artifactId>
-			<version>3.1.1</version>
+			<version>3.4.1</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -1183,7 +1147,7 @@
 		<dependency>
 			<groupId>net.sf.opencsv</groupId>
 			<artifactId>opencsv</artifactId>
-			<version>1.8</version>
+			<version>2.3</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -1200,12 +1164,6 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>stax</groupId>
-			<artifactId>stax-api</artifactId>
-			<version>1.0.1</version>
-			<scope>provided</scope>
-		</dependency>
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
@@ -1244,12 +1202,6 @@
 			<artifactId>hadoop-yarn-common</artifactId>
 			<version>${hadoop.version}</version>
 			<scope>provided</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>javax.servlet</groupId>
-					<artifactId>servlet-api</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -1275,7 +1227,7 @@
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scalap</artifactId>
 			<version>${scala.version}</version>
-		<scope>provided</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.scalatest</groupId>

--- a/src/assembly/bin/LICENSE
+++ b/src/assembly/bin/LICENSE
@@ -210,28 +210,28 @@ commons-collections-3.2.1.jar
 commons-configuration-1.6.jar
 commons-httpclient-3.1.jar
 commons-lang-2.6.jar
-commons-logging-1.1.1.jar
-commons-math3-3.1.1.jar
-guava-14.0.1.jar
-hadoop-auth-2.4.1.jar
-hadoop-client-2.4.1.jar
-hadoop-common-2.4.1.jar
-hadoop-hdfs-2.4.1.jar
-hadoop-mapreduce-client-app-2.4.1.jar
-hadoop-mapreduce-client-common-2.4.1.jar
-hadoop-mapreduce-client-core-2.4.1.jar
-hadoop-mapreduce-client-jobclient-2.4.1.jar
-hadoop-mapreduce-client-shuffle-2.4.1.jar
-hadoop-yarn-api-2.4.1.jar
-hadoop-yarn-client-2.4.1.jar
-hadoop-yarn-common-2.4.1.jar
-hadoop-yarn-server-common-2.4.1.jar
-hadoop-yarn-server-nodemanager-2.4.1.jar
-hadoop-yarn-server-web-proxy-2.4.1.jar
-jackson-core-asl-1.8.8.jar
-jackson-mapper-asl-1.8.8.jar
+commons-logging-1.1.3.jar
+commons-math3-3.4.1.jar
+guava-11.0.2.jar
+hadoop-auth-2.6.0.jar
+hadoop-client-2.6.0.jar
+hadoop-common-2.6.0.jar
+hadoop-hdfs-2.6.0.jar
+hadoop-mapreduce-client-app-2.6.0.jar
+hadoop-mapreduce-client-common-2.6.0.jar
+hadoop-mapreduce-client-core-2.6.0.jar
+hadoop-mapreduce-client-jobclient-2.6.0.jar
+hadoop-mapreduce-client-shuffle-2.6.0.jar
+hadoop-yarn-api-2.6.0.jar
+hadoop-yarn-client-2.6.0.jar
+hadoop-yarn-common-2.6.0.jar
+hadoop-yarn-server-common-2.6.0.jar
+hadoop-yarn-server-nodemanager-2.6.0.jar
+hadoop-yarn-server-web-proxy-2.6.0.jar
+jackson-core-asl-1.9.13.jar
+jackson-mapper-asl-1.9.13.jar
 log4j-1.2.15.jar
-opencsv-1.8.jar
+opencsv-2.3.jar
 
 The following windows-only components come under the Apache Software License 2.0.
 
@@ -288,7 +288,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following Protocol Buffer Java API dependencies are distributed under the BSD license.
 
 Protocol Buffer Java API (http://code.google.com/p/protobuf) com.google.protobuf:protobuf-java:2.5.0 (protobuf-java-2.5.0.jar)
-Protocol Buffer Java API (http://code.google.com/p/protobuf) org.spark-project.protobuf:protobuf-java:2.5.0-spark (protobuf-java-2.5.0-spark.jar)
 
 Copyright 2014, Google Inc.  All rights reserved.
 
@@ -322,8 +321,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following SLF4J dependencies are distributed under the MIT license.
 
-SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:1.7.10 (slf4j-api-1.7.10.jar)
-SLF4J LOG4J-12 Binding (http://www.slf4j.org) org.slf4j:slf4j-log4j12:1.7.10 (slf4j-log4j12-1.7.10.jar)
+SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:1.7.5 (slf4j-api-1.7.5.jar)
+SLF4J LOG4J-12 Binding (http://www.slf4j.org) org.slf4j:slf4j-log4j12:1.7.5 (slf4j-log4j12-1.7.5.jar)
 
 Copyright (c) 2004-2008 QOS.ch
 All rights reserved.

--- a/src/assembly/inmemory/LICENSE
+++ b/src/assembly/inmemory/LICENSE
@@ -207,12 +207,12 @@ The following dependencies come under the Apache Software License 2.0.
 commons-collections:commons-collections:3.2.1
 commons-configuration:commons-configuration:1.6
 commons-lang:commons-lang:2.6
-commons-logging:commons-logging:1.1.1
+commons-logging:commons-logging:1.1.3
 log4j:log4j:1.2.15
-org.apache.commons:commons-lang3:3.3.2
-org.apache.hadoop:hadoop-auth:2.4.1
-org.apache.hadoop:hadoop-common:2.4.1
-org.apache.hadoop:hadoop-mapreduce-client-core:2.4.1
+org.apache.commons:commons-lang3:3.5
+org.apache.hadoop:hadoop-auth:2.6.0
+org.apache.hadoop:hadoop-common:2.6.0
+org.apache.hadoop:hadoop-mapreduce-client-core:2.6.0
 
 Compile-scope dependencies:
 org.apache.wink:wink-json4j:1.4
@@ -261,8 +261,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following SLF4J dependencies are distributed under the MIT license.
 
-SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:1.7.10
-SLF4J LOG4J-12 Binding (http://www.slf4j.org) org.slf4j:slf4j-log4j12:1.7.10
+SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:1.7.5
+SLF4J LOG4J-12 Binding (http://www.slf4j.org) org.slf4j:slf4j-log4j12:1.7.5
 
 Copyright (c) 2004-2008 QOS.ch
 All rights reserved.

--- a/src/assembly/standalone-jar/LICENSE
+++ b/src/assembly/standalone-jar/LICENSE
@@ -204,33 +204,33 @@
 
 The following dependencies come under the Apache Software License 2.0.
 
-com.google.guava:guava:14.0.1
+com.google.guava:guava:11.0.2
 commons-cli:commons-cli:1.2
 commons-collections:commons-collections:3.2.1
 commons-configuration:commons-configuration:1.6
 commons-lang:commons-lang:2.6
-commons-logging:commons-logging:1.1.1
+commons-logging:commons-logging:1.1.3
 log4j:log4j:1.2.15
-net.sf.opencsv:opencsv:1.8
+net.sf.opencsv:opencsv:2.3
 org.apache.avro:avro:1.7.4
-org.apache.commons:commons-math3:3.1.1
-org.apache.hadoop:hadoop-auth:2.4.1
-org.apache.hadoop:hadoop-client:2.4.1
-org.apache.hadoop:hadoop-common:2.4.1
-org.apache.hadoop:hadoop-hdfs:2.4.1
-org.apache.hadoop:hadoop-mapreduce-client-app:2.4.1
-org.apache.hadoop:hadoop-mapreduce-client-common:2.4.1
-org.apache.hadoop:hadoop-mapreduce-client-core:2.4.1
-org.apache.hadoop:hadoop-mapreduce-client-jobclient:2.4.1
-org.apache.hadoop:hadoop-mapreduce-client-shuffle:2.4.1
-org.apache.hadoop:hadoop-yarn-api:2.4.1
-org.apache.hadoop:hadoop-yarn-client:2.4.1
-org.apache.hadoop:hadoop-yarn-common:2.4.1
-org.apache.hadoop:hadoop-yarn-server-common:2.4.1
-org.apache.hadoop:hadoop-yarn-server-nodemanager:2.4.1
-org.apache.hadoop:hadoop-yarn-server-web-proxy:2.4.1
-org.codehaus.jackson:jackson-core-asl:1.8.8
-org.codehaus.jackson:jackson-mapper-asl:1.8.8
+org.apache.commons:commons-math3:3.4.1
+org.apache.hadoop:hadoop-auth:2.6.0
+org.apache.hadoop:hadoop-client:2.6.0
+org.apache.hadoop:hadoop-common:2.6.0
+org.apache.hadoop:hadoop-hdfs:2.6.0
+org.apache.hadoop:hadoop-mapreduce-client-app:2.6.0
+org.apache.hadoop:hadoop-mapreduce-client-common:2.6.0
+org.apache.hadoop:hadoop-mapreduce-client-core:2.6.0
+org.apache.hadoop:hadoop-mapreduce-client-jobclient:2.6.0
+org.apache.hadoop:hadoop-mapreduce-client-shuffle:2.6.0
+org.apache.hadoop:hadoop-yarn-api:2.6.0
+org.apache.hadoop:hadoop-yarn-client:2.6.0
+org.apache.hadoop:hadoop-yarn-common:2.6.0
+org.apache.hadoop:hadoop-yarn-server-common:2.6.0
+org.apache.hadoop:hadoop-yarn-server-nodemanager:2.6.0
+org.apache.hadoop:hadoop-yarn-server-web-proxy:2.6.0
+org.codehaus.jackson:jackson-core-asl:1.9.13
+org.codehaus.jackson:jackson-mapper-asl:1.9.13
 
 Compile-scope dependencies:
 org.apache.wink:wink-json4j:1.4
@@ -280,7 +280,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following Protocol Buffer Java API dependencies are distributed under the BSD license.
 
 Protocol Buffer Java API (http://code.google.com/p/protobuf) com.google.protobuf:protobuf-java:2.5.0 (protobuf-java-2.5.0.jar)
-Protocol Buffer Java API (http://code.google.com/p/protobuf) org.spark-project.protobuf:protobuf-java:2.5.0-spark (protobuf-java-2.5.0-spark.jar)
 
 Copyright 2014, Google Inc.  All rights reserved.
 
@@ -314,8 +313,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following SLF4J dependencies are distributed under the MIT license.
 
-SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:1.7.10
-SLF4J LOG4J-12 Binding (http://www.slf4j.org) org.slf4j:slf4j-log4j12:1.7.10
+SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:1.7.5
+SLF4J LOG4J-12 Binding (http://www.slf4j.org) org.slf4j:slf4j-log4j12:1.7.5
 
 Copyright (c) 2004-2008 QOS.ch
 All rights reserved.


### PR DESCRIPTION
Remove Spark core and sql dependencies since they are transitive dependencies of mllib.
Remove Spark/Hadoop Guava workaround.
Update Hadoop version to 2.6.0 so as to minimize risk of incompatible jars.
Remove unnecessary servlet-api exclusions.
Increment commons-logging, commons-math3, opencsv versions.
Remove stax-api dependency.
Update licenses with version updates.
