### PR TITLE
[MINOR] Boolean hashcode for Java previous to 8

### DIFF
--- a/src/main/java/org/apache/sysml/hops/codegen/cplan/CNode.java
+++ b/src/main/java/org/apache/sysml/hops/codegen/cplan/CNode.java
@@ -144,7 +144,7 @@ public abstract class CNode
 					tmp[pos++] = c.hashCode();
 			tmp[numIn+0] = (_output!=null)?_output.hashCode():0;
 			tmp[numIn+1] = (_dataType!=null)?_dataType.hashCode():0;
-			tmp[numIn+2] = Boolean.hashCode(_literal);		
+			tmp[numIn+2] = Boolean.valueOf(_literal).hashCode();
 			_hash = Arrays.hashCode(tmp);
 		}
 		return _hash;

--- a/src/main/java/org/apache/sysml/hops/codegen/cplan/CNodeOuterProduct.java
+++ b/src/main/java/org/apache/sysml/hops/codegen/cplan/CNodeOuterProduct.java
@@ -146,7 +146,7 @@ public class CNodeOuterProduct extends CNodeTpl
 		if( _hash == 0 ) {
 			int h1 = super.hashCode();
 			int h2 = _type.hashCode();
-			int h3 = Boolean.hashCode(_transposeOutput);
+			int h3 = Boolean.valueOf(_transposeOutput).hashCode();
 			_hash = Arrays.hashCode(new int[]{h1,h2,h3});
 		}
 		return _hash;


### PR DESCRIPTION
Boolean.hashCode(value) was added in Java 8. Can update to Boolean.valueOf(value).hashCode() for Java 7 (and 6).