### PR TITLE
[SYSTEMML-1510] Add Pygments license in source distribution

### DIFF
--- a/src/assembly/source/LICENSE
+++ b/src/assembly/source/LICENSE
@@ -322,6 +322,36 @@ available at https://github.com/jquery/sizzle
 The following license applies to all parts of this software except as
 documented below:
 
+================================================================================
+
+Pygments (pygments-default.css) is distributed under the BSD license:
+
+Copyright (c) 2006-2017 by the respective authors (see AUTHORS file).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 ====
 
 Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
Updated license text for Pygments in source license file.

@deroneriksson Can you please review change?

Note:
    - I don't have Pygments version to specify, I don't think it matters.
    - License specifies to refer to AUTHORS file from Pygments source code, not sure if it needs to be added anywhere. 