### PR TITLE
[SYSTEMML-1554] IPA Scalar Transient Read Replacement

### DIFF
--- a/src/main/java/org/apache/sysml/hops/ipa/InterProceduralAnalysis.java
+++ b/src/main/java/org/apache/sysml/hops/ipa/InterProceduralAnalysis.java
@@ -467,13 +467,12 @@ public class InterProceduralAnalysis
 	 *
 	 * @param sb  DML statement blocks.
 	 * @param fcand  Function candidates.
-	 * @param callVars  Calling program's map of variables eligible for
-	 *                     propagation.
+	 * @param callVars  Map of variables eligible for propagation.
 	 * @param fcandSafeNNZ  Function candidate safe non-zeros.
 	 * @param unaryFcands  Unary function candidates.
 	 * @param fnStack  Function stack to determine current scope.
-	 * @throws HopsException
-	 * @throws ParseException
+	 * @throws HopsException  If a HopsException occurs.
+	 * @throws ParseException  If a ParseException occurs.
 	 */
 	private void propagateStatisticsAcrossBlock( StatementBlock sb, Map<String, Integer> fcand, LocalVariableMap callVars, Map<String, Set<Long>> fcandSafeNNZ, Set<String> unaryFcands, Set<String> fnStack )
 		throws HopsException, ParseException
@@ -566,10 +565,15 @@ public class InterProceduralAnalysis
 	 *
 	 * This replaces scalar reads and typecasts thereof with literals.
 	 *
+	 * Ultimately, this leads to improvements because the size
+	 * expression evaluation over DAGs with scalar symbol table entries
+	 * (which is also applied during IPA) is limited to supported
+	 * operations, whereas literal replacement is a brute force method
+	 * that applies to all (including future) operations.
+	 *
 	 * @param roots  List of HOPs.
-	 * @param vars  Calling program's map of variables eligible for
-	 *                 propagation.
-	 * @throws HopsException
+	 * @param vars  Map of variables eligible for propagation.
+	 * @throws HopsException  If a HopsException occurs.
 	 */
 	private void propagateScalarsAcrossDAG(ArrayList<Hop> roots, LocalVariableMap vars)
 		throws HopsException
@@ -608,9 +612,9 @@ public class InterProceduralAnalysis
 	/**
 	 * Propagate matrix sizes across DAGs.
 	 *
-	 * @param roots  List of HOPs.
+	 * @param roots  List of HOP DAG root nodes.
 	 * @param vars  Map of variables eligible for propagation.
-	 * @throws HopsException
+	 * @throws HopsException  If a HopsException occurs.
 	 */
 	private void propagateStatisticsAcrossDAG( ArrayList<Hop> roots, LocalVariableMap vars )
 		throws HopsException
@@ -643,15 +647,15 @@ public class InterProceduralAnalysis
 	 * block.
 	 *
 	 * @param prog  The DML program.
-	 * @param roots List of HOPs in this DAG for propagation.
+	 * @param roots List of HOP DAG root notes for propagation.
 	 * @param fcand  Function candidates.
 	 * @param callVars  Calling program's map of variables eligible for
 	 *                     propagation.
 	 * @param fcandSafeNNZ  Function candidate safe non-zeros.
 	 * @param unaryFcands  Unary function candidates.
 	 * @param fnStack  Function stack to determine current scope.
-	 * @throws HopsException
-	 * @throws ParseException
+	 * @throws HopsException  If a HopsException occurs.
+	 * @throws ParseException  If a ParseException occurs.
 	 */
 	private void propagateStatisticsIntoFunctions(DMLProgram prog, ArrayList<Hop> roots, Map<String, Integer> fcand, LocalVariableMap callVars, Map<String, Set<Long>> fcandSafeNNZ, Set<String> unaryFcands, Set<String> fnStack )
 			throws HopsException, ParseException
@@ -672,8 +676,8 @@ public class InterProceduralAnalysis
 	 * @param fcandSafeNNZ  Function candidate safe non-zeros.
 	 * @param unaryFcands  Unary function candidates.
 	 * @param fnStack  Function stack to determine current scope.
-	 * @throws HopsException
-	 * @throws ParseException
+	 * @throws HopsException  If a HopsException occurs.
+	 * @throws ParseException  If a ParseException occurs.
 	 */
 	private void propagateStatisticsIntoFunctions(DMLProgram prog, Hop hop, Map<String, Integer> fcand, LocalVariableMap callVars, Map<String, Set<Long>> fcandSafeNNZ, Set<String> unaryFcands, Set<String> fnStack ) 
 		throws HopsException, ParseException
@@ -784,7 +788,20 @@ public class InterProceduralAnalysis
 			}
 		}
 	}
-	
+
+	/**
+	 * Extract return variable statistics from this function into the
+	 * calling program.
+	 *
+	 * @param fstmt  The function statement.
+	 * @param fop  The function op.
+	 * @param tmpVars  Function's map of variables eligible for
+	 *                    extraction.
+	 * @param callVars  Calling program's map of variables.
+	 * @param overwrite  Whether or not to overwrite variables in the
+	 *                      calling program's variable map.
+	 * @throws HopsException  If a HopsException occurs.
+	 */
 	private void extractFunctionCallReturnStatistics( FunctionStatement fstmt, FunctionOp fop, LocalVariableMap tmpVars, LocalVariableMap callVars, boolean overwrite ) 
 		throws HopsException
 	{

--- a/src/main/java/org/apache/sysml/hops/ipa/InterProceduralAnalysis.java
+++ b/src/main/java/org/apache/sysml/hops/ipa/InterProceduralAnalysis.java
@@ -535,7 +535,7 @@ public class InterProceduralAnalysis
 			//old stats in, new stats out if updated
 			ArrayList<Hop> roots = sb.get_hops();
 			DMLProgram prog = sb.getDMLProg();
-			//replace scalar transient reads with literals
+			//replace scalar reads with literals
 			Hop.resetVisitStatus(roots);
 			propagateScalarsAcrossDAG(roots, callVars);
 			//refresh stats across dag
@@ -550,7 +550,7 @@ public class InterProceduralAnalysis
 	/**
 	 * Propagate scalar values across DAGs.
 	 *
-	 * This replaces scalar transient reads with literals.
+	 * This replaces scalar reads and typecasts thereof with literals.
 	 *
 	 * @param roots  List of HOPs.
 	 * @param vars  Map of variables eligible for propagation.
@@ -561,9 +561,9 @@ public class InterProceduralAnalysis
 	{
 		for (Hop hop : roots) {
 			try {
-				Recompiler.rReplaceLiterals(hop, vars);
+				Recompiler.rReplaceLiterals(hop, vars, true);
 			} catch (Exception ex) {
-				throw new HopsException("Failed to replace transient reads w/ literals.", ex);
+				throw new HopsException("Failed to perform scalar literal replacement.", ex);
 			}
 		}
 	}

--- a/src/main/java/org/apache/sysml/hops/ipa/InterProceduralAnalysis.java
+++ b/src/main/java/org/apache/sysml/hops/ipa/InterProceduralAnalysis.java
@@ -747,7 +747,20 @@ public class InterProceduralAnalysis
 				DataIdentifier di = foutputOps.get(i);
 				String fvarname = di.getName(); //name in function signature
 				String pvarname = outputVars[i]; //name in calling program
-				
+
+				// If the calling program is reassigning a variable with the output of this
+				// function, and the datatype differs between that variable and this function
+				// output, remove that variable from the calling program's variable map.
+				if( callVars.keySet().contains(pvarname) ) {
+					DataType fdataType = di.getDataType();
+					DataType pdataType = callVars.get(pvarname).getDataType();
+					if( fdataType != pdataType ) {
+						// datatype has changed, and the calling program is reassigning the
+						// the variable, so remove it from the calling variable map
+						callVars.remove(pvarname);
+					}
+				}
+				// Update or add to the calling program's variable map.
 				if( di.getDataType()==DataType.MATRIX && tmpVars.keySet().contains(fvarname) )
 				{
 					MatrixObject moIn = (MatrixObject) tmpVars.get(fvarname);

--- a/src/main/java/org/apache/sysml/hops/ipa/InterProceduralAnalysis.java
+++ b/src/main/java/org/apache/sysml/hops/ipa/InterProceduralAnalysis.java
@@ -460,8 +460,22 @@ public class InterProceduralAnalysis
 	/////////////////////////////
 	// INTRA-PROCEDURE ANALYSIS
 	//////	
-	
-	private void propagateStatisticsAcrossBlock( StatementBlock sb, Map<String, Integer> fcand, LocalVariableMap callVars, Map<String, Set<Long>> fcandSafeNNZ, Set<String> unaryFcands, Set<String> fnStack ) 
+
+	/**
+	 * Perform intra-procedural analysis (IPA) by propagating statistics
+	 * across statement blocks.
+	 *
+	 * @param sb  DML statement blocks.
+	 * @param fcand  Function candidates.
+	 * @param callVars  Calling program's map of variables eligible for
+	 *                     propagation.
+	 * @param fcandSafeNNZ  Function candidate safe non-zeros.
+	 * @param unaryFcands  Unary function candidates.
+	 * @param fnStack  Function stack to determine current scope.
+	 * @throws HopsException
+	 * @throws ParseException
+	 */
+	private void propagateStatisticsAcrossBlock( StatementBlock sb, Map<String, Integer> fcand, LocalVariableMap callVars, Map<String, Set<Long>> fcandSafeNNZ, Set<String> unaryFcands, Set<String> fnStack )
 		throws HopsException, ParseException
 	{
 		if (sb instanceof FunctionStatementBlock)
@@ -553,7 +567,8 @@ public class InterProceduralAnalysis
 	 * This replaces scalar reads and typecasts thereof with literals.
 	 *
 	 * @param roots  List of HOPs.
-	 * @param vars  Map of variables eligible for propagation.
+	 * @param vars  Calling program's map of variables eligible for
+	 *                 propagation.
 	 * @throws HopsException
 	 */
 	private void propagateScalarsAcrossDAG(ArrayList<Hop> roots, LocalVariableMap vars)
@@ -589,8 +604,15 @@ public class InterProceduralAnalysis
 			throw new HopsException("Failed to update Hop DAG statistics.", ex);
 		}
 	}
-	
-	private void propagateStatisticsAcrossDAG( ArrayList<Hop> roots, LocalVariableMap vars ) 
+
+	/**
+	 * Propagate matrix sizes across DAGs.
+	 *
+	 * @param roots  List of HOPs.
+	 * @param vars  Map of variables eligible for propagation.
+	 * @throws HopsException
+	 */
+	private void propagateStatisticsAcrossDAG( ArrayList<Hop> roots, LocalVariableMap vars )
 		throws HopsException
 	{
 		if( roots == null )
@@ -615,14 +637,44 @@ public class InterProceduralAnalysis
 	/////////////////////////////
 	// INTER-PROCEDURE ANALYIS
 	//////
-	
-	private void propagateStatisticsIntoFunctions(DMLProgram prog, ArrayList<Hop> roots, Map<String, Integer> fcand, LocalVariableMap callVars, Map<String, Set<Long>> fcandSafeNNZ, Set<String> unaryFcands, Set<String> fnStack ) 
+
+	/**
+	 * Propagate statistics from the calling program into a function
+	 * block.
+	 *
+	 * @param prog  The DML program.
+	 * @param roots List of HOPs in this DAG for propagation.
+	 * @param fcand  Function candidates.
+	 * @param callVars  Calling program's map of variables eligible for
+	 *                     propagation.
+	 * @param fcandSafeNNZ  Function candidate safe non-zeros.
+	 * @param unaryFcands  Unary function candidates.
+	 * @param fnStack  Function stack to determine current scope.
+	 * @throws HopsException
+	 * @throws ParseException
+	 */
+	private void propagateStatisticsIntoFunctions(DMLProgram prog, ArrayList<Hop> roots, Map<String, Integer> fcand, LocalVariableMap callVars, Map<String, Set<Long>> fcandSafeNNZ, Set<String> unaryFcands, Set<String> fnStack )
 			throws HopsException, ParseException
 	{
 		for( Hop root : roots )
 			propagateStatisticsIntoFunctions(prog, root, fcand, callVars, fcandSafeNNZ, unaryFcands, fnStack);
 	}
-	
+
+	/**
+	 * Propagate statistics from the calling program into a function
+	 * block.
+	 *
+	 * @param prog  The DML program.
+	 * @param hop HOP to propagate statistics into.
+	 * @param fcand  Function candidates.
+	 * @param callVars  Calling program's map of variables eligible for
+	 *                     propagation.
+	 * @param fcandSafeNNZ  Function candidate safe non-zeros.
+	 * @param unaryFcands  Unary function candidates.
+	 * @param fnStack  Function stack to determine current scope.
+	 * @throws HopsException
+	 * @throws ParseException
+	 */
 	private void propagateStatisticsIntoFunctions(DMLProgram prog, Hop hop, Map<String, Integer> fcand, LocalVariableMap callVars, Map<String, Set<Long>> fcandSafeNNZ, Set<String> unaryFcands, Set<String> fnStack ) 
 		throws HopsException, ParseException
 	{

--- a/src/main/java/org/apache/sysml/hops/recompile/Recompiler.java
+++ b/src/main/java/org/apache/sysml/hops/recompile/Recompiler.java
@@ -1313,18 +1313,17 @@ public class Recompiler
 	}
 
 	/**
-	 * Remove any scalar variables from the calling program's
-	 * variable map if the variable is updated in this block.
+	 * Remove any scalar variables from the variable map if the variable
+	 * is updated in this block.
 	 *
-	 * @param callVars  Calling program's map of variables eligible for
-	 *                     propagation.
-	 * @param sb  DML statement blocks.
+	 * @param callVars  Map of variables eligible for propagation.
+	 * @param sb  DML statement block.
 	 */
 	public static void removeUpdatedScalars( LocalVariableMap callVars, StatementBlock sb )
 	{
 		if( sb != null )
 		{
-			//remove update scalar variables from constants
+			//remove updated scalar variables from constants
 			for( String varname : sb.variablesUpdated().getVariables().keySet() )
 			{
 				Data dat = callVars.get(varname);

--- a/src/main/java/org/apache/sysml/hops/recompile/Recompiler.java
+++ b/src/main/java/org/apache/sysml/hops/recompile/Recompiler.java
@@ -1311,7 +1311,15 @@ public class Recompiler
 		}
 		
 	}
-	
+
+	/**
+	 * Remove any scalar variables from the calling program's
+	 * variable map if the variable is updated in this block.
+	 *
+	 * @param callVars  Calling program's map of variables eligible for
+	 *                     propagation.
+	 * @param sb  DML statement blocks.
+	 */
 	public static void removeUpdatedScalars( LocalVariableMap callVars, StatementBlock sb )
 	{
 		if( sb != null )


### PR DESCRIPTION
Currently, during IPA we collect all variables (scalars & matrices)
eligible for propagation across blocks (i.e. not updated in block), and
then propagate the only the matrix sizes across the blocks. It seems
plausible that we could also replace all eligible scalar transient reads
with literals based on the variables that have already been collected.
The benefit is that many ops will be able to determine their respective
output sizes during regular compilation, instead of having to wait until
dynamic recompilation, and thus we can reduce the pressure on dynamic
recompilation.

Are there drawbacks to this approach?  The use case is that I was seeing a large number of memory warnings while training a convolutional net due to the sizes being unknown during regular compilation, yet the engine only having CP versions of the ops.  Additionally, I was running into actual heap space OOM errors for situations that should not run out of memory, and thus I started exploring.

I've attached an example script and the explain plan (hops & runtime) w/ and w/o the IPA scalar replacement to the associated JIRA issue.

cc @mboehm7 