### PR TITLE
[SYSTEMML-1280] Restore and deprecate SQLContext methods

### DIFF
--- a/src/main/java/org/apache/sysml/api/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/MLContext.java
@@ -37,6 +37,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.api.jmlc.JMLCUtils;
@@ -1593,5 +1594,20 @@ public class MLContext {
 		JavaPairRDD<MatrixIndexes, MatrixBlock> blocks = out.getBinaryBlockedRDD("output");
 		MatrixCharacteristics mcOut = out.getMatrixCharacteristics("output");
 		return MLMatrix.createMLMatrix(this, sparkSession, blocks, mcOut);
-	}	
+	}
+
+	/**
+	 * Experimental API: Might be discontinued in future release
+	 * @param sqlContext the SQL Context
+	 * @param filePath the file path
+	 * @param format the format
+	 * @return the MLMatrix
+	 * @throws IOException if IOException occurs
+	 * @throws DMLException if DMLException occurs
+	 * @throws ParseException if ParseException occurs
+	 */
+	public MLMatrix read(SQLContext sqlContext, String filePath, String format) throws IOException, DMLException, ParseException {
+		SparkSession sparkSession = sqlContext.sparkSession();
+		return read(sparkSession, filePath, format);
+	}
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/FrameRDDConverterUtils.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/FrameRDDConverterUtils.java
@@ -42,6 +42,7 @@ import org.apache.spark.ml.linalg.VectorUDT;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
@@ -283,6 +284,14 @@ public class FrameRDDConverterUtils
 	
 		//rdd to data frame conversion
 		return sparkSession.createDataFrame(rowRDD, dfSchema);
+	}
+	
+	@Deprecated
+	public static Dataset<Row> binaryBlockToDataFrame(SQLContext sqlContext, JavaPairRDD<Long,FrameBlock> in, 
+			MatrixCharacteristics mc, ValueType[] schema)
+	{
+		SparkSession sparkSession = sqlContext.sparkSession();
+		return binaryBlockToDataFrame(sparkSession, in, mc, schema);
 	}
 	
 	

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtils.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtils.java
@@ -42,6 +42,7 @@ import org.apache.spark.ml.linalg.Vectors;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
@@ -284,6 +285,14 @@ public class RDDConverterUtils
 		
 		//rdd to data frame conversion
 		return sparkSession.createDataFrame(rowsRDD.rdd(), DataTypes.createStructType(fields));
+	}
+
+	@Deprecated
+	public static Dataset<Row> binaryBlockToDataFrame(SQLContext sqlContext,
+			JavaPairRDD<MatrixIndexes, MatrixBlock> in, MatrixCharacteristics mc, boolean toVector)  
+	{
+		SparkSession sparkSession = sqlContext.sparkSession();
+		return binaryBlockToDataFrame(sparkSession, in, mc, toVector);
 	}
 
 	public static JavaPairRDD<LongWritable, Text> stringToSerializableText(JavaPairRDD<Long,String> in)

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
@@ -236,7 +236,22 @@ public class RDDConverterUtilsExt
 		JavaRDD<Row> newRows = df.rdd().toJavaRDD().zipWithIndex().map(new AddRowID());
 		return sparkSession.createDataFrame(newRows, new StructType(newSchema));
 	}
-	
+
+	/**
+	 * Add element indices as new column to DataFrame
+	 * 
+	 * @param df input data frame
+	 * @param sqlContext the SQL Context
+	 * @param nameOfCol name of index column
+	 * @return new data frame
+	 * 
+	 * @deprecated This will be removed in SystemML 1.0.
+	 */
+	@Deprecated
+	public static Dataset<Row> addIDToDataFrame(Dataset<Row> df, SQLContext sqlContext, String nameOfCol) {
+		SparkSession sparkSession = sqlContext.sparkSession();
+		return addIDToDataFrame(df, sparkSession, nameOfCol);
+	}
 	
 	
 	private static class MatrixEntryToBinaryBlockFunction implements PairFlatMapFunction<Iterator<MatrixEntry>,MatrixIndexes,MatrixBlock> 


### PR DESCRIPTION
Restore Java SQLContext method signatures (migrated to SparkSession by
SYSTEMML-1194) in case any users are using the old SystemML methods and
are unable to use SparkSessions.
Applies to old MLContext, MLMatrix, MLOutput, FrameRDDConverterUtils,
RDDConverterUtils, and RDDConverterUtilsExt.