### PR TITLE
[SYSTEMML-871] Remove optional python flag from docs examples

### DIFF
--- a/docs/beginners-guide-to-dml-and-pydml.md
+++ b/docs/beginners-guide-to-dml-and-pydml.md
@@ -50,13 +50,13 @@ DML and PyDML scripts can be invoked in a variety of ways. Suppose that we have 
 
 	print('hello ' + $1)
 
-One way to begin working with SystemML is to [download a standalone distribution of SystemML](http://systemml.apache.org/download.html)
+One way to begin working with SystemML is to [download a binary distribution of SystemML](http://systemml.apache.org/download.html)
 and use the `runStandaloneSystemML.sh` and `runStandaloneSystemML.bat` scripts to run SystemML in standalone
-mode. The name of the DML or PyDML script
-is passed as the first argument to these scripts, along with a variety of arguments.
+mode. The name of the DML or PyDML script is passed as the first argument to these scripts,
+along with a variety of arguments. Note that PyDML invocation can be forced with the addition of a `-python` flag.
 
 	./runStandaloneSystemML.sh hello.dml -args world
-	./runStandaloneSystemML.sh hello.pydml -python -args world
+	./runStandaloneSystemML.sh hello.pydml -args world
 
 
 # Data Types
@@ -778,7 +778,7 @@ for (i in 0:numRowsToPrint-1):
 
 <div data-lang="PyDML Named Arguments and Results" markdown="1">
 	Example #1 Arguments:
-	-f ex.pydml -python -nvargs M=m.csv rowsToPrint=1 colsToPrint=3
+	-f ex.pydml -nvargs M=m.csv rowsToPrint=1 colsToPrint=3
 	
 	Example #1 Results:
 	[0,0]:1.0
@@ -786,7 +786,7 @@ for (i in 0:numRowsToPrint-1):
 	[0,2]:3.0
 	
 	Example #2 Arguments:
-	-f ex.pydml -python -nvargs M=m.csv
+	-f ex.pydml -nvargs M=m.csv
 	
 	Example #2 Results:
 	[0,0]:1.0
@@ -860,7 +860,7 @@ for (i in 0:numRowsToPrint-1):
 
 <div data-lang="PyDML Positional Arguments and Results" markdown="1">
 	Example #1 Arguments:
-	-f ex.pydml -python -args m.csv 1 3
+	-f ex.pydml -args m.csv 1 3
 	
 	Example #1 Results:
 	[0,0]:1.0
@@ -868,7 +868,7 @@ for (i in 0:numRowsToPrint-1):
 	[0,2]:3.0
 	
 	Example #2 Arguments:
-	-f ex.pydml -python -args m.csv
+	-f ex.pydml -args m.csv
 	
 	Example #2 Results:
 	[0,0]:1.0
@@ -885,5 +885,5 @@ for (i in 0:numRowsToPrint-1):
 
 The [Language Reference](dml-language-reference.html) contains highly detailed information regarding DML.
 
-In addition, many excellent examples of DML and PyDML can be found in the [`scripts`](https://github.com/apache/incubator-systemml/tree/master/scripts) directory.
+In addition, many excellent examples can be found in the [`scripts`](https://github.com/apache/incubator-systemml/tree/master/scripts) directory.
 

--- a/docs/dml-language-reference.md
+++ b/docs/dml-language-reference.md
@@ -61,8 +61,6 @@ limitations under the License.
     * [Transforming Frames](dml-language-reference.html#transforming-frames)
   * [Modules](dml-language-reference.html#modules)
   * [Reserved Keywords](dml-language-reference.html#reserved-keywords)
-  * [Invocation of SystemML](dml-language-reference.html#invocation-of-systemml)
-  * [MLContext API](dml-language-reference.html#mlcontext-api)
 
 
 ## Introduction
@@ -334,7 +332,7 @@ var is an integer scalar variable. lower, upper, and increment are integer expre
 
 [lower]:[upper] defines a sequence of numbers with increment 1: {lower, lower + 1, lower + 2, …, upper – 1, upper}.
 
-Similarly, seq([lower],[upper],[increment]) defines a sequence of numbers: {lower, lower + increment, lower + 2(increment), … }. For each element in the sequence, var is assigned the value, and statements in the for loop body are executed.
+Similarly, `seq([lower],[upper],[increment])` defines a sequence of numbers: {lower, lower + increment, lower + 2(increment), … }. For each element in the sequence, var is assigned the value, and statements in the for loop body are executed.
 
 The for loop body may contain any sequence of statements. The statements in the for statement body must be surrounded by braces, even if the body only has a single statement.
 

--- a/docs/engine-dev-guide.md
+++ b/docs/engine-dev-guide.md
@@ -63,7 +63,7 @@ The `DMLScript` class serves as the main entrypoint to SystemML. Executing
 `DMLScript` with no arguments displays usage information. A script file can be specified using the `-f` argument.
 
 In Eclipse, a Debug Configuration can be created with `DMLScript` as the Main class and any arguments specified as
-Program arguments. A PyDML script requires the addition of a `-python` switch.
+Program arguments.
 
 Suppose that we have a `hello.dml` script containing the following:
 


### PR DESCRIPTION
Update Beginner's Guide and Engine Dev Guide for python flag.
Fix or remove broken links in DML Language Ref.