### PR TITLE
[SYSTEMML-1396] Lazy cudafree

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/GPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/GPUInstruction.java
@@ -44,6 +44,8 @@ public abstract class GPUInstruction extends Instruction
 	public final static String MISC_TIMER_CUDA_FREE = 						"f";		// time spent in calling cudaFree
 	public final static String MISC_TIMER_ALLOCATE = 							"a";		// time spent to allocate memory on gpu
 	public final static String MISC_TIMER_ALLOCATE_DENSE_OUTPUT = "ao";		// time spent to allocate dense output (recorded differently than MISC_TIMER_ALLOCATE)
+	public final static String MISC_TIMER_SET_ZERO = 							"az";		// time spent to allocate
+	public final static String MISC_TIMER_REUSE = 								"r";		// time spent in reusing already allocated memory on GPU (mainly for the count)
 
 	// Matmult instructions
 	public final static String MISC_TIMER_SPARSE_ALLOCATE_LIB = 						"Msao";		// time spend in allocating for sparse matrix output

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUContext.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUContext.java
@@ -18,11 +18,6 @@
  */
 package org.apache.sysml.runtime.instructions.gpu.context;
 
-import java.util.ArrayList;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.hops.OptimizerUtils;
 import org.apache.sysml.runtime.DMLRuntimeException;
@@ -32,18 +27,6 @@ import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
 
 @SuppressWarnings("rawtypes")
 public abstract class GPUContext {
-
-	public static ArrayList<GPUObject> allocatedPointers = new ArrayList<GPUObject>();
-
-	/** cudaFree calls are done asynchronously on a separate thread,
-	 *  this list preserve the list of currently happening cudaFree calls */
-	public static ConcurrentLinkedQueue<Future> pendingDeallocates = new ConcurrentLinkedQueue<Future>();
-
-	/** All asynchronous cudaFree calls will be done on this executor service */
-	public static ExecutorService deallocExecutorService;
-
-	/** Synchronization object to make sure no allocations happen when something is being evicted from memory */
-	public static final Object syncObj = new Object();
 
 	protected static GPUContext currContext;
 	public static volatile Boolean isGPUContextCreated = false;
@@ -76,7 +59,7 @@ public abstract class GPUContext {
 			synchronized(isGPUContextCreated) {
 				currContext = new JCudaContext();
 				currContext.ensureComputeCapability();
-				OptimizerUtils.GPU_MEMORY_BUDGET = ((JCudaContext)currContext).getAvailableMemory();
+				OptimizerUtils.GPU_MEMORY_BUDGET = currContext.getAvailableMemory();
 				isGPUContextCreated = true;
 			}
 		}

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUObject.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUObject.java
@@ -135,6 +135,7 @@ public abstract class GPUObject
 	protected static void evict(String instructionName, final long GPUSize) throws DMLRuntimeException {
 		synchronized (JCudaContext.syncObj) {
 
+			GPUStatistics.cudaEvictionCount.addAndGet(1);
 			// Release the set of free blocks maintained in a JCudaObject.freeCUDASpaceMap
 			// to free up space
 			LRUCacheMap<Long, LinkedList<Pointer>> lruCacheMap = JCudaObject.freeCUDASpaceMap;
@@ -156,8 +157,6 @@ public abstract class GPUObject
 			if (JCudaContext.allocatedPointers.size() == 0) {
 				throw new DMLRuntimeException("There is not enough memory on device for this matrix!");
 			}
-
-			GPUStatistics.cudaEvictionCount.addAndGet(1);
 
 			synchronized (evictionLock) {
 				Collections.sort(JCudaContext.allocatedPointers, new Comparator<GPUObject>() {

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUObject.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUObject.java
@@ -18,16 +18,16 @@
  */
 package org.apache.sysml.runtime.instructions.gpu.context;
 
+import jcuda.Pointer;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.controlprogram.caching.CacheException;
 import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.utils.GPUStatistics;
+import org.apache.sysml.utils.LRUCacheMap;
 
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -95,7 +95,7 @@ public abstract class GPUObject
 
 	abstract void allocateDenseMatrixOnDevice() throws DMLRuntimeException;
 	abstract void allocateSparseMatrixOnDevice() throws DMLRuntimeException;
-	abstract void deallocateMemoryOnDevice(boolean synchronous) throws DMLRuntimeException;
+	abstract void deallocateMemoryOnDevice(boolean eager) throws DMLRuntimeException;
 	abstract long getSizeOnDevice() throws DMLRuntimeException;
 	
 	abstract void copyFromHostToDevice() throws DMLRuntimeException;
@@ -109,47 +109,51 @@ public abstract class GPUObject
 	 * @throws DMLRuntimeException if DMLRuntimeException occurs
 	 */
 	abstract void copyFromDeviceToHost() throws DMLRuntimeException; // Called by export()
-	
+
+
+	/**
+	 * Convenience wrapper over {@link GPUObject#evict(String, long)}
+	 * @param GPUSize Desired size to be freed up on the GPU
+	 * @throws DMLRuntimeException If no blocks to free up or if not enough blocks with zero locks on them.
+	 */
+	protected static void evict(final long GPUSize) throws DMLRuntimeException {
+		evict(null, GPUSize);
+	}
+
 	/**
 	 * Cycles through the sorted list of allocated {@link GPUObject} instances. Sorting is based on
 	 * number of (read) locks that have been obtained on it (reverse order). It repeatedly frees up 
 	 * blocks on which there are zero locks until the required size has been freed up.
 	 * // TODO: update it with hybrid policy
+	 * @param instructionName name of the instruction for which performance measurements are made
 	 * @param GPUSize Desired size to be freed up on the GPU
 	 * @throws DMLRuntimeException If no blocks to free up or if not enough blocks with zero locks on them.	 
 	 */
 	@SuppressWarnings("rawtypes")
-	protected static void evict(final long GPUSize) throws DMLRuntimeException {
-		synchronized (GPUContext.syncObj) {
-			// Check for the completion of asynchronous cudaFree calls
-			try {
-				while (GPUSize > getAvailableMemory()) {
-					Future f = GPUContext.pendingDeallocates.poll();
-					if (f == null) {
-						break;
-					} else if (f.isDone()) {
-						continue;
-					} else {
-						f.get();
-					}
-				}
-			} catch (InterruptedException e) {
-				throw new DMLRuntimeException("There was an error with pending deallocates", e);
-			} catch (ExecutionException e) {
-				throw new DMLRuntimeException("There was an error with pending deallocates", e);
+	protected static void evict(String instructionName, final long GPUSize) throws DMLRuntimeException {
+		synchronized (JCudaContext.syncObj) {
+
+			// Release the set of free blocks maintained in a JCudaObject.freeCUDASpaceMap
+			// to free up space
+			LRUCacheMap<Long, Pointer> lruCacheMap = JCudaObject.freeCUDASpaceMap;
+			while (lruCacheMap.size() > 0) {
+				if (GPUSize <= getAvailableMemory())
+					break;
+				Pointer toFree = lruCacheMap.removeAndGetLRUEntry().getValue();
+				JCudaObject.cudaFreeHelper(instructionName, toFree, true);
 			}
 
 			if (GPUSize <= getAvailableMemory())
 				return;
 
-			if (GPUContext.allocatedPointers.size() == 0) {
+			if (JCudaContext.allocatedPointers.size() == 0) {
 				throw new DMLRuntimeException("There is not enough memory on device for this matrix!");
 			}
 
 			GPUStatistics.cudaEvictionCount.addAndGet(1);
 
 			synchronized (evictionLock) {
-				Collections.sort(GPUContext.allocatedPointers, new Comparator<GPUObject>() {
+				Collections.sort(JCudaContext.allocatedPointers, new Comparator<GPUObject>() {
 
 					@Override
 					public int compare(GPUObject p1, GPUObject p2) {
@@ -189,8 +193,8 @@ public abstract class GPUObject
 					}
 				});
 
-				while (GPUSize > getAvailableMemory() && GPUContext.allocatedPointers.size() > 0) {
-					GPUObject toBeRemoved = GPUContext.allocatedPointers.get(GPUContext.allocatedPointers.size() - 1);
+				while (GPUSize > getAvailableMemory() && JCudaContext.allocatedPointers.size() > 0) {
+					GPUObject toBeRemoved = JCudaContext.allocatedPointers.get(JCudaContext.allocatedPointers.size() - 1);
 					if (toBeRemoved.numLocks.get() > 0) {
 						throw new DMLRuntimeException("There is not enough memory on device for this matrix!");
 					}
@@ -205,7 +209,7 @@ public abstract class GPUObject
 	}
 
 	/**
-	 * Asynchronously clears the data associated with this {@link GPUObject} instance
+	 * lazily clears the data associated with this {@link GPUObject} instance
 	 * @throws CacheException ?
 	 */
 	public void clearData() throws CacheException {
@@ -214,15 +218,15 @@ public abstract class GPUObject
 
 	/**
 	 * Clears the data associated with this {@link GPUObject} instance
-	 * @param synchronous whether to be done synchronously or asynchronously
+	 * @param eager whether to be done synchronously or asynchronously
 	 * @throws CacheException ?
 	 */
-	public void clearData(boolean synchronous) throws CacheException {
+	public void clearData(boolean eager) throws CacheException {
 		synchronized(evictionLock) {
-			GPUContext.allocatedPointers.remove(this);
+			JCudaContext.allocatedPointers.remove(this);
 		}
 		try {
-			deallocateMemoryOnDevice(synchronous);
+			deallocateMemoryOnDevice(eager);
 		} catch (DMLRuntimeException e) {
 			throw new CacheException(e);
 		}

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/JCudaContext.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/JCudaContext.java
@@ -104,7 +104,6 @@ public class JCudaContext extends GPUContext {
 		LOG.info("Active CUDA device number : " + device[0]);
 		LOG.info("Max Blocks/Threads/SharedMem : " + maxBlocks + "/" + maxThreadsPerBlock + "/" + sharedMemPerBlock);
 
-
 		GPUStatistics.cudaInitTime = System.nanoTime() - start;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/JCudaObject.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/JCudaObject.java
@@ -28,6 +28,7 @@ import jcuda.jcusparse.cusparseMatDescr;
 import jcuda.jcusparse.cusparsePointerMode;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.controlprogram.caching.CacheException;
 import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
@@ -195,13 +196,14 @@ public class JCudaObject extends GPUObject {
 		 */
 		public static void copyToDevice(CSRPointer dest, int rows, long nnz, int[] rowPtr, int[] colInd, double[] values) {
 			CSRPointer r = dest;
-			long t0 = System.nanoTime();
+			long t0=0;
+			if (DMLScript.STATISTICS) t0 = System.nanoTime();
 			r.nnz = nnz;
 			cudaMemcpy(r.rowPtr, Pointer.to(rowPtr), getIntSizeOf(rows + 1), cudaMemcpyHostToDevice);
 			cudaMemcpy(r.colInd, Pointer.to(colInd), getIntSizeOf(nnz), cudaMemcpyHostToDevice);
 			cudaMemcpy(r.val, Pointer.to(values), getDoubleSizeOf(nnz), cudaMemcpyHostToDevice);
-			GPUStatistics.cudaToDevTime.addAndGet(System.nanoTime()-t0);
-			GPUStatistics.cudaToDevCount.addAndGet(3);
+			if (DMLScript.STATISTICS) GPUStatistics.cudaToDevTime.addAndGet(System.nanoTime()-t0);
+			if (DMLScript.STATISTICS) GPUStatistics.cudaToDevCount.addAndGet(3);
 		}
 		
 		/**
@@ -215,12 +217,13 @@ public class JCudaObject extends GPUObject {
 		 */
 		public static void copyToHost(CSRPointer src, int rows, long nnz, int[] rowPtr, int[] colInd, double[] values){
 			CSRPointer r = src;
-			long t0 = System.nanoTime();
+			long t0=0;
+			if (DMLScript.STATISTICS) t0 = System.nanoTime();
 			cudaMemcpy(Pointer.to(rowPtr), r.rowPtr, getIntSizeOf(rows + 1), cudaMemcpyDeviceToHost);
 			cudaMemcpy(Pointer.to(colInd), r.colInd, getIntSizeOf(nnz), cudaMemcpyDeviceToHost);
 			cudaMemcpy(Pointer.to(values), r.val, getDoubleSizeOf(nnz), cudaMemcpyDeviceToHost);
-			GPUStatistics.cudaFromDevTime.addAndGet(System.nanoTime()-t0);
-			GPUStatistics.cudaFromDevCount.addAndGet(3);
+			if (DMLScript.STATISTICS) GPUStatistics.cudaFromDevTime.addAndGet(System.nanoTime()-t0);
+			if (DMLScript.STATISTICS) GPUStatistics.cudaFromDevCount.addAndGet(3);
 		}
 		
 		// ==============================================================================================
@@ -685,18 +688,12 @@ public class JCudaObject extends GPUObject {
 	@Override
 	void deallocateMemoryOnDevice(boolean eager) {
 		if(jcudaDenseMatrixPtr != null) {
-			long start = System.nanoTime();
 			cudaFreeHelper(null, jcudaDenseMatrixPtr, eager);
 			((JCudaContext)GPUContext.currContext).getAndAddAvailableMemory(numBytes);
-			GPUStatistics.cudaDeAllocTime.addAndGet(System.nanoTime()-start);
-			GPUStatistics.cudaDeAllocCount.addAndGet(1);
 		}
 		if (jcudaSparseMatrixPtr != null) {
-			long start = System.nanoTime();
 			jcudaSparseMatrixPtr.deallocate(eager);
 			((JCudaContext)GPUContext.currContext).getAndAddAvailableMemory(numBytes);
-			GPUStatistics.cudaDeAllocTime.addAndGet(System.nanoTime()-start);
-			GPUStatistics.cudaDeAllocCount.addAndGet(1);
 		}
 		jcudaDenseMatrixPtr = null;
 		jcudaSparseMatrixPtr = null;
@@ -729,7 +726,8 @@ public class JCudaObject extends GPUObject {
 		throws DMLRuntimeException 
 	{
 		printCaller();
-		long start = System.nanoTime();
+		long start=0;
+		if (DMLScript.STATISTICS) start = System.nanoTime();
 		
 		MatrixBlock tmp = mat.acquireRead();
 		if(tmp.isInSparseFormat()) {
@@ -759,21 +757,22 @@ public class JCudaObject extends GPUObject {
 				// CSR is the preferred format for cuSparse GEMM
 				// Converts MCSR and COO to CSR
 				SparseBlockCSR csrBlock = null;
+				long t0=0;
 				if (block instanceof SparseBlockCSR){ 
 					csrBlock = (SparseBlockCSR)block;
 				} else if (block instanceof SparseBlockCOO) {
 					// TODO - should we do this on the GPU using cusparse<t>coo2csr() ?
-					long t0 = System.nanoTime();
+					if (DMLScript.STATISTICS) t0 = System.nanoTime();
 					SparseBlockCOO cooBlock = (SparseBlockCOO)block;
 					csrBlock = new SparseBlockCSR(toIntExact(mat.getNumRows()), cooBlock.rowIndexes(), cooBlock.indexes(), cooBlock.values());
-					GPUStatistics.cudaSparseConversionTime.addAndGet(System.nanoTime() - t0);
-					GPUStatistics.cudaSparseConversionCount.incrementAndGet();
+					if (DMLScript.STATISTICS) GPUStatistics.cudaSparseConversionTime.addAndGet(System.nanoTime() - t0);
+					if (DMLScript.STATISTICS) GPUStatistics.cudaSparseConversionCount.incrementAndGet();
 				} else if (block instanceof SparseBlockMCSR) {
-					long t0 = System.nanoTime();
+					if (DMLScript.STATISTICS) t0 = System.nanoTime();
 					SparseBlockMCSR mcsrBlock = (SparseBlockMCSR)block;
 					csrBlock = new SparseBlockCSR(mcsrBlock.getRows(), toIntExact(mcsrBlock.size()));
-					GPUStatistics.cudaSparseConversionTime.addAndGet(System.nanoTime() - t0);
-					GPUStatistics.cudaSparseConversionCount.incrementAndGet();
+					if (DMLScript.STATISTICS) GPUStatistics.cudaSparseConversionTime.addAndGet(System.nanoTime() - t0);
+					if (DMLScript.STATISTICS) GPUStatistics.cudaSparseConversionCount.incrementAndGet();
 				} else {
 					throw new DMLRuntimeException("Unsupported sparse matrix format for CUDA operations");
 				}
@@ -810,9 +809,9 @@ public class JCudaObject extends GPUObject {
 		}
 		
 		mat.release();
-		
-		GPUStatistics.cudaToDevTime.addAndGet(System.nanoTime()-start);
-		GPUStatistics.cudaToDevCount.addAndGet(1);
+
+		if (DMLScript.STATISTICS) GPUStatistics.cudaToDevTime.addAndGet(System.nanoTime()-start);
+		if (DMLScript.STATISTICS) GPUStatistics.cudaToDevCount.addAndGet(1);
 	}
 	
 	public static int toIntExact(long l) throws DMLRuntimeException {
@@ -830,7 +829,8 @@ public class JCudaObject extends GPUObject {
 
 		if(jcudaDenseMatrixPtr != null) {
 			printCaller();
-			long start = System.nanoTime();
+			long start=0;
+			if (DMLScript.STATISTICS) start = System.nanoTime();
 			MatrixBlock tmp = new MatrixBlock(toIntExact(mat.getNumRows()), toIntExact(mat.getNumColumns()), false);
 			tmp.allocateDenseBlock();
 			double [] data = tmp.getDenseBlock();
@@ -840,9 +840,9 @@ public class JCudaObject extends GPUObject {
 			tmp.recomputeNonZeros();
 			mat.acquireModify(tmp);
 			mat.release();
-			
-			GPUStatistics.cudaFromDevTime.addAndGet(System.nanoTime()-start);
-			GPUStatistics.cudaFromDevCount.addAndGet(1);
+
+			if (DMLScript.STATISTICS) GPUStatistics.cudaFromDevTime.addAndGet(System.nanoTime()-start);
+			if (DMLScript.STATISTICS) GPUStatistics.cudaFromDevCount.addAndGet(1);
 		}
 		else if (jcudaSparseMatrixPtr != null){
 			printCaller();
@@ -854,7 +854,8 @@ public class JCudaObject extends GPUObject {
 				mat.acquireModify(tmp);
 				mat.release();
 			} else {
-				long start = System.nanoTime();
+				long start=0;
+				if (DMLScript.STATISTICS) start = System.nanoTime();
 
 				int rows = toIntExact(mat.getNumRows());
 				int cols = toIntExact(mat.getNumColumns());
@@ -868,8 +869,8 @@ public class JCudaObject extends GPUObject {
 				MatrixBlock tmp = new MatrixBlock(rows, cols, nnz, sparseBlock);
 				mat.acquireModify(tmp);
 				mat.release();
-				GPUStatistics.cudaFromDevTime.addAndGet(System.nanoTime() - start);
-				GPUStatistics.cudaFromDevCount.addAndGet(1);
+				if (DMLScript.STATISTICS) GPUStatistics.cudaFromDevTime.addAndGet(System.nanoTime() - start);
+				if (DMLScript.STATISTICS) GPUStatistics.cudaFromDevCount.addAndGet(1);
 			}
 		}
 		else {
@@ -959,7 +960,8 @@ public class JCudaObject extends GPUObject {
 	 * @throws DMLRuntimeException if DMLRuntimeException occurs
 	 */
 	public void denseToSparse() throws DMLRuntimeException {
-		long t0 = System.nanoTime();
+		long t0=0;
+		if (DMLScript.STATISTICS) t0 = System.nanoTime();
 		cusparseHandle cusparseHandle = LibMatrixCUDA.cusparseHandle;
 		if(cusparseHandle == null)
 			throw new DMLRuntimeException("Expected cusparse to be initialized");
@@ -973,8 +975,8 @@ public class JCudaObject extends GPUObject {
 		setSparseMatrixCudaPointer(columnMajorDenseToRowMajorSparse(cusparseHandle, rows, cols, jcudaDenseMatrixPtr));
 		// TODO: What if mat.getNnz() is -1 ?
 		numBytes = CSRPointer.estimateSize(mat.getNnz(), rows);
-		GPUStatistics.cudaDenseToSparseTime.addAndGet(System.nanoTime() - t0);
-		GPUStatistics.cudaDenseToSparseCount.addAndGet(1);
+		if (DMLScript.STATISTICS) GPUStatistics.cudaDenseToSparseTime.addAndGet(System.nanoTime() - t0);
+		if (DMLScript.STATISTICS) GPUStatistics.cudaDenseToSparseCount.addAndGet(1);
 	}
 
 	/**
@@ -1046,16 +1048,17 @@ public class JCudaObject extends GPUObject {
 	 * @throws DMLRuntimeException ?
 	 */
 	public void sparseToDense(String instructionName) throws DMLRuntimeException {
-		long start = System.nanoTime();
+		long start=0, end=0;
+		if (DMLScript.STATISTICS) start = System.nanoTime();
 		if(jcudaSparseMatrixPtr == null || !isAllocated())
 			throw new DMLRuntimeException("Expected allocated sparse matrix before sparseToDense() call");
 
 		sparseToColumnMajorDense();
 		convertDensePtrFromColMajorToRowMajor();
-		long end = System.nanoTime();
+		if (DMLScript.STATISTICS) end = System.nanoTime();
 		if (instructionName != null && GPUStatistics.DISPLAY_STATISTICS) GPUStatistics.maintainCPMiscTimes(instructionName, GPUInstruction.MISC_TIMER_SPARSE_TO_DENSE, end - start);
-		GPUStatistics.cudaSparseToDenseTime.addAndGet(end - start);
-		GPUStatistics.cudaSparseToDenseCount.addAndGet(1);
+		if (DMLScript.STATISTICS) GPUStatistics.cudaSparseToDenseTime.addAndGet(end - start);
+		if (DMLScript.STATISTICS) GPUStatistics.cudaSparseToDenseCount.addAndGet(1);
 	}
 	
 	/**
@@ -1091,26 +1094,23 @@ public class JCudaObject extends GPUObject {
 	 */
 	public static CSRPointer columnMajorDenseToRowMajorSparse(cusparseHandle cusparseHandle, int rows, int cols, Pointer densePtr) throws DMLRuntimeException {
 		cusparseMatDescr matDescr = CSRPointer.getDefaultCuSparseMatrixDescriptor();
-		Pointer nnzPerRowPtr = new Pointer();
-		Pointer nnzTotalDevHostPtr = new Pointer();
+		Pointer nnzPerRowPtr = null;
+		Pointer nnzTotalDevHostPtr = null;
 		
 		ensureFreeSpace(getIntSizeOf(rows + 1));
-		
-		long t1 = System.nanoTime();
 		nnzPerRowPtr = allocate(getIntSizeOf(rows));
 		nnzTotalDevHostPtr = allocate(getIntSizeOf(1));
-		GPUStatistics.cudaAllocTime.addAndGet(System.nanoTime() - t1);
-		GPUStatistics.cudaAllocCount.addAndGet(2);
 		
 		// Output is in dense vector format, convert it to CSR
 		cusparseDnnz(cusparseHandle, cusparseDirection.CUSPARSE_DIRECTION_ROW, rows, cols, matDescr, densePtr, rows, nnzPerRowPtr, nnzTotalDevHostPtr);
 		cudaDeviceSynchronize();
 		int[] nnzC = {-1};
-		
-		long t2 = System.nanoTime();
+
+		long t2=0;
+		if (DMLScript.STATISTICS) t2 = System.nanoTime();
 		cudaMemcpy(Pointer.to(nnzC), nnzTotalDevHostPtr, getIntSizeOf(1), cudaMemcpyDeviceToHost);
-		GPUStatistics.cudaFromDevTime.addAndGet(System.nanoTime() - t2);
-		GPUStatistics.cudaFromDevCount.addAndGet(2);
+		if (DMLScript.STATISTICS) GPUStatistics.cudaFromDevTime.addAndGet(System.nanoTime() - t2);
+		if (DMLScript.STATISTICS) GPUStatistics.cudaFromDevCount.addAndGet(1);
 		
 		if (nnzC[0] == -1){
 			throw new DMLRuntimeException("cusparseDnnz did not calculate the correct number of nnz from the sparse-matrix vector mulitply on the GPU");
@@ -1165,25 +1165,33 @@ public class JCudaObject extends GPUObject {
 	 * @throws DMLRuntimeException if DMLRuntimeException occurs
 	 */
 	public static Pointer allocate(String instructionName, long size, int statsCount) throws DMLRuntimeException{
+		long t0=0, t1=0, end=0;
 		synchronized (JCudaContext.syncObj) {
 			Pointer A;
 			if (freeCUDASpaceMap.containsKey(size)) {
+				if (instructionName != null && GPUStatistics.DISPLAY_STATISTICS) t0 = System.nanoTime();
 				LinkedList<Pointer> freeList = freeCUDASpaceMap.get(size);
 				A = freeList.pop();
 				if (freeList.isEmpty())
 					freeCUDASpaceMap.remove(size);
+				if (instructionName != null && GPUStatistics.DISPLAY_STATISTICS) GPUStatistics.maintainCPMiscTimes(instructionName, GPUInstruction.MISC_TIMER_REUSE, System.nanoTime() - t0);
 			} else {
-				long t0 = System.nanoTime();
+				if (DMLScript.STATISTICS) t0 = System.nanoTime();
 				ensureFreeSpace(instructionName, size);
 				A = new Pointer();
 				cudaMalloc(A, size);
 				((JCudaContext)(JCudaContext.currContext)).deviceMemBytes.addAndGet(size);
-				GPUStatistics.cudaAllocTime.getAndAdd(System.nanoTime() - t0);
-				GPUStatistics.cudaAllocCount.getAndAdd(statsCount);
+				if (DMLScript.STATISTICS) GPUStatistics.cudaAllocTime.getAndAdd(System.nanoTime() - t0);
+				if (DMLScript.STATISTICS) GPUStatistics.cudaAllocCount.getAndAdd(statsCount);
 				if (instructionName != null && GPUStatistics.DISPLAY_STATISTICS) GPUStatistics.maintainCPMiscTimes(instructionName, GPUInstruction.MISC_TIMER_ALLOCATE, System.nanoTime() - t0);
 			}
 			// Set all elements to 0 since newly allocated space will contain garbage
+			if (DMLScript.STATISTICS) t1 = System.nanoTime();
 			cudaMemset(A, 0, size);
+			if (DMLScript.STATISTICS) end = System.nanoTime() - t1;
+			if (instructionName != null && GPUStatistics.DISPLAY_STATISTICS) GPUStatistics.maintainCPMiscTimes(instructionName, GPUInstruction.MISC_TIMER_SET_ZERO, end - t1);
+			if (DMLScript.STATISTICS) GPUStatistics.cudaMemSet0Time.getAndAdd(end - t1);
+			if (DMLScript.STATISTICS) GPUStatistics.cudaMemSet0Count.getAndAdd(1);
 			cudaBlockSizeMap.put(A, size);
 			return A;
 		}
@@ -1228,10 +1236,12 @@ public class JCudaObject extends GPUObject {
 		assert cudaBlockSizeMap.containsKey(toFree) : "ERROR : Internal state corrupted, cache block size map is not aware of a block it trying to free up";
 		long size = cudaBlockSizeMap.get(toFree);
 		if (eager) {
-			if (instructionName != null) t0 = System.nanoTime();
+			if (DMLScript.STATISTICS) t0 = System.nanoTime();
 			((JCudaContext)(JCudaContext.currContext)).deviceMemBytes.addAndGet(-size);
 			cudaFree(toFree);
 			cudaBlockSizeMap.remove(toFree);
+			if (DMLScript.STATISTICS) GPUStatistics.cudaDeAllocTime.addAndGet(System.nanoTime() - t0);
+			if (DMLScript.STATISTICS) GPUStatistics.cudaDeAllocCount.addAndGet(1);
 			if (instructionName != null && GPUStatistics.DISPLAY_STATISTICS) GPUStatistics.maintainCPMiscTimes(instructionName, GPUInstruction.MISC_TIMER_CUDA_FREE, System.nanoTime() - t0);
 		} else {
 			LinkedList<Pointer> freeList = freeCUDASpaceMap.get(size);

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCUDA.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCUDA.java
@@ -679,12 +679,12 @@ public class LibMatrixCUDA {
 			((JCudaObject)image.getGPUObject()).sparseToDense(instName);
 		}
 		Pointer x = ((JCudaObject)image.getGPUObject()).jcudaDenseMatrixPtr;
-		MatrixObject temp = new MatrixObject(image);
-		temp.getGPUObject().acquireDeviceModifyDense();
+		//MatrixObject temp = new MatrixObject(image);
+		//temp.getGPUObject().acquireDeviceModifyDense();
 		Pointer y = ((JCudaObject)image.getGPUObject()).jcudaDenseMatrixPtr;
 		performReLU(instName, x, y, N, C, H, W);
 		performMaxpooling(instName, y, outputBlock, N, C, H, W, K, R, S, pad_h, pad_w, stride_h, stride_w, P, Q);
-		((JCudaObject)temp.getGPUObject()).clearData(); // deallocate the temporary data
+		//((JCudaObject)temp.getGPUObject()).clearData(); // deallocate the temporary data
 	}
 	
 	private static void performMaxpooling(String instName, Pointer x,

--- a/src/main/java/org/apache/sysml/utils/GPUStatistics.java
+++ b/src/main/java/org/apache/sysml/utils/GPUStatistics.java
@@ -52,10 +52,12 @@ public class GPUStatistics {
 
   public static AtomicLong cudaAllocTime = new AtomicLong(0);             // time spent in allocating memory on the GPU
   public static AtomicLong cudaDeAllocTime = new AtomicLong(0);           // time spent in deallocating memory on the GPU
+  public static AtomicLong cudaMemSet0Time = new AtomicLong(0);           // time spent in setting memory to 0 on the GPU (part of reusing and for new allocates)
   public static AtomicLong cudaToDevTime = new AtomicLong(0);             // time spent in copying data from host (CPU) to device (GPU) memory
   public static AtomicLong cudaFromDevTime = new AtomicLong(0);           // time spent in copying data from device to host
   public static AtomicLong cudaAllocCount = new AtomicLong(0);
   public static AtomicLong cudaDeAllocCount = new AtomicLong(0);
+  public static AtomicLong cudaMemSet0Count = new AtomicLong(0);
   public static AtomicLong cudaToDevCount = new AtomicLong(0);
   public static AtomicLong cudaFromDevCount = new AtomicLong(0);
   public static AtomicLong cudaEvictionCount = new AtomicLong(0);
@@ -82,6 +84,8 @@ public class GPUStatistics {
     cudaLibrariesInitTime = 0;
     cudaAllocTime.set(0);
     cudaDeAllocTime.set(0);
+    cudaMemSet0Time.set(0);
+    cudaMemSet0Count.set(0);
     cudaToDevTime.set(0);
     cudaFromDevTime.set(0);
     cudaAllocCount.set(0);
@@ -187,14 +191,16 @@ public class GPUStatistics {
     sb.append("CUDA/CuLibraries init time:\t" + String.format("%.3f", cudaInitTime*1e-9) + "/"
             + String.format("%.3f", cudaLibrariesInitTime*1e-9) + " sec.\n");
     sb.append("Number of executed GPU inst:\t" + getNoOfExecutedGPUInst() + ".\n");
-    sb.append("GPU mem tx time  (alloc/dealloc/toDev/fromDev):\t"
+    sb.append("GPU mem tx time  (alloc/dealloc/set0/toDev/fromDev):\t"
             + String.format("%.3f", cudaAllocTime.get()*1e-9) + "/"
             + String.format("%.3f", cudaDeAllocTime.get()*1e-9) + "/"
+            + String.format("%.3f", cudaMemSet0Time.get()*1e-9) + "/"
             + String.format("%.3f", cudaToDevTime.get()*1e-9) + "/"
             + String.format("%.3f", cudaFromDevTime.get()*1e-9)  + " sec.\n");
-    sb.append("GPU mem tx count (alloc/dealloc/toDev/fromDev/evict):\t"
+    sb.append("GPU mem tx count (alloc/dealloc/set0/toDev/fromDev/evict):\t"
             + cudaAllocCount.get() + "/"
             + cudaDeAllocCount.get() + "/"
+            + cudaMemSet0Count.get() + "/"
             + cudaSparseConversionCount.get() + "/"
             + cudaToDevCount.get() + "/"
             + cudaFromDevCount.get() + "/"

--- a/src/main/java/org/apache/sysml/utils/LRUCacheMap.java
+++ b/src/main/java/org/apache/sysml/utils/LRUCacheMap.java
@@ -1,0 +1,71 @@
+package org.apache.sysml.utils;
+
+
+import org.apache.sysml.runtime.DMLRuntimeException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * An access ordered LRU Cache Map which conforms to the {@link Map} interface
+ * while also providing the ability to get the least recently used entry
+ * @param <K> the key type
+ * @param <V> the value type
+ */
+public class LRUCacheMap<K,V> extends LinkedHashMap<K,V> {
+
+  /**
+   * Creates an access-ordered {@link LRUCacheMap}
+   */
+  public LRUCacheMap() {
+    // An access-ordered LinkedHashMap is instantiated with the default initial capacity and load factors
+    super(16, 0.75f, true);
+  }
+
+  // Private variables to assist in capturing the lease recently used entry
+  private boolean evictLRU = false;
+  private Map.Entry<K,V> lastEvictedEntry = null;
+
+  /**
+   * Removes and gets the least recently used entry
+   * @return  the lease recently used entry
+   * @throws DMLRuntimeException if the internal state is somehow corrupted
+   */
+  public Map.Entry<K,V> removeAndGetLRUEntry() throws DMLRuntimeException {
+    lastEvictedEntry = null;
+    if (size() <= 0){
+      return null;
+    }
+
+    // The idea is to set removing the eldest entry to true and then putting in a dummy
+    // entry (null, null). the removeEldestEntry will capture the eldest entry and is available
+    // to return via a class member variable.
+    evictLRU = true;
+    V previous = super.put(null, null);
+    remove(null);
+    if (previous != null){
+      throw new DMLRuntimeException("ERROR : Internal state of LRUCacheMap invalid - a value for the key 'null' is already present");
+    }
+    evictLRU = false;
+    Map.Entry<K,V> toRet = lastEvictedEntry;
+    return toRet;
+  }
+
+  @Override
+  protected boolean removeEldestEntry(Map.Entry<K,V> eldest) {
+    if (evictLRU) {
+      lastEvictedEntry = eldest;
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public V put (K k, V v){
+    if (k == null)
+      throw new IllegalArgumentException("ERROR: an entry with a null key was tried to be inserted in to the LRUCacheMap");
+    return super.put (k, v);
+  }
+
+
+}

--- a/src/test/java/org/apache/sysml/test/utils/LRUCacheMapTest.java
+++ b/src/test/java/org/apache/sysml/test/utils/LRUCacheMapTest.java
@@ -1,0 +1,102 @@
+package org.apache.sysml.test.utils;
+
+import org.apache.sysml.utils.LRUCacheMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class LRUCacheMapTest {
+
+  @Test
+  public void test1() throws Exception {
+    LRUCacheMap<String, Long> m = new LRUCacheMap<String, Long>();
+    m.put("k1", 10l);
+    m.put("k2", 20l);
+    m.put("k3", 30l);
+    m.put("k4", 40l);
+
+    Map.Entry<String, Long> e = m.removeAndGetLRUEntry();
+    Assert.assertEquals("k1", e.getKey());
+  }
+
+  @Test
+  public void test2() throws Exception {
+    LRUCacheMap<String, Long> m = new LRUCacheMap<String, Long>();
+    m.put("k1", 10l);
+    m.put("k2", 20l);
+    m.put("k3", 30l);
+    m.put("k4", 40l);
+    m.get("k1");
+
+    Map.Entry<String, Long> e = m.removeAndGetLRUEntry();
+    Assert.assertEquals("k2", e.getKey());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void test3() {
+    LRUCacheMap<String, Long> m = new LRUCacheMap<String, Long>();
+    m.put(null, 10l);
+  }
+
+  @Test
+  public void test4() throws Exception {
+    LRUCacheMap<String, Long> m = new LRUCacheMap<String, Long>();
+    m.put("k1", 10l);
+    m.put("k2", 20l);
+    m.put("k3", 30l);
+    m.put("k4", 40l);
+    m.remove("k1");
+    m.remove("k2");
+
+    Map.Entry<String, Long> e = m.removeAndGetLRUEntry();
+    Assert.assertEquals("k3", e.getKey());
+  }
+
+  @Test
+  public void test5() throws Exception {
+    LRUCacheMap<String, Long> m = new LRUCacheMap<String, Long>();
+    m.put("k1", 10l);
+    m.put("k2", 20l);
+    m.put("k1", 30l);
+
+    Map.Entry<String, Long> e = m.removeAndGetLRUEntry();
+    Assert.assertEquals("k2", e.getKey());
+  }
+
+  @Test
+  public void test6() throws Exception {
+    LRUCacheMap<String, Long> m = new LRUCacheMap<String, Long>();
+    m.put("k1", 10l);
+    m.put("k2", 20l);
+    m.put("k3", 30l);
+    m.put("k4", 40l);
+    m.put("k5", 50l);
+    m.put("k6", 60l);
+    m.put("k7", 70l);
+    m.put("k8", 80l);
+    m.get("k4");
+
+
+    Map.Entry<String, Long> e;
+    e = m.removeAndGetLRUEntry();
+    Assert.assertEquals("k1", e.getKey());
+    e = m.removeAndGetLRUEntry();
+    Assert.assertEquals("k2", e.getKey());
+    e = m.removeAndGetLRUEntry();
+    Assert.assertEquals("k3", e.getKey());
+    e = m.removeAndGetLRUEntry();
+    Assert.assertEquals("k5", e.getKey());
+    e = m.removeAndGetLRUEntry();
+    Assert.assertEquals("k6", e.getKey());
+    e = m.removeAndGetLRUEntry();
+    Assert.assertEquals("k7", e.getKey());
+    e = m.removeAndGetLRUEntry();
+    Assert.assertEquals("k8", e.getKey());
+    e = m.removeAndGetLRUEntry();
+    Assert.assertEquals("k4", e.getKey());
+
+  }
+
+
+}


### PR DESCRIPTION
Lazily frees cuda memory. Reuses memory already allocation on the GPU as much as possible.

Caveat - It is possible to run into the issue of internal/external memory fragmentation.
cudaMemGetInfo returns the total available free memory. That reported memory may not be contiguous to satisfy a request for an allocation though. No successful experiments have run into this issue yet, but a bug that I had introduced in my initial coding showed me this issue.

Also, with 2 use cases that I ran - @prithvirajsen's  [Autoencoder](https://github.com/apache/incubator-systemml/pull/384) and @dusenberrymw's lennet script with some small sample data i was provided, showed between a **`5x-10x`** speedup.

The PR also adds some advanced timers and adds certain bugfixes.
@niketanpansare - can you please verify if [this](https://github.com/apache/incubator-systemml/commit/02ae4ed667849ee006b1320b451e89daa9c7cb16) bug fix is legit?

ping @bertholdreinwald 

