### PR TITLE
[SYSTEMML-1246] Use correct jar name in sparkDML.sh of -bin artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,27 @@
 							<outputDirectory>${basedir}/target/lib/hadoop/bin</outputDirectory>
 						</configuration>
 					</execution>
+					
+					<execution>
+						<id>copy-resources-filtered</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<overwrite>true</overwrite>
+							<outputDirectory>${basedir}/target/scripts</outputDirectory>
+							<resources>
+								<resource>
+									<directory>${basedir}/src/main/resources/scripts</directory>
+									<includes>
+										<include>sparkDML.sh</include>
+									</includes>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 

--- a/src/assembly/bin.xml
+++ b/src/assembly/bin.xml
@@ -41,8 +41,15 @@
 				<exclude>perftest</exclude>
 				<exclude>staging/**/*</exclude>
 				<exclude>staging</exclude>
-				<!-- <exclude>*.sh</exclude> --> <!-- applies to sparkDML.sh -->
+				<exclude>sparkDML.sh</exclude>
 			</excludes>
+			<outputDirectory>scripts</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<directory>${basedir}/target/scripts</directory>
+			<includes>
+				<include>sparkDML.sh</include>
+			</includes>
 			<outputDirectory>scripts</outputDirectory>
 		</fileSet>
 

--- a/src/main/resources/scripts/sparkDML.sh
+++ b/src/main/resources/scripts/sparkDML.sh
@@ -114,7 +114,7 @@ $SPARK_HOME/bin/spark-submit \
      ${executor_memory} \
      ${executor_cores} \
      ${conf} \
-     ${SYSTEMML_HOME}/SystemML.jar \
+     ${SYSTEMML_HOME}/${project.artifactId}-${project.version}.jar \
          -f ${f} \
          -config=${SYSTEMML_HOME}/SystemML-config.xml \
          -exec hybrid_spark \


### PR DESCRIPTION
Added resource filter to use correct jar name in sparkDML.sh of -bin artifact.  The pattern {project.artifactId}-${project.version} was used to handle both snapshot and release builds.