### PR TITLE
[SYSTEMML-1377] Add processing of custom configuration file for GDFO …

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysml/test/integration/AutomatedTestBase.java
@@ -341,6 +341,16 @@ public abstract class AutomatedTestBase
 		return new File(getCurLocalTempDir(), "SystemML-config.xml");
 	}
 	
+	/**
+	 * <p>
+	 * Tests that use custom SystemML configuration should override to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 * </p>
+	 */
+	protected File getConfigTemplateFile() {
+		return CONFIG_TEMPLATE_FILE;
+	}
+	
 	protected MLContext getMLContextForTesting() throws DMLRuntimeException {
 		synchronized(AutomatedTestBase.class) {
 			
@@ -889,9 +899,9 @@ public abstract class AutomatedTestBase
 			curLocalTempDir.mkdirs();
 			TestUtils.clearDirectory(curLocalTempDir.getPath());
 
-			// Create a SystemML config file for this test case.
-			// Use the canned file under src/test/config as a template
-			String configTemplate = FileUtils.readFileToString(CONFIG_TEMPLATE_FILE, "UTF-8");
+			// Create a SystemML config file for this test case based on default template
+			// from src/test/config or derive from custom configuration provided by test.
+			String configTemplate = FileUtils.readFileToString(getConfigTemplateFile(), "UTF-8");
 			
 			String localTemp = curLocalTempDir.getPath();
 			String configContents = configTemplate.replace("<scratch>scratch_space</scratch>", 
@@ -901,9 +911,7 @@ public abstract class AutomatedTestBase
 			
 			FileUtils.write(getCurConfigFile(), configContents, "UTF-8");
 			
-			System.out.printf(
-					"This test case will use SystemML config file %s\n",
-					getCurConfigFile());
+			System.out.printf("This test case will use SystemML config file %s\n", getCurConfigFile());
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmGLM.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmGLM.java
@@ -19,9 +19,10 @@
 
 package org.apache.sysml.test.integration.functions.codegen;
 
+import java.io.File;
+
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.hops.OptimizerUtils;
@@ -36,6 +37,7 @@ public class AlgorithmGLM extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/codegen/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmGLM.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-codegen.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	//private final static double eps = 1e-5;
 	
@@ -158,7 +160,7 @@ public class AlgorithmGLM extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain", "-stats",
-				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("Y"),
+				"-args", input("X"), input("Y"),
 				String.valueOf(intercept), String.valueOf(epsilon), String.valueOf(maxiter), 
 				addArgs[0], addArgs[1], addArgs[2], addArgs[3], output("w")};
 
@@ -190,5 +192,16 @@ public class AlgorithmGLM extends AutomatedTestBase
 			OptimizerUtils.ALLOW_AUTO_VECTORIZATION = true;
 			OptimizerUtils.ALLOW_OPERATOR_FUSION = true;
 		}
+	}
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmKMeans.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmKMeans.java
@@ -19,9 +19,10 @@
 
 package org.apache.sysml.test.integration.functions.codegen;
 
+import java.io.File;
+
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.hops.OptimizerUtils;
@@ -36,6 +37,7 @@ public class AlgorithmKMeans extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/codegen/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmKMeans.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-codegen.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	//private final static double eps = 1e-5;
 	
@@ -158,7 +160,7 @@ public class AlgorithmKMeans extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain", "hops", "-stats",
-				"-config=" + HOME + TEST_CONF, "-args", input("X"), String.valueOf(centroids),
+				"-args", input("X"), String.valueOf(centroids),
 				String.valueOf(runs), String.valueOf(epsilon), String.valueOf(maxiter), output("C")};
 
 			//rCmd = getRCmd(inputDir(), String.valueOf(intercept),String.valueOf(epsilon),
@@ -188,5 +190,16 @@ public class AlgorithmKMeans extends AutomatedTestBase
 			OptimizerUtils.ALLOW_AUTO_VECTORIZATION = true;
 			OptimizerUtils.ALLOW_OPERATOR_FUSION = true;
 		}
+	}
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmL2SVM.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmL2SVM.java
@@ -19,11 +19,11 @@
 
 package org.apache.sysml.test.integration.functions.codegen;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.hops.OptimizerUtils;
@@ -39,6 +39,7 @@ public class AlgorithmL2SVM extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/codegen/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmL2SVM.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-codegen.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private final static double eps = 1e-5;
 	
@@ -122,7 +123,7 @@ public class AlgorithmL2SVM extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain", "-stats",
-				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("Y"),
+				"-args", input("X"), input("Y"),
 				String.valueOf(intercept), String.valueOf(epsilon),
 				String.valueOf(maxiter), output("w")};
 
@@ -153,5 +154,16 @@ public class AlgorithmL2SVM extends AutomatedTestBase
 			OptimizerUtils.ALLOW_AUTO_VECTORIZATION = true;
 			OptimizerUtils.ALLOW_OPERATOR_FUSION = true;
 		}
+	}
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmLinregCG.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmLinregCG.java
@@ -19,11 +19,11 @@
 
 package org.apache.sysml.test.integration.functions.codegen;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.hops.OptimizerUtils;
@@ -39,6 +39,7 @@ public class AlgorithmLinregCG extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/codegen/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmLinregCG.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-codegen.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private final static double eps = 1e-5;
 	
@@ -114,7 +115,7 @@ public class AlgorithmLinregCG extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain", "-stats",
-				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("y"),
+				"-args", input("X"), input("y"),
 				String.valueOf(intercept), String.valueOf(epsilon),
 				String.valueOf(maxiter), output("w")};
 
@@ -145,5 +146,16 @@ public class AlgorithmLinregCG extends AutomatedTestBase
 			OptimizerUtils.ALLOW_AUTO_VECTORIZATION = true;
 			OptimizerUtils.ALLOW_OPERATOR_FUSION = true;
 		}
+	}
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmMLogreg.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmMLogreg.java
@@ -19,11 +19,11 @@
 
 package org.apache.sysml.test.integration.functions.codegen;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.hops.OptimizerUtils;
@@ -39,6 +39,7 @@ public class AlgorithmMLogreg extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/codegen/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmMLogreg.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-codegen.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private final static double eps = 1e-5;
 	
@@ -162,7 +163,7 @@ public class AlgorithmMLogreg extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain", "-stats",
-				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("Y"),
+				"-args", input("X"), input("Y"),
 				String.valueOf(intercept), String.valueOf(epsilon),
 				String.valueOf(maxiter), output("w")};
 
@@ -193,5 +194,16 @@ public class AlgorithmMLogreg extends AutomatedTestBase
 			OptimizerUtils.ALLOW_AUTO_VECTORIZATION = true;
 			OptimizerUtils.ALLOW_OPERATOR_FUSION = true;
 		}
+	}
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmMSVM.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmMSVM.java
@@ -19,11 +19,11 @@
 
 package org.apache.sysml.test.integration.functions.codegen;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.hops.OptimizerUtils;
@@ -39,6 +39,7 @@ public class AlgorithmMSVM extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/codegen/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmMSVM.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-codegen.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private final static double eps = 1e-5;
 	
@@ -122,7 +123,7 @@ public class AlgorithmMSVM extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain", "-stats",
-				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("Y"),
+				"-args", input("X"), input("Y"),
 				String.valueOf(intercept), String.valueOf(epsilon),
 				String.valueOf(maxiter), output("w")};
 
@@ -153,5 +154,16 @@ public class AlgorithmMSVM extends AutomatedTestBase
 			OptimizerUtils.ALLOW_AUTO_VECTORIZATION = true;
 			OptimizerUtils.ALLOW_OPERATOR_FUSION = true;
 		}
+	}
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmPNMF.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/AlgorithmPNMF.java
@@ -19,11 +19,11 @@
 
 package org.apache.sysml.test.integration.functions.codegen;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.hops.OptimizerUtils;
@@ -39,6 +39,7 @@ public class AlgorithmPNMF extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/codegen/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmPNMF.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-codegen.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private final static double eps = 1e-5;
 	
@@ -102,7 +103,7 @@ public class AlgorithmPNMF extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain", "-stats",
-				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("W"), input("H"),
+				"-args", input("X"), input("W"), input("H"),
 				String.valueOf(rank), String.valueOf(epsilon), String.valueOf(maxiter), 
 				output("W"), output("H")};
 
@@ -138,5 +139,16 @@ public class AlgorithmPNMF extends AutomatedTestBase
 			OptimizerUtils.ALLOW_AUTO_VECTORIZATION = true;
 			OptimizerUtils.ALLOW_OPERATOR_FUSION = true;
 		}
+	}
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/CellwiseTmplTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/CellwiseTmplTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysml.test.integration.functions.codegen;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Assert;
@@ -44,6 +45,7 @@ public class CellwiseTmplTest extends AutomatedTestBase
 	private static final String TEST_DIR = "functions/codegen/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + CellwiseTmplTest.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-codegen.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private static final double eps = Math.pow(10, -10);
 	
@@ -146,8 +148,7 @@ public class CellwiseTmplTest extends AutomatedTestBase
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
-			programArgs = new String[]{"-explain", "runtime", "-stats", 
-					"-config=" + HOME + TEST_CONF, "-args", output("S") };
+			programArgs = new String[]{"-explain", "runtime", "-stats", "-args", output("S") };
 			
 			fullRScriptName = HOME + testname + ".R";
 			rCmd = getRCmd(inputDir(), expectedDir());			
@@ -180,4 +181,15 @@ public class CellwiseTmplTest extends AutomatedTestBase
 			OptimizerUtils.ALLOW_OPERATOR_FUSION = true;
 		}
 	}	
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
+	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/DAGCellwiseTmplTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/DAGCellwiseTmplTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysml.test.integration.functions.codegen;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Assert;
@@ -41,6 +42,7 @@ public class DAGCellwiseTmplTest extends AutomatedTestBase
 	private static final String TEST_DIR = "functions/codegen/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + DAGCellwiseTmplTest.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-codegen.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private static final double eps = Math.pow(10, -10);
 	
@@ -136,7 +138,7 @@ public class DAGCellwiseTmplTest extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
 			programArgs = new String[]{"-explain", "hops", "-stats", 
-					"-config=" + HOME + TEST_CONF, "-args", String.valueOf(cols), output("S") };
+					"-args", String.valueOf(cols), output("S") };
 			
 			fullRScriptName = HOME + testname + ".R";
 			rCmd = getRCmd(String.valueOf(cols), expectedDir());			
@@ -158,4 +160,15 @@ public class DAGCellwiseTmplTest extends AutomatedTestBase
 			OptimizerUtils.ALLOW_OPERATOR_FUSION = true;
 		}
 	}	
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
+	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/OuterProdTmplTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/OuterProdTmplTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysml.test.integration.functions.codegen;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Assert;
@@ -45,6 +46,7 @@ public class OuterProdTmplTest extends AutomatedTestBase
 	private static final String TEST_DIR = "functions/codegen/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + OuterProdTmplTest.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-codegen.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private static final double eps = Math.pow(10, -8);
 	
@@ -174,8 +176,7 @@ public class OuterProdTmplTest extends AutomatedTestBase
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
-			programArgs = new String[]{"-explain", "-stats", 
-					"-config=" + HOME + TEST_CONF, "-args", output("S")};
+			programArgs = new String[]{"-explain", "-stats", "-args", output("S")};
 			
 			fullRScriptName = HOME + testname + ".R";
 			rCmd = getRCmd(inputDir(), expectedDir());			
@@ -223,8 +224,7 @@ public class OuterProdTmplTest extends AutomatedTestBase
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
-			programArgs = new String[]{"-explain", "-stats", 
-				"-config=" + HOME + TEST_CONF, "-args", output("S"), input("A")};
+			programArgs = new String[]{"-explain", "-stats", "-args", output("S"), input("A")};
 			
 			fullRScriptName = HOME + testname + ".R";
 			rCmd = getRCmd(inputDir(), expectedDir());			
@@ -256,4 +256,15 @@ public class OuterProdTmplTest extends AutomatedTestBase
 			OptimizerUtils.ALLOW_OPERATOR_FUSION = true;
 		}
 	}	
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
+	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/RowAggTmplTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/RowAggTmplTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysml.test.integration.functions.codegen;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Assert;
@@ -42,6 +43,7 @@ public class RowAggTmplTest extends AutomatedTestBase
 	private static final String TEST_DIR = "functions/codegen/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + RowAggTmplTest.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-codegen.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private static final double eps = Math.pow(10, -10);
 	
@@ -115,8 +117,7 @@ public class RowAggTmplTest extends AutomatedTestBase
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
-			programArgs = new String[]{"-explain", "runtime", "-stats", 
-					"-config=" + HOME + TEST_CONF, "-args", output("S") };
+			programArgs = new String[]{"-explain", "runtime", "-stats", "-args", output("S") };
 			
 			fullRScriptName = HOME + testname + ".R";
 			rCmd = getRCmd(inputDir(), expectedDir());			
@@ -139,4 +140,15 @@ public class RowAggTmplTest extends AutomatedTestBase
 			rtplatform = oldPlatform;
 		}
 	}	
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
+	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/SumProductChainTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/SumProductChainTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysml.test.integration.functions.codegen;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Assert;
@@ -39,6 +40,7 @@ public class SumProductChainTest extends AutomatedTestBase
 	private static final String TEST_DIR = "functions/codegen/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + SumProductChainTest.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-codegen.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private static final int rows = 1191;
 	private static final int cols1 = 1;
@@ -119,7 +121,7 @@ public class SumProductChainTest extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
 			programArgs = new String[]{"-explain", "hops", "-stats", 
-					"-config=" + HOME + TEST_CONF, "-args", input("X"), output("R") };
+					"-args", input("X"), output("R") };
 			
 			fullRScriptName = HOME + testname + ".R";
 			rCmd = getRCmd(inputDir(), expectedDir());			
@@ -150,4 +152,15 @@ public class SumProductChainTest extends AutomatedTestBase
 			OptimizerUtils.ALLOW_OPERATOR_FUSION = true;
 		}
 	}	
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
+	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/compress/CompressedLinregCG.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/compress/CompressedLinregCG.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysml.test.integration.functions.compress;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.apache.sysml.api.DMLScript;
@@ -40,6 +41,7 @@ public class CompressedLinregCG extends AutomatedTestBase
 	private final static String TEST_NAME1 = "LinregCG";
 	private final static String TEST_DIR = "functions/compress/";
 	private final static String TEST_CONF = "SystemML-config-compress.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private final static double eps = 1e-4;
 	
@@ -109,7 +111,6 @@ public class CompressedLinregCG extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain","-stats",
-					                    "-config="+HOME+TEST_CONF,
 					                    "-args", HOME + INPUT_DIR + "X",
 					                             HOME + INPUT_DIR + "y",
 					                             String.valueOf(intercept),
@@ -149,4 +150,14 @@ public class CompressedLinregCG extends AutomatedTestBase
 		}
 	}
 
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
+	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOLinregCG.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOLinregCG.java
@@ -19,10 +19,10 @@
 
 package org.apache.sysml.test.integration.functions.gdfo;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.lops.LopProperties.ExecType;
@@ -41,6 +41,7 @@ public class GDFOLinregCG extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/gdfo/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + GDFOLinregCG.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-globalopt.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private final static double eps = 1e-5;
 	
@@ -129,7 +130,7 @@ public class GDFOLinregCG extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain", //"hops",
-				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("y"),
+				"-args", input("X"), input("y"),
 				String.valueOf(intercept), String.valueOf(epsilon),
 				String.valueOf(maxiter), output("w")};
 
@@ -157,4 +158,14 @@ public class GDFOLinregCG extends AutomatedTestBase
 		}
 	}
 
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
+	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOLinregDS.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOLinregDS.java
@@ -19,10 +19,10 @@
 
 package org.apache.sysml.test.integration.functions.gdfo;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.lops.LopProperties.ExecType;
@@ -41,6 +41,7 @@ public class GDFOLinregDS extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/gdfo/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + GDFOLinregDS.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-globalopt.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private final static double eps = 1e-8;
 	
@@ -126,7 +127,7 @@ public class GDFOLinregDS extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain","hops",
-				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("y"),
+				"-args", input("X"), input("y"),
 				String.valueOf(intercept), String.valueOf(lambda), output("B")};
 
 			rCmd = getRCmd(inputDir(), String.valueOf(intercept), String.valueOf(lambda), expectedDir());
@@ -152,4 +153,14 @@ public class GDFOLinregDS extends AutomatedTestBase
 		}
 	}
 
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
+	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOLinregDSsimpl.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOLinregDSsimpl.java
@@ -19,10 +19,10 @@
 
 package org.apache.sysml.test.integration.functions.gdfo;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.junit.Test;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.lops.LopProperties.ExecType;
@@ -41,6 +41,7 @@ public class GDFOLinregDSsimpl extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/gdfo/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + GDFOLinregDSsimpl.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-globalopt.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private final static double eps = 1e-8;
 	
@@ -126,7 +127,7 @@ public class GDFOLinregDSsimpl extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain","hops",
-				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("y"),
+				"-args", input("X"), input("y"),
 				String.valueOf(intercept), String.valueOf(lambda), output("B")};
 
 			rCmd = getRCmd(inputDir(), String.valueOf(intercept), String.valueOf(lambda), expectedDir());
@@ -152,4 +153,14 @@ public class GDFOLinregDSsimpl extends AutomatedTestBase
 		}
 	}
 
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
+	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOMMChainLoop.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/gdfo/GDFOMMChainLoop.java
@@ -19,9 +19,10 @@
 
 package org.apache.sysml.test.integration.functions.gdfo;
 
+import java.io.File;
 import java.util.HashMap;
-import org.junit.Test;
 
+import org.junit.Test;
 import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
 import org.apache.sysml.lops.LopProperties.ExecType;
 import org.apache.sysml.runtime.matrix.data.MatrixValue.CellIndex;
@@ -39,6 +40,7 @@ public class GDFOMMChainLoop extends AutomatedTestBase
 	private final static String TEST_DIR = "functions/gdfo/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + GDFOMMChainLoop.class.getSimpleName() + "/";
 	private final static String TEST_CONF = "SystemML-config-globalopt.xml";
+	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 	
 	private final static double eps = 1e-10;
 	
@@ -91,7 +93,7 @@ public class GDFOMMChainLoop extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[]{ "-explain", //"hops",
-				"-config=" + HOME + TEST_CONF, "-args", input("X"), input("v"),
+				"-args", input("X"), input("v"),
 				String.valueOf(maxiter), output("w")};
 			
 			rCmd = getRCmd(inputDir(), String.valueOf(maxiter), expectedDir());
@@ -117,4 +119,14 @@ public class GDFOMMChainLoop extends AutomatedTestBase
 		}
 	}
 
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
+	}
 }


### PR DESCRIPTION
…tests

This patch allows tests that provide their own configuration to have the file processed by base test class which may relocate the scratch_space.  This prevents potential test failures in global data flow optimization tests due to folder hierarchy not publicly accessible. 