### PR TITLE
[SYSTEMML-1354] Move minimum recommended Spark version to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
 		<hadoop.version>2.6.0</hadoop.version>
 		<antlr.version>4.5.3</antlr.version>
 		<spark.version>2.1.0</spark.version>
+		<minimum.recommended.spark.version>2.1.0</minimum.recommended.spark.version>
 		<scala.version>2.11.8</scala.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<scala.test.version>2.2.6</scala.test.version>
@@ -519,6 +520,7 @@
 									<Group-Id>${project.groupId}</Group-Id>
 									<Artifact-Id>${project.artifactId}</Artifact-Id>
 									<Version>${project.version}</Version>
+									<Minimum-Recommended-Spark-Version>${minimum.recommended.spark.version}</Minimum-Recommended-Spark-Version>
 								</manifestEntries>
 							</archive>
 						</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
 		<hadoop.version>2.6.0</hadoop.version>
 		<antlr.version>4.5.3</antlr.version>
 		<spark.version>2.1.0</spark.version>
-		<minimum.recommended.spark.version>2.1.0</minimum.recommended.spark.version>
 		<scala.version>2.11.8</scala.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<scala.test.version>2.2.6</scala.test.version>
@@ -520,7 +519,7 @@
 									<Group-Id>${project.groupId}</Group-Id>
 									<Artifact-Id>${project.artifactId}</Artifact-Id>
 									<Version>${project.version}</Version>
-									<Minimum-Recommended-Spark-Version>${minimum.recommended.spark.version}</Minimum-Recommended-Spark-Version>
+									<Minimum-Recommended-Spark-Version>${spark.version}</Minimum-Recommended-Spark-Version>
 								</manifestEntries>
 							</archive>
 						</configuration>

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
@@ -57,11 +57,6 @@ import org.apache.sysml.utils.Explain.ExplainType;
  */
 public class MLContext {
 	/**
-	 * Minimum Spark version supported by SystemML.
-	 */
-	public static final String SYSTEMML_MINIMUM_SPARK_VERSION = "2.1.0";
-
-	/**
 	 * Logger for MLContext
 	 */
 	public static Logger log = Logger.getLogger(MLContext.class);
@@ -109,11 +104,6 @@ public class MLContext {
 	 * explain is set to true.
 	 */
 	private ExplainLevel explainLevel = null;
-
-	/**
-	 * Project information such as the version and the build time.
-	 */
-	private ProjectInfo projectInfo = null;
 
 	/**
 	 * Whether or not all values should be maintained in the symbol table
@@ -220,7 +210,16 @@ public class MLContext {
 		try {
 			MLContextUtil.verifySparkVersionSupported(sc);
 		} catch (MLContextException e) {
-			log.warn("Apache Spark " + SYSTEMML_MINIMUM_SPARK_VERSION + " or above is recommended for SystemML " + this.info().version());
+			if (info() != null) {
+				log.warn("Apache Spark " + this.info().minimumRecommendedSparkVersion() + " or above is recommended for SystemML " + this.info().version());
+			} else {
+				try {
+					String minSparkVersion = MLContextUtil.getMinimumRecommendedSparkVersionFromPom();
+					log.warn("Apache Spark " + minSparkVersion + " or above is recommended for this version of SystemML.");
+				} catch (MLContextException e1) {
+					log.error("Minimum recommended Spark version could not be determined from SystemML jar file manifest or pom.xml");
+				}
+			}
 		}
 
 		if (activeMLContext == null) {
@@ -627,10 +626,13 @@ public class MLContext {
 	 * @return information about the project
 	 */
 	public ProjectInfo info() {
-		if (projectInfo == null) {
-			projectInfo = new ProjectInfo();
+		try {
+			ProjectInfo projectInfo = ProjectInfo.getProjectInfo();
+			return projectInfo;
+		} catch (Exception e) {
+			log.warn("Project information not available");
+			return null;
 		}
-		return projectInfo;
 	}
 
 	/**
@@ -639,6 +641,9 @@ public class MLContext {
 	 * @return the SystemML version number
 	 */
 	public String version() {
+		if (info() == null) {
+			return "Version not available";
+		}
 		return info().version();
 	}
 
@@ -648,6 +653,9 @@ public class MLContext {
 	 * @return the SystemML jar file build time
 	 */
 	public String buildTime() {
+		if (info() == null) {
+			return "Build time not available";
+		}
 		return info().buildTime();
 	}
 

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
@@ -205,7 +205,7 @@ public final class MLContextUtil {
 	 * @return the minimum recommended Spark version from XML parsing of the pom file (during development).
 	 */
 	static String getMinimumRecommendedSparkVersionFromPom() {
-		return getUniquePomProperty("minimum.recommended.spark.version");
+		return getUniquePomProperty("spark.version");
 	}
 
 	/**

--- a/src/main/java/org/apache/sysml/api/mlcontext/ProjectInfo.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/ProjectInfo.java
@@ -36,8 +36,21 @@ import java.util.jar.Manifest;
 public class ProjectInfo {
 
 	SortedMap<String, String> properties = null;
+	static ProjectInfo projectInfo = null;
 
-	public ProjectInfo() {
+	/**
+	 * Return a ProjectInfo singleton instance.
+	 * 
+	 * @return the ProjectInfo singleton instance
+	 */
+	public static ProjectInfo getProjectInfo() {
+		if (projectInfo == null) {
+			projectInfo = new ProjectInfo();
+		}
+		return projectInfo;
+	}
+
+	private ProjectInfo() {
 		JarFile systemMlJar = null;
 		try {
 			String path = this.getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
@@ -99,6 +112,15 @@ public class ProjectInfo {
 	 */
 	public String buildTime() {
 		return property("Build-Time");
+	}
+
+	/**
+	 * Obtain the minimum recommended Spark version from the manifest.
+	 * 
+	 * @return the minimum recommended Spark version
+	 */
+	public String minimumRecommendedSparkVersion() {
+		return property("Minimum-Recommended-Spark-Version");
 	}
 
 	/**


### PR DESCRIPTION
Move MLContext minimum recommended Spark version to pom.xml to simplify project
maintenance. For SystemML jar, put value in manifest and read from there.
If no jar file present (development environment), read value from pom.xml