### PR TITLE
[SYSTEMML-259] Function with no return value fix

### DIFF
--- a/src/main/java/org/apache/sysml/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysml/parser/DMLTranslator.java
@@ -848,8 +848,10 @@ public class DMLTranslator
 			if (current instanceof AssignmentStatement) {
 				AssignmentStatement as = (AssignmentStatement) current;
 				DataIdentifier target = as.getTarget();
-				if (liveOut.containsVariable(target.getName())) {
-					liveOutToTemp.put(target.getName(), Integer.valueOf(i));
+				if (target != null) {
+					if (liveOut.containsVariable(target.getName())) {
+						liveOutToTemp.put(target.getName(), Integer.valueOf(i));
+					}
 				}
 			}
 			if (current instanceof MultiAssignmentStatement) {
@@ -1065,7 +1067,13 @@ public class DMLTranslator
 
 					//create function op
 					FunctionType ftype = fsb.getFunctionOpType();
-					FunctionOp fcall = new FunctionOp(ftype, fci.getNamespace(), fci.getName(), finputs, new String[]{target.getName()});
+					FunctionOp fcall = null;
+					if (target == null) {
+						fcall = new FunctionOp(ftype, fci.getNamespace(), fci.getName(), finputs, new String[]{});
+					} else {
+						fcall = new FunctionOp(ftype, fci.getNamespace(), fci.getName(), finputs, new String[]{target.getName()});
+					}
+
 					output.add(fcall);
 					
 					//TODO function output dataops (phase 3)

--- a/src/main/java/org/apache/sysml/parser/StatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/StatementBlock.java
@@ -596,14 +596,16 @@ public class StatementBlock extends LiveVariableAnalysis
 					setStatementFormatType(as, conditional);
 				
 				// Handle const vars: (a) basic constant propagation, and (b) transitive constant propagation over assignments 
-				currConstVars.remove(target.getName());
-				if(source instanceof ConstIdentifier && !(target instanceof IndexedIdentifier)){ //basic
-					currConstVars.put(target.getName(), (ConstIdentifier)source);
-				}
-				if( source instanceof DataIdentifier && !(target instanceof IndexedIdentifier) ){ //transitive
-					DataIdentifier diSource = (DataIdentifier) source;
-					if( currConstVars.containsKey(diSource.getName()) ){
-						currConstVars.put(target.getName(), currConstVars.get(diSource.getName()));
+				if (target != null) {
+					currConstVars.remove(target.getName());
+					if(source instanceof ConstIdentifier && !(target instanceof IndexedIdentifier)){ //basic
+						currConstVars.put(target.getName(), (ConstIdentifier)source);
+					}
+					if( source instanceof DataIdentifier && !(target instanceof IndexedIdentifier) ){ //transitive
+						DataIdentifier diSource = (DataIdentifier) source;
+						if( currConstVars.containsKey(diSource.getName()) ){
+							currConstVars.put(target.getName(), currConstVars.get(diSource.getName()));
+						}
 					}
 				}
 			
@@ -634,8 +636,11 @@ public class StatementBlock extends LiveVariableAnalysis
 						}
 					}
 				}
+				if (target == null) {
+					// function has no return value
+				}
 				// CASE: target NOT indexed identifier
-				if (!(target instanceof IndexedIdentifier)){
+				else if (!(target instanceof IndexedIdentifier)){
 					target.setProperties(source.getOutput());
 					if (source.getOutput() instanceof IndexedIdentifier){
 						target.setDimensions(source.getOutput().getDim1(), source.getOutput().getDim2());
@@ -688,7 +693,9 @@ public class StatementBlock extends LiveVariableAnalysis
 					((IndexedIdentifier)target).setDimensions(targetSize._row, targetSize._col);		
 				}
 				
-				ids.addVariable(target.getName(), target);
+				if (target != null) {
+					ids.addVariable(target.getName(), target);
+				}
 				
 			}
 			

--- a/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
@@ -2656,6 +2656,26 @@ public class MLContextTest extends AutomatedTestBase {
 	}
 
 	@Test
+	public void testFunctionNoReturnValueForceFunctionCallDML() {
+		System.out.println("MLContextTest - function with no return value, force function call DML");
+
+		String s = "hello=function(){\nif(1==1){};\nprint('no return value, force function call');\n}\nhello();";
+		Script script = dml(s);
+		setExpectedStdOut("no return value, force function call");
+		ml.execute(script);
+	}
+
+	@Test
+	public void testFunctionNoReturnValueForceFunctionCallPYDML() {
+		System.out.println("MLContextTest - function with no return value, force function call PYDML");
+
+		String s = "def hello():\n\tif (1==1):\n\t\tprint('')\n\tprint('no return value, force function call')\nhello()";
+		Script script = pydml(s);
+		setExpectedStdOut("no return value, force function call");
+		ml.execute(script);
+	}
+
+	@Test
 	public void testFunctionReturnValueDML() {
 		System.out.println("MLContextTest - function with return value DML");
 


### PR DESCRIPTION
Add additional target null checks so that if a function does not return a
value and is not inlined, it does not require an lvalue.
Add MLContext tests with forced function calls.