### PR TITLE
[SYSTEMML-1564] Add a Java test suite wrapper around the `nn` DML test suite

### DIFF
--- a/scripts/nn/test/grad_check.dml
+++ b/scripts/nn/test/grad_check.dml
@@ -1612,11 +1612,12 @@ two_layer_affine_l2_net = function() {
   M = 10 # number of hidden neurons
   [W1, b1] = affine::init(D, M)
   [W2, b2] = affine::init(M, yD)
+  W2 = W2 / sqrt(2)  # different initialization, since being fed into l2 loss, instead of relu
 
   # Optimize for short "burn-in" time to move to characteristic
   # mode of operation and unmask any real issues.
   print(" - Burn-in:")
-  lr = 0.0001
+  lr = 0.01
   decay = 0.99
   for(i in 1:5) {
     # Compute forward and backward passes of net
@@ -1635,7 +1636,7 @@ two_layer_affine_l2_net = function() {
   [pred, loss, dX, dW1, db1, dW2, db2] = two_layer_affine_l2_net_run(X, y, W1, b1, W2, b2)
 
   # Grad check
-  h = 1e-5
+  h = 1e-6
   print(" - Grad checking X.")
   for (i in 1:2) {
     for (j in 1:ncol(X)) {

--- a/src/main/java/org/apache/sysml/parser/ParserWrapper.java
+++ b/src/main/java/org/apache/sysml/parser/ParserWrapper.java
@@ -24,6 +24,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -110,7 +112,10 @@ public abstract class ParserWrapper {
 				LOG.debug("Looking for the following file in the local file system: " + script);
 				if( !LocalFileUtils.validateExternalFilename(script, false) )
 					throw new LanguageException("Invalid (non-trustworthy) local filename.");
-				in = new BufferedReader(new FileReader(script));
+				if (Files.exists(Paths.get(script)))
+					in = new BufferedReader(new FileReader(script));
+				else  // check in scripts/ directory for file (useful for tests)
+					in = new BufferedReader(new FileReader("scripts/" + script));
 			}
 			
 			//core script reading

--- a/src/test/java/org/apache/sysml/test/integration/scripts/nn/NNTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/scripts/nn/NNTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.test.integration.scripts.nn;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.sysml.api.mlcontext.MLContext;
+import org.apache.sysml.api.mlcontext.MLContextUtil;
+import org.apache.sysml.api.mlcontext.Script;
+import org.apache.sysml.test.integration.AutomatedTestBase;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.apache.sysml.api.mlcontext.ScriptFactory.dmlFromFile;
+
+/**
+ * Test the SystemML deep learning library, `nn`.
+ */
+public class NNTest extends AutomatedTestBase {
+
+	private static final String TEST_NAME = "NNTest";
+	private static final String TEST_DIR = "scripts/";
+	private static final String TEST_SCRIPT = "scripts/nn/test/run_tests.dml";
+	private static final String ERROR_STRING = "ERROR:";
+
+	private static SparkSession spark;
+	private static JavaSparkContext sc;
+	private static MLContext ml;
+
+	@BeforeClass
+	public static void setUpClass() {
+		spark = createSystemMLSparkSession("MLContextTest", "local");
+		ml = new MLContext(spark);
+		sc = MLContextUtil.getJavaSparkContext(ml);
+	}
+
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_DIR, TEST_NAME);
+		getAndLoadTestConfiguration(TEST_NAME);
+	}
+
+	@Test
+	public void testNNLibrary() {
+		Script script = dmlFromFile(TEST_SCRIPT);
+		setUnexpectedStdOut(ERROR_STRING);
+		ml.execute(script);
+	}
+
+	@After
+	public void tearDown() {
+		super.tearDown();
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		// stop underlying spark context to allow single jvm tests (otherwise the
+		// next test that tries to create a SparkContext would fail)
+		spark.stop();
+		sc = null;
+		spark = null;
+
+		// clear status mlcontext and spark exec context
+		ml.close();
+		ml = null;
+	}
+}

--- a/src/test/java/org/apache/sysml/test/integration/scripts/nn/NNTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/scripts/nn/NNTest.java
@@ -19,10 +19,8 @@
 
 package org.apache.sysml.test.integration.scripts.nn;
 
-import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.sysml.api.mlcontext.MLContext;
-import org.apache.sysml.api.mlcontext.MLContextUtil;
 import org.apache.sysml.api.mlcontext.Script;
 import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.junit.After;
@@ -43,14 +41,12 @@ public class NNTest extends AutomatedTestBase {
 	private static final String ERROR_STRING = "ERROR:";
 
 	private static SparkSession spark;
-	private static JavaSparkContext sc;
 	private static MLContext ml;
 
 	@BeforeClass
 	public static void setUpClass() {
 		spark = createSystemMLSparkSession("MLContextTest", "local");
 		ml = new MLContext(spark);
-		sc = MLContextUtil.getJavaSparkContext(ml);
 	}
 
 	@Override
@@ -76,7 +72,6 @@ public class NNTest extends AutomatedTestBase {
 		// stop underlying spark context to allow single jvm tests (otherwise the
 		// next test that tries to create a SparkContext would fail)
 		spark.stop();
-		sc = null;
 		spark = null;
 
 		// clear status mlcontext and spark exec context

--- a/src/test_suites/java/org/apache/sysml/test/integration/scripts/nn/ZPackageSuite.java
+++ b/src/test_suites/java/org/apache/sysml/test/integration/scripts/nn/ZPackageSuite.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.test.integration.scripts.nn;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/** Group together the tests in this package/related subpackages into a single suite so that the Maven build
+ *  won't run two of them at once. Since the DML and PyDML equivalent tests currently share the same directories,
+ *  they should not be run in parallel. */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+  NNTest.class,
+})
+
+
+/** This class is just a holder for the above JUnit annotations. */
+public class ZPackageSuite {
+
+}


### PR DESCRIPTION
The `nn` library contains it's own DML test suite for gradient checks
and unit tests that produces "ERROR: ..." messages if any of the
mathematical operations return incorrect results.  Note that this has
helped to find mathematical bugs in the library & engine that do not
result in JVM exceptions.  This commit simply adds a Java test harness
that wraps these DML tests, parsing the standard out for "ERROR:"
messages.  A new `scripts` test package has been created, with the aim
of eventually testing all of our DML algorithms.  Additionally, the
ParserWrapper has been updated to look in the `scripts` folder as a
fallback, which allows for easy testing of our actual scripts.