### PR TITLE
[SYSTEMML-1391] Update project compilation to Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,8 +215,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/org/apache/sysml/api/MLBlock.java
+++ b/src/main/java/org/apache/sysml/api/MLBlock.java
@@ -32,7 +32,9 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 
+import scala.collection.JavaConversions;
 import scala.collection.Seq;
+import scala.collection.mutable.Buffer;
 
 /**
  * @deprecated This will be removed in SystemML 1.0. Please migrate to {@link org.apache.sysml.api.mlcontext.MLContext}
@@ -185,7 +187,9 @@ public class MLBlock implements Row {
 		retVal.add(indexes);
 		retVal.add(block);
 		// retVal.add(new Tuple2<MatrixIndexes, MatrixBlock>(indexes, block));
-		return (Seq<T>) scala.collection.JavaConversions.asScalaBuffer(retVal).toSeq();
+		@SuppressWarnings("rawtypes")
+		Buffer scBuf = JavaConversions.asScalaBuffer(retVal);
+		return scBuf.toSeq();
 	}
 
 	@Override
@@ -245,13 +249,16 @@ public class MLBlock implements Row {
 		return 2;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public Seq<Object> toSeq() {
 		ArrayList<Object> retVal = new ArrayList<Object>();
 		retVal.add(indexes);
 		retVal.add(block);
 		// retVal.add(new Tuple2<MatrixIndexes, MatrixBlock>(indexes, block));
-		return scala.collection.JavaConversions.asScalaBuffer(retVal).toSeq();
+		@SuppressWarnings("rawtypes")
+		Buffer scBuf = JavaConversions.asScalaBuffer(retVal);
+		return scBuf.toSeq();
 	}
 	
 	public static StructType getDefaultSchemaForBinaryBlock() {

--- a/src/test/java/org/apache/sysml/test/integration/functions/frame/FrameConverterTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/frame/FrameConverterTest.java
@@ -464,7 +464,7 @@ public class FrameConverterTest extends AutomatedTestBase
 			case CSV2BIN: {
 				InputInfo iinfo = InputInfo.CSVInputInfo;
 				OutputInfo oinfo = OutputInfo.BinaryBlockOutputInfo;
-				JavaPairRDD<LongWritable,Text> rddIn = sc.hadoopFile(fnameIn, iinfo.inputFormatClass, iinfo.inputKeyClass, iinfo.inputValueClass);
+				JavaPairRDD<LongWritable,Text> rddIn = (JavaPairRDD<LongWritable,Text>) sc.hadoopFile(fnameIn, iinfo.inputFormatClass, iinfo.inputKeyClass, iinfo.inputValueClass);
 				JavaPairRDD<LongWritable, FrameBlock> rddOut = FrameRDDConverterUtils
 						.csvToBinaryBlock(sc, rddIn, mc, null, false, separator, false, 0)
 						.mapToPair(new LongFrameToLongWritableFrameFunction());
@@ -483,7 +483,7 @@ public class FrameConverterTest extends AutomatedTestBase
 			case TXTCELL2BIN: {
 				InputInfo iinfo = InputInfo.TextCellInputInfo;
 				OutputInfo oinfo = OutputInfo.BinaryBlockOutputInfo;
-				JavaPairRDD<LongWritable,Text> rddIn = sc.hadoopFile(fnameIn, iinfo.inputFormatClass, iinfo.inputKeyClass, iinfo.inputValueClass);
+				JavaPairRDD<LongWritable,Text> rddIn = (JavaPairRDD<LongWritable,Text>) sc.hadoopFile(fnameIn, iinfo.inputFormatClass, iinfo.inputKeyClass, iinfo.inputValueClass);
 				JavaPairRDD<LongWritable, FrameBlock> rddOut = FrameRDDConverterUtils
 						.textCellToBinaryBlock(sc, rddIn, mc, lschema)
 						.mapToPair(new LongFrameToLongWritableFrameFunction());
@@ -501,7 +501,7 @@ public class FrameConverterTest extends AutomatedTestBase
 			case MAT2BIN: {
 				InputInfo iinfo = InputInfo.BinaryBlockInputInfo;
 				OutputInfo oinfo = OutputInfo.BinaryBlockOutputInfo;
-				JavaPairRDD<MatrixIndexes,MatrixBlock> rddIn = sc.hadoopFile(fnameIn, iinfo.inputFormatClass, iinfo.inputKeyClass, iinfo.inputValueClass);
+				JavaPairRDD<MatrixIndexes,MatrixBlock> rddIn = (JavaPairRDD<MatrixIndexes,MatrixBlock>) sc.hadoopFile(fnameIn, iinfo.inputFormatClass, iinfo.inputKeyClass, iinfo.inputValueClass);
 				JavaPairRDD<LongWritable, FrameBlock> rddOut = FrameRDDConverterUtils.matrixBlockToBinaryBlock(sc, rddIn, mcMatrix);
 				rddOut.saveAsHadoopFile(fnameOut, LongWritable.class, FrameBlock.class, oinfo.outputFormatClass);
 				break;


### PR DESCRIPTION
Update maven-compiler-plugin source and target to 1.8.
Minor updates to MLBlock for Java 8 in Eclipse (Neon) on OS X.
Add JavaPairRDD casts in FrameConverterTest for Java 8.