### PR TITLE
[SYSTEMML-1282] Remove avro from bin and standalone jar artifacts

### DIFF
--- a/src/assembly/bin.xml
+++ b/src/assembly/bin.xml
@@ -114,7 +114,6 @@
 		<dependencySet>
 			<includes>
 				<include>*:${artifactId}*</include>
-				<include>*:avro*</include>
 				<include>*:commons-cli*</include>
 				<include>*:commons-collections*</include>
 				<include>*:commons-configuration*</include>

--- a/src/assembly/bin/LICENSE
+++ b/src/assembly/bin/LICENSE
@@ -204,10 +204,6 @@
 
 The following components come under the Apache Software License 2.0.
 
-avro-1.7.4.jar
-avro-ipc-1.7.7-tests.jar
-avro-ipc-1.7.7.jar
-avro-mapred-1.7.7-hadoop2.jar
 commons-cli-1.2.jar
 commons-collections-3.2.1.jar
 commons-configuration-1.6.jar

--- a/src/assembly/standalone-jar.xml
+++ b/src/assembly/standalone-jar.xml
@@ -83,7 +83,6 @@
 		<dependencySet>
 			<includes>
 				<include>*:${artifactId}*</include>
-				<include>*:avro*</include>
 				<include>*:commons-cli*</include>
 				<include>*:commons-collections*</include>
 				<include>*:commons-configuration*</include>

--- a/src/assembly/standalone-jar/LICENSE
+++ b/src/assembly/standalone-jar/LICENSE
@@ -213,10 +213,6 @@ commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.3
 log4j:log4j:1.2.15
 net.sf.opencsv:opencsv:2.3
-org.apache.avro:avro:1.7.4
-org.apache.avro:avro-ipc:1.7.7
-org.apache.avro:avro-ipc:1.7.7:tests
-org.apache.avro:avro-mapred:1.7.7:hadoop2
 org.apache.commons:commons-math3:3.4.1
 org.apache.hadoop:hadoop-auth:2.6.0
 org.apache.hadoop:hadoop-client:2.6.0


### PR DESCRIPTION
Remove avro libraries from -bin.tgz, -bin.zip, and -standalone.jar
artifacts to simplify project build dependency management and
reduce artifact size. Update corresponding LICENSE files.