### PR TITLE
[SYSTEMML-1442] Reduce the JVM memory required for transfering Numpy/Scipy array

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
@@ -889,11 +889,12 @@ public final class MLContextUtil {
 				}
 				sb.append(") ");
 
-				sb.append(key);
-				sb.append(": ");
-				String str = object.toString();
-				str = StringUtils.abbreviate(str, 100);
-				sb.append(str);
+				// Can cause java.lang.OutOfMemoryError: Java heap space at org.apache.sysml.runtime.matrix.data.MatrixBlock.toString(MatrixBlock.java:5804)
+				// sb.append(key);
+				// sb.append(": ");
+				// String str = object.toString();
+				// str = StringUtils.abbreviate(str, 100);
+				// sb.append(str);
 				sb.append("\n");
 			}
 		}

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
@@ -889,12 +889,17 @@ public final class MLContextUtil {
 				}
 				sb.append(") ");
 
-				// Can cause java.lang.OutOfMemoryError: Java heap space at org.apache.sysml.runtime.matrix.data.MatrixBlock.toString(MatrixBlock.java:5804)
-				// sb.append(key);
-				// sb.append(": ");
-				// String str = object.toString();
-				// str = StringUtils.abbreviate(str, 100);
-				// sb.append(str);
+				 sb.append(key);
+				 sb.append(": ");
+				 String str = null;
+				 if(object instanceof MatrixBlock) {
+					 MatrixBlock mb = (MatrixBlock) object;
+					 str = "MatrixBlock [sparse? = " + mb.isInSparseFormat() + ", nonzeros = " + mb.getNonZeros() + ", size: " + mb.getNumRows() + " X " + mb.getNumColumns() + "]";  
+				 }
+				 else 
+					 str = object.toString(); // TODO: Deal with OOM for other objects such as Frame, etc
+				 str = StringUtils.abbreviate(str, 100);
+				 sb.append(str);
 				sb.append("\n");
 			}
 		}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
@@ -208,7 +208,16 @@ public class RDDConverterUtilsExt
 		return allocateDenseOrSparse(rlen, clen, isSparse);
 	}
 	
+	public static void copyRowBlocks(MatrixBlock mb, int rowIndex, MatrixBlock ret, int numRowsPerBlock, int rlen, int clen) throws DMLRuntimeException {
+		copyRowBlocks(mb, (long)rowIndex, ret, (long)numRowsPerBlock, (long)rlen, (long)clen);
+	}
+	public static void copyRowBlocks(MatrixBlock mb, long rowIndex, MatrixBlock ret, int numRowsPerBlock, int rlen, int clen) throws DMLRuntimeException {
+		copyRowBlocks(mb, (long)rowIndex, ret, (long)numRowsPerBlock, (long)rlen, (long)clen);
+	}
 	public static void copyRowBlocks(MatrixBlock mb, int rowIndex, MatrixBlock ret, long numRowsPerBlock, long rlen, long clen) throws DMLRuntimeException {
+		copyRowBlocks(mb, (long)rowIndex, ret, (long)numRowsPerBlock, (long)rlen, (long)clen);
+	}
+	public static void copyRowBlocks(MatrixBlock mb, long rowIndex, MatrixBlock ret, long numRowsPerBlock, long rlen, long clen) throws DMLRuntimeException {
 		// TODO: Double-check if synchronization is required here.
 		// synchronized (RDDConverterUtilsExt.class) {
 			ret.copy((int)(rowIndex*numRowsPerBlock), (int)Math.min((rowIndex+1)*numRowsPerBlock-1, rlen-1), 0, (int)(clen-1), mb, false);

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
@@ -165,37 +165,6 @@ public class RDDConverterUtilsExt
 		return convertPy4JArrayToMB(data, (int) rlen, (int) clen, isSparse);
 	}
 	
-	public static MatrixBlock mergeRowBlocks(ArrayList<MatrixBlock> mb, int numRowsPerBlock, int rlen, int clen, boolean isSparse) throws DMLRuntimeException {
-		return mergeRowBlocks(mb, (long)numRowsPerBlock, (long)rlen, (long)clen, isSparse);
-	}
-	
-	/**
-	 * This creates a MatrixBlock from list of row blocks
-	 * 
-	 * @param mb list of row blocks
-	 * @param numRowsPerBlock number of rows per block
-	 * @param rlen number of rows
-	 * @param clen number of columns
-	 * @param isSparse is the output matrix in sparse format
-	 * @return a matrix block of shape (rlen, clen)
-	 * @throws DMLRuntimeException if DMLRuntimeException occurs
-	 */
-	public static MatrixBlock mergeRowBlocks(ArrayList<MatrixBlock> mb, long numRowsPerBlock, long rlen, long clen, boolean isSparse) throws DMLRuntimeException {
-		if(clen >= Integer.MAX_VALUE)
-			throw new DMLRuntimeException("Number of columns cannot be greater than " + Integer.MAX_VALUE);
-		if(rlen >= Integer.MAX_VALUE)
-			throw new DMLRuntimeException("Number of rows cannot be greater than " + Integer.MAX_VALUE);
-		
-		MatrixBlock ret = new MatrixBlock((int)rlen, (int) clen, isSparse);
-		ret.allocateDenseOrSparseBlock();
-		for(int i = 0; i < mb.size(); i++) {
-			ret.copy((int)(i*numRowsPerBlock), (int)Math.min((i+1)*numRowsPerBlock-1, rlen-1), 0, (int)(clen-1), mb.get(i), false);
-		}
-		ret.recomputeNonZeros();
-		ret.examSparsity();
-		return ret;
-	}
-	
 	public static MatrixBlock allocateDenseOrSparse(int rlen, int clen, boolean isSparse) {
 		MatrixBlock ret = new MatrixBlock(rlen, clen, isSparse);
 		ret.allocateDenseOrSparseBlock();

--- a/src/main/python/systemml/converters.py
+++ b/src/main/python/systemml/converters.py
@@ -57,6 +57,7 @@ def convertToLabeledDF(sparkSession, X, y=None):
         return out.select('features')
 
 def _convertSPMatrixToMB(sc, src):
+    src = coo_matrix(src,  dtype=np.float64)
     numRows = src.shape[0]
     numCols = src.shape[1]
     data = src.data
@@ -82,9 +83,6 @@ def _copyRowBlock(i, sc, ret, src, numRowsPerBlock,  rlen, clen):
     mb = _convertSPMatrixToMB(sc, src.getrow(i)) if isinstance(src, spmatrix) else  _convertDenseMatrixToMB(sc, src[i:i+numRowsPerBlock,])
     sc._jvm.org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt.copyRowBlocks(mb, rowIndex, ret, numRowsPerBlock, rlen, clen)
     return i
-
-def _copyRowBlock_helper(args):
-    return _copyRowBlock(*args)
     
 def convertToMatrixBlock(sc, src, maxSizeBlockInMB=8):
     if not isinstance(sc, SparkContext):

--- a/src/main/python/systemml/converters.py
+++ b/src/main/python/systemml/converters.py
@@ -104,11 +104,7 @@ def convertToMatrixBlock(sc, src, maxSizeBlockInMB=8):
         rlen = int(src.shape[0])
         clen = int(src.shape[1])
         ret = sc._jvm.org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt.allocateDenseOrSparse(rlen, clen, isSparse)
-        import multiprocessing
-        pool = multiprocessing.Pool()
-        pool.map(_copyRowBlock_helper, [ (i, sc, ret, src, numRowsPerBlock,  rlen, clen) for i in range(0, src.shape[0], numRowsPerBlock)])
-        pool.close()
-        pool.join()
+        [ _copyRowBlock(i, sc, ret, src, numRowsPerBlock,  rlen, clen) for i in range(0, src.shape[0], numRowsPerBlock) ]
         sc._jvm.org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt.postProcessAfterCopying(ret)
         return ret
 

--- a/src/main/python/systemml/converters.py
+++ b/src/main/python/systemml/converters.py
@@ -100,7 +100,7 @@ def convertToMatrixBlock(sc, src, maxSizeBlockInMB=8):
         numRowsPerBlock = 1 if isSparse else numRowsPerBlock
         ret = sc._jvm.org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt.allocateDenseOrSparse(int(src.shape[0]), int(src.shape[1]), isSparse)
         from functools import partial
-        partialFunc = partial(_copyRowBlock, sc=sc, ret=ret, src=src, numRowsPerBlock=numRowsPerBlock, rlen=rlen, clen=clen)
+        partialFunc = partial(_copyRowBlock, sc=sc, ret=ret, src=src, numRowsPerBlock=int(numRowsPerBlock), rlen=int(src.shape[0]), clen=int(src.shape[1]))
         import multiprocessing
         pool = multiprocessing.Pool()
         pool.map(partialFunc, range(0, src.shape[0], numRowsPerBlock))


### PR DESCRIPTION
```python
# ~/spark-2.1.0-bin-hadoop2.7/bin/pyspark  --driver-memory 4G
import numpy as np
import systemml as sml
import timeit
num_rows = 10000
num_cols = 5000
ml = sml.MLContext(sc)
X = None
def executeDML():
	script = sml.dml('print("X:" + sum(X))').input(X=X)
	ml.execute(script)

# --------------------------------------------------------------
# Conversion time if the data is available in the required format
X = np.random.rand(num_rows,num_cols)
timeit.timeit(executeDML, number=1)
>> 15.64487600326538 seconds

# The below number shows a usecase where the data scientist parallelizes NumPy externally.
import pandas as pd
X=sqlCtx.createDataFrame(pd.DataFrame(np.random.rand(num_rows,num_cols)))
timeit.timeit(executeDML, number=1)
>> 26.79346513748169 seconds

# Just to check if sparse format works
from scipy.sparse import random
X = random(num_rows, num_cols, density=0.25)
timeit.timeit(executeDML, number=1)
>> 24.338059902191162 seconds
# --------------------------------------------------------------

def executeNumpy():
	script = sml.dml('print("X:" + sum(X))').input(X=np.random.rand(num_rows,num_cols))
	ml.execute(script)

def executeDF():
	import pandas as pd
	script = sml.dml('print("X:" + sum(X))').input(X=sqlCtx.createDataFrame(pd.DataFrame(np.random.rand(num_rows,num_cols))))
	ml.execute(script)

# --------------------------------------------------------------
# Conversion time if the data is not available in the required format
timeit.timeit(executeNumpy, number=1)
>> 17.52155303955078 seconds

# This represents the time required if we always pass datastructures via DataFrame _py2java:
# This experiment justify why existing approach is valid (even at cost of simplicity of implementation)
timeit.timeit(executeDF, number=1)
>>  458.05856013298035 seconds
# --------------------------------------------------------------
```

@deroneriksson  The above script throws OOM on current master with [MLContextUtil.displayInputs](https://github.com/apache/incubator-systemml/pull/443/files#diff-735518f2b386956b683891394661808bL892) uncommented:
```bash
py4j.protocol.Py4JJavaError: An error occurred while calling o37.execute.
: java.lang.OutOfMemoryError: Java heap space
        at java.util.Arrays.copyOf(Arrays.java:3332)
        at java.lang.AbstractStringBuilder.ensureCapacityInternal(AbstractStringBuilder.java:124)
        at java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:596)
        at java.lang.StringBuilder.append(StringBuilder.java:190)
        at sun.misc.FloatingDecimal$BinaryToASCIIBuffer.appendTo(FloatingDecimal.java:309)
        at sun.misc.FloatingDecimal.appendTo(FloatingDecimal.java:89)
        at java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:736)
        at java.lang.StringBuilder.append(StringBuilder.java:226)
        at org.apache.sysml.runtime.matrix.data.MatrixBlock.toString(MatrixBlock.java:5804)
        at org.apache.sysml.api.mlcontext.MLContextUtil.displayInputs(MLContextUtil.java:894)
        at org.apache.sysml.api.mlcontext.Script.displayInputs(Script.java:612)
        at org.apache.sysml.api.mlcontext.MLContextUtil.createHistoryForScript(MLContextUtil.java:988)
        at org.apache.sysml.api.mlcontext.MLContext.execute(MLContext.java:311)
        at org.apache.sysml.api.mlcontext.MLContext.execute(MLContext.java:286)
```

@bertholdreinwald This PR doesnot require 2 copies of MatrixBlock.

@dusenberrymw The above numbers addresses our earlier discussion on `_py2java`. 