### PR TITLE
[SYSTEMML-1370] More robust conversion of numpy array to matrixblock by passing multiple blocks

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
@@ -165,6 +165,37 @@ public class RDDConverterUtilsExt
 		return convertPy4JArrayToMB(data, (int) rlen, (int) clen, isSparse);
 	}
 	
+	public static MatrixBlock mergeRowBlocks(ArrayList<MatrixBlock> mb, int numRowsPerBlock, int rlen, int clen, boolean isSparse) throws DMLRuntimeException {
+		return mergeRowBlocks(mb, (long)numRowsPerBlock, (long)rlen, (long)clen, isSparse);
+	}
+	
+	/**
+	 * This creates a MatrixBlock from list of row blocks
+	 * 
+	 * @param mb list of row blocks
+	 * @param numRowsPerBlock number of rows per block
+	 * @param rlen number of rows
+	 * @param clen number of columns
+	 * @param isSparse is the output matrix in sparse format
+	 * @return a matrix block of shape (rlen, clen)
+	 * @throws DMLRuntimeException if DMLRuntimeException occurs
+	 */
+	public static MatrixBlock mergeRowBlocks(ArrayList<MatrixBlock> mb, long numRowsPerBlock, long rlen, long clen, boolean isSparse) throws DMLRuntimeException {
+		if(clen >= Integer.MAX_VALUE)
+			throw new DMLRuntimeException("Number of columns cannot be greater than " + Integer.MAX_VALUE);
+		if(rlen >= Integer.MAX_VALUE)
+			throw new DMLRuntimeException("Number of rows cannot be greater than " + Integer.MAX_VALUE);
+		
+		MatrixBlock ret = new MatrixBlock((int)rlen, (int) clen, isSparse);
+		ret.allocateDenseOrSparseBlock();
+		for(int i = 0; i < mb.size(); i++) {
+			ret.copy((int)(i*numRowsPerBlock), (int)Math.min((i+1)*numRowsPerBlock-1, rlen-1), 0, (int)(clen-1), mb.get(i), false);
+		}
+		ret.recomputeNonZeros();
+		ret.examSparsity();
+		return ret;
+	}
+	
 	public static MatrixBlock convertPy4JArrayToMB(byte [] data, int rlen, int clen, boolean isSparse) throws DMLRuntimeException {
 		MatrixBlock mb = new MatrixBlock(rlen, clen, isSparse, -1);
 		if(isSparse) {


### PR DESCRIPTION
Here is the code to test this functionality:

```python
from systemml import MLContext, dml, convertToMatrixBlock
import pandas as pd
nr = 46900
X_pd = pd.DataFrame(range(1,
(nr*784)+1,1),dtype=float).values.reshape(nr,784)
# Sending 8MB blocks at a time   ... succeeds
convertToMatrixBlock(sc, X_pd)
# Sending entire block at a time ... fails
convertToMatrixBlock(sc, X_pd, maxSizeBlockInMB=100000)
```

Drawback of multiple blocks approach: 
- We create two copies of the data (one for smaller blocks passed through Py4J and other for final output).

Advantage:
- More robust. Can handle large number of rows.

TODO: 
- Process multiple blocks in parallel. This requires investigation of whether to use PySpark's parallelism or create threads (and likely sockets) on the driver.
- Use squared blocks for extremely wide matrices.

@bertholdreinwald @dusenberrymw @iyounus