### PR TITLE
[SYSTEMML-1431] Throw controlled error when one-dimensional numpy array is passed to SystemML

### DIFF
--- a/docs/beginners-guide-python.md
+++ b/docs/beginners-guide-python.md
@@ -183,7 +183,7 @@ y_train = diabetes.target[:-20]
 y_test = diabetes.target[-20:]
 # Train Linear Regression model
 X = sml.matrix(X_train)
-y = sml.matrix(y_train)
+y = sml.matrix(np.matrix(y_train).T)
 A = X.transpose().dot(X)
 b = X.transpose().dot(y)
 beta = sml.solve(A, b).toNumPy()

--- a/src/main/python/systemml/converters.py
+++ b/src/main/python/systemml/converters.py
@@ -82,6 +82,13 @@ def convertToMatrixBlock(sc, src, maxSizeBlockInMB=8):
         src = coo_matrix(src,  dtype=np.float64)
     else:
         src = np.asarray(src, dtype=np.float64)
+    if len(src.shape) != 2:
+        hint = ''
+        if type(src) == np.ndarray and len(src.shape) == 1:
+            hint = '. Hint: If you intend to pass a one dimensional ndarray as column-vector, please use np.matrix(input).T'
+        elif len(src.shape) > 2:
+            hint = '. Hint: If you intend to pass a tensor, please reshape it into (N, CHW) format'
+        raise TypeError('SystemML only supports matrix datatype (i.e. len(input.shape) should be 2)' + hint)
     numRowsPerBlock = int(math.ceil((maxSizeBlockInMB*1000000) / (src.shape[1]*8)))
     # print("numRowsPerBlock=" + str(numRowsPerBlock))
     multiBlockTransfer = False if numRowsPerBlock >= src.shape[0] else True

--- a/src/main/python/systemml/converters.py
+++ b/src/main/python/systemml/converters.py
@@ -84,13 +84,14 @@ def convertToMatrixBlock(sc, src, maxSizeBlockInMB=8):
         src = np.asarray(src, dtype=np.float64)
     if len(src.shape) != 2:
         hint = ''
-        if type(src) == np.ndarray and len(src.shape) == 1:
-            hint = '. Hint: If you intend to pass a one dimensional ndarray as column-vector, please use np.matrix(input).T'
-        elif len(src.shape) > 2:
+        num_dim = len(src.shape)
+        type = str(type(src).__name__)
+        if type(src) == np.ndarray and num_dim == 1:
+            hint = '. Hint: If you intend to pass the 1-dimensional ndarray as a column-vector, please reshape it: input_ndarray.reshape(-1, 1)'
+        elif num_dim > 2:
             hint = '. Hint: If you intend to pass a tensor, please reshape it into (N, CHW) format'
-        raise TypeError('SystemML only supports matrix datatype (i.e. len(input.shape) should be 2)' + hint)
+        raise TypeError('Expected 2-dimensional ' + type + ', instead passed ' + str(num_dim) + '-dimensional ' + type + hint)
     numRowsPerBlock = int(math.ceil((maxSizeBlockInMB*1000000) / (src.shape[1]*8)))
-    # print("numRowsPerBlock=" + str(numRowsPerBlock))
     multiBlockTransfer = False if numRowsPerBlock >= src.shape[0] else True
     if not multiBlockTransfer:
         if isinstance(src, spmatrix):

--- a/src/main/python/systemml/converters.py
+++ b/src/main/python/systemml/converters.py
@@ -85,12 +85,12 @@ def convertToMatrixBlock(sc, src, maxSizeBlockInMB=8):
     if len(src.shape) != 2:
         hint = ''
         num_dim = len(src.shape)
-        type = str(type(src).__name__)
+        type1 = str(type(src).__name__)
         if type(src) == np.ndarray and num_dim == 1:
             hint = '. Hint: If you intend to pass the 1-dimensional ndarray as a column-vector, please reshape it: input_ndarray.reshape(-1, 1)'
         elif num_dim > 2:
             hint = '. Hint: If you intend to pass a tensor, please reshape it into (N, CHW) format'
-        raise TypeError('Expected 2-dimensional ' + type + ', instead passed ' + str(num_dim) + '-dimensional ' + type + hint)
+        raise TypeError('Expected 2-dimensional ' + type1 + ', instead passed ' + str(num_dim) + '-dimensional ' + type1 + hint)
     numRowsPerBlock = int(math.ceil((maxSizeBlockInMB*1000000) / (src.shape[1]*8)))
     multiBlockTransfer = False if numRowsPerBlock >= src.shape[0] else True
     if not multiBlockTransfer:

--- a/src/main/python/systemml/mllearn/estimators.py
+++ b/src/main/python/systemml/mllearn/estimators.py
@@ -81,7 +81,11 @@ class BaseSystemMLEstimator(Estimator):
     
     def _fit_numpy(self):
         try:
-            self.model = self.estimator.fit(convertToMatrixBlock(self.sc, self.X), convertToMatrixBlock(self.sc, self.y))
+            if type(self.y) == np.ndarray and len(self.y.shape) == 1:
+                # Since we know that mllearn always needs a column vector
+                self.y = np.matrix(self.y).T
+            y_mb = convertToMatrixBlock(self.sc, self.y)
+            self.model = self.estimator.fit(convertToMatrixBlock(self.sc, self.X), y_mb)
         except Py4JError:
             traceback.print_exc()
                     


### PR DESCRIPTION
@bertholdreinwald can you please review this PR ?

```python
>>> from mlxtend.data import mnist_data
>>> import numpy as np
>>> from sklearn.utils import shuffle
>>> X, y = mnist_data()
>>> from systemml import MLContext, dml
>>> ml = MLContext(sc)

Welcome to Apache SystemML!

>>> script = dml('print(sum(X))').input(X=X)
>>> ml.execute(script)
1.31267102E8
MLResults
>>> script = dml('print(sum(X))').input(X=y)
>>> ml.execute(script)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "systemml/mlcontext.py", line 337, in execute
    py4j.java_gateway.get_method(script_java, "in")(key, _py2java(self._sc, val))
  File "systemml/mlcontext.py", line 124, in _py2java
    obj = convertToMatrixBlock(sc, obj)
  File "systemml/converters.py", line 91, in convertToMatrixBlock
    raise TypeError('SystemML only supports matrix datatype (i.e. len(input.shape) should be 2)' + hint)
TypeError: SystemML only supports matrix datatype (i.e. len(input.shape) should be 2). Hint: If you intend to pass a one dimensional ndarray as column-vector, please use np.matrix(input).T
>>> script = dml('print(sum(X))').input(X=np.matrix(y).T)
>>> ml.execute(script)
22500.0
MLResults
>>>
```