### PR TITLE
[SYSTEMML-1034] implemented gpu solve

### DIFF
--- a/src/main/java/org/apache/sysml/hops/BinaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/BinaryOp.java
@@ -574,7 +574,7 @@ public class BinaryOp extends Hop
 				ot = HopsOpOp2LopsU.get(op);
 			
 			if(DMLScript.USE_ACCELERATOR && (DMLScript.FORCE_ACCELERATOR || getMemEstimate() < OptimizerUtils.GPU_MEMORY_BUDGET) 
-					&& (op == OpOp2.MULT || op == OpOp2.PLUS || op == OpOp2.MINUS || op == OpOp2.DIV || op == OpOp2.POW) ) {
+					&& (op == OpOp2.MULT || op == OpOp2.PLUS || op == OpOp2.MINUS || op == OpOp2.DIV || op == OpOp2.POW || op == OpOp2.SOLVE) ) {
 				et = ExecType.GPU;
 			}
 			Unary unary1 = new Unary(getInput().get(0).constructLops(),

--- a/src/main/java/org/apache/sysml/hops/BinaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/BinaryOp.java
@@ -574,7 +574,7 @@ public class BinaryOp extends Hop
 				ot = HopsOpOp2LopsU.get(op);
 			
 			if(DMLScript.USE_ACCELERATOR && (DMLScript.FORCE_ACCELERATOR || getMemEstimate() < OptimizerUtils.GPU_MEMORY_BUDGET) 
-					&& (op == OpOp2.MULT || op == OpOp2.PLUS || op == OpOp2.MINUS || op == OpOp2.DIV || op == OpOp2.POW || op == OpOp2.SOLVE) ) {
+					&& (op == OpOp2.MULT || op == OpOp2.PLUS || op == OpOp2.MINUS || op == OpOp2.DIV || op == OpOp2.POW) ) {
 				et = ExecType.GPU;
 			}
 			Unary unary1 = new Unary(getInput().get(0).constructLops(),
@@ -592,7 +592,7 @@ public class BinaryOp extends Hop
 			if ( et == ExecType.CP ) 
 			{
 				if(DMLScript.USE_ACCELERATOR && (DMLScript.FORCE_ACCELERATOR || getMemEstimate() < OptimizerUtils.GPU_MEMORY_BUDGET) 
-						&& (op == OpOp2.MULT || op == OpOp2.PLUS || op == OpOp2.MINUS || op == OpOp2.DIV || op == OpOp2.POW)) {
+						&& (op == OpOp2.MULT || op == OpOp2.PLUS || op == OpOp2.MINUS || op == OpOp2.DIV || op == OpOp2.POW || op == OpOp2.SOLVE)) {
 					et = ExecType.GPU;
 				}
 				

--- a/src/main/java/org/apache/sysml/runtime/instructions/GPUInstructionParser.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/GPUInstructionParser.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.instructions.gpu.AggregateBinaryGPUInstruction;
 import org.apache.sysml.runtime.instructions.gpu.ArithmeticBinaryGPUInstruction;
+import org.apache.sysml.runtime.instructions.gpu.BuiltinBinaryGPUInstruction;
 import org.apache.sysml.runtime.instructions.gpu.BuiltinUnaryGPUInstruction;
 import org.apache.sysml.runtime.instructions.gpu.ConvolutionGPUInstruction;
 import org.apache.sysml.runtime.instructions.gpu.GPUInstruction;
@@ -69,12 +70,15 @@ public class GPUInstructionParser  extends InstructionParser
 		String2GPUInstructionType.put( "^2"   , GPUINSTRUCTION_TYPE.ArithmeticBinary); //special ^ case
 		String2GPUInstructionType.put( "*2"   , GPUINSTRUCTION_TYPE.ArithmeticBinary); //special * case
 		String2GPUInstructionType.put( "-nz"  , GPUINSTRUCTION_TYPE.ArithmeticBinary); //special - case
-		String2GPUInstructionType.put( "+*"  , GPUINSTRUCTION_TYPE.ArithmeticBinary); 
-		String2GPUInstructionType.put( "-*"  , GPUINSTRUCTION_TYPE.ArithmeticBinary); 
+		String2GPUInstructionType.put( "+*"  	, GPUINSTRUCTION_TYPE.ArithmeticBinary);
+		String2GPUInstructionType.put( "-*"  	, GPUINSTRUCTION_TYPE.ArithmeticBinary);
 		
 		// Builtin functions
-		String2GPUInstructionType.put( "sel+"  , GPUINSTRUCTION_TYPE.BuiltinUnary);
-		String2GPUInstructionType.put( "exp"  , GPUINSTRUCTION_TYPE.BuiltinUnary);
+		String2GPUInstructionType.put( "sel+"  	, GPUINSTRUCTION_TYPE.BuiltinUnary);
+		String2GPUInstructionType.put( "exp"  	, GPUINSTRUCTION_TYPE.BuiltinUnary);
+
+		String2GPUInstructionType.put( "solve"  , GPUINSTRUCTION_TYPE.BuiltinBinary);
+
 
 		// Aggregate Unary
 		String2GPUInstructionType.put( "ua+"	 	 , GPUINSTRUCTION_TYPE.AggregateUnary);	// Sum
@@ -96,7 +100,7 @@ public class GPUInstructionParser  extends InstructionParser
 		String2GPUInstructionType.put( "uasqk+"	 , GPUINSTRUCTION_TYPE.AggregateUnary);	// Sum of Squares
 		String2GPUInstructionType.put( "uarsqk+" , GPUINSTRUCTION_TYPE.AggregateUnary);	// Row Sum of Squares
 		String2GPUInstructionType.put( "uacsqk+" , GPUINSTRUCTION_TYPE.AggregateUnary);	// Col Sum of Squares
-		String2GPUInstructionType.put( "uavar" 	 , GPUINSTRUCTION_TYPE.AggregateUnary);		// Variance
+		String2GPUInstructionType.put( "uavar" 	 , GPUINSTRUCTION_TYPE.AggregateUnary);	// Variance
 		String2GPUInstructionType.put( "uarvar"  , GPUINSTRUCTION_TYPE.AggregateUnary);	// Row Variance
 		String2GPUInstructionType.put( "uacvar"  , GPUINSTRUCTION_TYPE.AggregateUnary);	// Col Variance
 	}
@@ -133,6 +137,9 @@ public class GPUInstructionParser  extends InstructionParser
 			
 			case BuiltinUnary:
 				return BuiltinUnaryGPUInstruction.parseInstruction(str);
+
+			case BuiltinBinary:
+				return BuiltinBinaryGPUInstruction.parseInstruction(str);
 			
 			case Convolution:
 				return ConvolutionGPUInstruction.parseInstruction(str);

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/BuiltinBinaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/BuiltinBinaryGPUInstruction.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.runtime.instructions.gpu;
+
+import org.apache.sysml.parser.Expression;
+import org.apache.sysml.runtime.DMLRuntimeException;
+import org.apache.sysml.runtime.functionobjects.Builtin;
+import org.apache.sysml.runtime.functionobjects.ValueFunction;
+import org.apache.sysml.runtime.instructions.InstructionUtils;
+import org.apache.sysml.runtime.instructions.cp.CPOperand;
+import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
+import org.apache.sysml.runtime.matrix.operators.Operator;
+
+public abstract class BuiltinBinaryGPUInstruction extends GPUInstruction {
+
+  private int _arity;
+  CPOperand output;
+  CPOperand input1, input2;
+
+
+  public BuiltinBinaryGPUInstruction(Operator op, CPOperand input1, CPOperand input2, CPOperand output, String opcode, String istr, int _arity) {
+    super(op, opcode, istr);
+    this._arity = _arity;
+    this.output = output;
+    this.input1 = input1;
+    this.input2 = input2;
+  }
+
+  public static BuiltinBinaryGPUInstruction parseInstruction(String str) throws DMLRuntimeException {
+    CPOperand in1 = new CPOperand("", Expression.ValueType.UNKNOWN, Expression.DataType.UNKNOWN);
+    CPOperand in2 = new CPOperand("", Expression.ValueType.UNKNOWN, Expression.DataType.UNKNOWN);
+    CPOperand out = new CPOperand("", Expression.ValueType.UNKNOWN, Expression.DataType.UNKNOWN);
+
+    String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
+    InstructionUtils.checkNumFields ( parts, 3 );
+
+    String opcode = parts[0];
+    in1.split(parts[1]);
+    in2.split(parts[2]);
+    out.split(parts[3]);
+
+    // check for valid data type of output
+    if((in1.getDataType() == Expression.DataType.MATRIX || in2.getDataType() == Expression.DataType.MATRIX) && out.getDataType() != Expression.DataType.MATRIX)
+      throw new DMLRuntimeException("Element-wise matrix operations between variables " + in1.getName() +
+              " and " + in2.getName() + " must produce a matrix, which " + out.getName() + " is not");
+
+    // Determine appropriate Function Object based on opcode
+    ValueFunction func = Builtin.getBuiltinFnObject(opcode);
+
+    // Only for "solve"
+    if ( in1.getDataType() == Expression.DataType.SCALAR && in2.getDataType() == Expression.DataType.SCALAR )
+      throw new DMLRuntimeException("GPU : Unsupported GPU builtin operations on 2 scalars");
+    else if ( in1.getDataType() == Expression.DataType.MATRIX && in2.getDataType() == Expression.DataType.MATRIX )
+      return new MatrixMatrixBuiltinGPUInstruction(new BinaryOperator(func), in1, in2, out, opcode, str, 2);
+    else
+      throw new DMLRuntimeException("GPU : Unsupported GPU builtin operations on a matrix and a scalar");
+
+
+  }
+
+}

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/BuiltinUnaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/BuiltinUnaryGPUInstruction.java
@@ -43,7 +43,7 @@ public abstract class BuiltinUnaryGPUInstruction  extends GPUInstruction {
 		_gputype = GPUINSTRUCTION_TYPE.BuiltinUnary;
 		this._arity = _arity;
 		_input = in;
-        _output = out;
+    _output = out;
 	}
 
 	public int getArity() {

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/GPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/GPUInstruction.java
@@ -32,7 +32,7 @@ import org.apache.sysml.utils.Statistics;
 
 public abstract class GPUInstruction extends Instruction
 {
-	public enum GPUINSTRUCTION_TYPE { AggregateUnary, AggregateBinary, Convolution, MMTSJ, Reorg, ArithmeticBinary, BuiltinUnary, Builtin };
+	public enum GPUINSTRUCTION_TYPE { AggregateUnary, AggregateBinary, Convolution, MMTSJ, Reorg, ArithmeticBinary, BuiltinUnary, BuiltinBinary, Builtin };
 
 	// Memory/conversions
 	public final static String MISC_TIMER_HOST_TO_DEVICE = 				"H2D";	// time spent in bringing data to gpu (from host)

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixMatrixBuiltinGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixMatrixBuiltinGPUInstruction.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.runtime.instructions.gpu;
+
+import org.apache.sysml.runtime.DMLRuntimeException;
+import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
+import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysml.runtime.instructions.cp.CPOperand;
+import org.apache.sysml.runtime.matrix.data.LibMatrixCUDA;
+import org.apache.sysml.runtime.matrix.operators.Operator;
+import org.apache.sysml.utils.GPUStatistics;
+
+
+public class MatrixMatrixBuiltinGPUInstruction extends BuiltinBinaryGPUInstruction {
+
+  public MatrixMatrixBuiltinGPUInstruction(Operator op, CPOperand input1, CPOperand input2, CPOperand output, String opcode, String istr, int _arity) {
+    super(op, input1, input2, output, opcode, istr, _arity);
+    _gputype = GPUINSTRUCTION_TYPE.BuiltinUnary;
+
+  }
+
+  @Override
+  public void processInstruction(ExecutionContext ec) throws DMLRuntimeException {
+    GPUStatistics.incrementNoOfExecutedGPUInst();
+
+    String opcode = getOpcode();
+    MatrixObject mat1 = getMatrixInputForGPUInstruction(ec, input1.getName());
+    MatrixObject mat2 = getMatrixInputForGPUInstruction(ec, input2.getName());
+
+    if(opcode.equals("solve")) {
+      LibMatrixCUDA.solve(ec, ec.getGPUContext(), getExtendedOpcode(), mat1, mat2, output.getName());
+
+    } else {
+      throw new DMLRuntimeException("Unsupported GPU operator:" + opcode);
+    }
+    ec.releaseMatrixInputForGPUInstruction(input1.getName());
+    ec.releaseMatrixInputForGPUInstruction(input2.getName());
+    ec.releaseMatrixOutputForGPUInstruction(output.getName());
+  }
+
+}

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUObject.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUObject.java
@@ -323,7 +323,7 @@ public class GPUObject {
 	}
 
 	/**
-	 * Convenience method. Converts Row Major Dense Matrix --> Column Major Dense Matrix
+	 * Convenience method. Converts Row Major Dense Matrix to Column Major Dense Matrix
 	 * @throws DMLRuntimeException if DMLRuntimeException occurs
 	 */
 	public void denseRowMajorToColumnMajor() throws DMLRuntimeException {
@@ -342,7 +342,7 @@ public class GPUObject {
 	}
 
 	/**
-	 * Convenience method. Converts Column Major Dense Matrix --> Row Major Dense Matrix
+	 * Convenience method. Converts Column Major Dense Matrix to Row Major Dense Matrix
 	 * @throws DMLRuntimeException
 	 */
 	public void denseColumnMajorToRowMajor() throws DMLRuntimeException {

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUObject.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUObject.java
@@ -26,7 +26,9 @@ import static jcuda.jcudnn.cudnnDataType.CUDNN_DATA_DOUBLE;
 import static jcuda.jcudnn.cudnnTensorFormat.CUDNN_TENSOR_NCHW;
 import static jcuda.jcusparse.JCusparse.cusparseDdense2csr;
 import static jcuda.jcusparse.JCusparse.cusparseDnnz;
+import static jcuda.runtime.JCuda.cudaMalloc;
 import static jcuda.runtime.JCuda.cudaMemcpy;
+import static jcuda.runtime.cudaMemcpyKind.cudaMemcpyDeviceToDevice;
 import static jcuda.runtime.cudaMemcpyKind.cudaMemcpyDeviceToHost;
 import static jcuda.runtime.cudaMemcpyKind.cudaMemcpyHostToDevice;
 
@@ -50,6 +52,7 @@ import org.apache.sysml.runtime.matrix.data.SparseBlockMCSR;
 import org.apache.sysml.utils.GPUStatistics;
 
 import jcuda.Pointer;
+import jcuda.Sizeof;
 import jcuda.jcublas.JCublas2;
 import jcuda.jcudnn.cudnnTensorDescriptor;
 import jcuda.jcusparse.JCusparse;
@@ -100,6 +103,40 @@ public class GPUObject {
 //		return getGPUContext().allocate(instName, size);
 //	}
 
+	@Override
+	public Object clone() {
+		GPUObject me = this;
+		GPUObject that = new GPUObject(me.gpuContext, me.mat);
+		System.arraycopy(me.tensorShape, 0, that.tensorShape, 0, me.tensorShape.length);
+		that.dirty = me.dirty;
+		that.readLocks = new AtomicInteger(me.readLocks.get());
+		that.timestamp = new AtomicLong(me.timestamp.get());
+		that.isSparse = me.isSparse;
+
+		try {
+		if (me.jcudaDenseMatrixPtr != null) {
+			long rows = me.mat.getNumRows();
+			long cols = me.mat.getNumColumns();
+			long size = rows * cols * Sizeof.DOUBLE;
+			me.gpuContext.ensureFreeSpace((int)size);
+			Pointer ptrCopy = allocate(size);
+			cudaMemcpy(ptrCopy, me.jcudaDenseMatrixPtr, size, cudaMemcpyDeviceToDevice);
+		}
+
+		if (me.jcudaSparseMatrixPtr != null){
+			long rows = mat.getNumRows();
+			that.jcudaSparseMatrixPtr = me.jcudaSparseMatrixPtr.clone((int)rows);
+		}
+
+		that.allocateTensorDescriptor(me.tensorShape[0], me.tensorShape[1], me.tensorShape[2], me.tensorShape[3]);
+
+		} catch (DMLRuntimeException e){
+			throw new RuntimeException(e);
+		}
+
+		return that;
+	}
+
 	private Pointer allocate(long size) throws DMLRuntimeException {
 		return getGPUContext().allocate(size);
 	}
@@ -116,7 +153,7 @@ public class GPUObject {
 		getGPUContext().cudaFreeHelper(instName, toFree, eager);
 	}
 
-	private GPUContext getGPUContext() throws DMLRuntimeException {
+	private GPUContext getGPUContext() {
 		return gpuContext;
 	}
 
@@ -275,7 +312,7 @@ public class GPUObject {
 		if(getJcudaDenseMatrixPtr() == null || !isAllocated())
 			throw new DMLRuntimeException("Expected allocated dense matrix before denseToSparse() call");
 
-		convertDensePtrFromRowMajorToColumnMajor();
+		denseRowMajorToColumnMajor();
 		setSparseMatrixCudaPointer(columnMajorDenseToRowMajorSparse(getGPUContext(), cusparseHandle, getJcudaDenseMatrixPtr(), rows, cols));
 		// TODO: What if mat.getNnz() is -1 ?
 		if (DMLScript.STATISTICS) GPUStatistics.cudaDenseToSparseTime.addAndGet(System.nanoTime() - t0);
@@ -286,7 +323,7 @@ public class GPUObject {
 	 * Convenience method. Converts Row Major Dense Matrix --> Column Major Dense Matrix
 	 * @throws DMLRuntimeException if DMLRuntimeException occurs
 	 */
-	private void convertDensePtrFromRowMajorToColumnMajor() throws DMLRuntimeException {
+	public void denseRowMajorToColumnMajor() throws DMLRuntimeException {
 		LOG.trace("GPU : dense Ptr row-major -> col-major on " + this + ", GPUContext=" + getGPUContext());
 		int m = toIntExact(mat.getNumRows());
 		int n = toIntExact(mat.getNumColumns());
@@ -301,7 +338,11 @@ public class GPUObject {
 		setDenseMatrixCudaPointer(tmp);
 	}
 
-	private void convertDensePtrFromColMajorToRowMajor() throws DMLRuntimeException {
+	/**
+	 * Convenience method. Converts Column Major Dense Matrix --> Row Major Dense Matrix
+	 * @throws DMLRuntimeException
+	 */
+	public void denseColumnMajorToRowMajor() throws DMLRuntimeException {
 		LOG.trace("GPU : dense Ptr row-major -> col-major on " + this + ", GPUContext=" + getGPUContext());
 
 		int n = toIntExact(mat.getNumRows());
@@ -340,7 +381,7 @@ public class GPUObject {
 			throw new DMLRuntimeException("Expected allocated sparse matrix before sparseToDense() call");
 
 		sparseToColumnMajorDense();
-		convertDensePtrFromColMajorToRowMajor();
+		denseColumnMajorToRowMajor();
 		if (DMLScript.STATISTICS) end = System.nanoTime();
 		if (instructionName != null && GPUStatistics.DISPLAY_STATISTICS) GPUStatistics.maintainCPMiscTimes(instructionName, GPUInstruction.MISC_TIMER_SPARSE_TO_DENSE, end - start);
 		if (DMLScript.STATISTICS) GPUStatistics.cudaSparseToDenseTime.addAndGet(end - start);
@@ -431,17 +472,12 @@ public class GPUObject {
 	}
 
 	public boolean isInputAllocated() {
-		try {
-			boolean eitherAllocated = (getJcudaDenseMatrixPtr() != null || getJcudaSparseMatrixPtr() != null);
-			boolean isAllocatedOnThisGPUContext = getGPUContext().isBlockRecorded(this);
-			if (eitherAllocated && !isAllocatedOnThisGPUContext) {
-				LOG.warn("GPU : A block was allocated but was not on this GPUContext, GPUContext=" + getGPUContext());
-			}
-			return eitherAllocated && isAllocatedOnThisGPUContext;
-		} catch (DMLRuntimeException e){
-			LOG.info("GPU : System is in an inconsistent state");
-			throw new RuntimeException(e);
+		boolean eitherAllocated = (getJcudaDenseMatrixPtr() != null || getJcudaSparseMatrixPtr() != null);
+		boolean isAllocatedOnThisGPUContext = getGPUContext().isBlockRecorded(this);
+		if (eitherAllocated && !isAllocatedOnThisGPUContext) {
+			LOG.warn("GPU : A block was allocated but was not on this GPUContext, GPUContext=" + getGPUContext());
 		}
+		return eitherAllocated && isAllocatedOnThisGPUContext;
 	}
 
 	/**
@@ -862,6 +898,5 @@ public class GPUObject {
 		sb.append('}');
 		return sb.toString();
 	}
-
 
 }

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCUDA.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCUDA.java
@@ -95,10 +95,10 @@ import org.apache.sysml.runtime.functionobjects.ReduceRow;
 import org.apache.sysml.runtime.functionobjects.ValueFunction;
 import org.apache.sysml.runtime.instructions.cp.DoubleObject;
 import org.apache.sysml.runtime.instructions.gpu.GPUInstruction;
+import org.apache.sysml.runtime.instructions.gpu.context.CSRPointer;
 import org.apache.sysml.runtime.instructions.gpu.context.ExecutionConfig;
 import org.apache.sysml.runtime.instructions.gpu.context.GPUContext;
 import org.apache.sysml.runtime.instructions.gpu.context.GPUObject;
-import org.apache.sysml.runtime.instructions.gpu.context.CSRPointer;
 import org.apache.sysml.runtime.instructions.gpu.context.JCudaKernels;
 import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysml.runtime.matrix.operators.AggregateUnaryOperator;
@@ -113,10 +113,13 @@ import org.apache.sysml.utils.Statistics;
 import jcuda.CudaException;
 import jcuda.Pointer;
 import jcuda.Sizeof;
+import jcuda.jcublas.JCublas;
 import jcuda.jcublas.JCublas2;
+import jcuda.jcublas.cublasDiagType;
 import jcuda.jcublas.cublasFillMode;
 import jcuda.jcublas.cublasHandle;
 import jcuda.jcublas.cublasOperation;
+import jcuda.jcublas.cublasSideMode;
 import jcuda.jcudnn.cudnnActivationDescriptor;
 import jcuda.jcudnn.cudnnBatchNormMode;
 import jcuda.jcudnn.cudnnConvolutionDescriptor;
@@ -126,6 +129,8 @@ import jcuda.jcudnn.cudnnHandle;
 import jcuda.jcudnn.cudnnPoolingDescriptor;
 import jcuda.jcudnn.cudnnStatus;
 import jcuda.jcudnn.cudnnTensorDescriptor;
+import jcuda.jcusolver.JCusolver;
+import jcuda.jcusolver.JCusolverDn;
 import jcuda.jcusparse.JCusparse;
 import jcuda.jcusparse.cusparseHandle;
 
@@ -306,15 +311,31 @@ public class LibMatrixCUDA {
 	/**
 	 * Convenience method to get jcudaDenseMatrixPtr. This method explicitly converts sparse to dense format, so use it judiciously.
 	 * @param gCtx a valid {@link GPUContext}
-	 * @param image input matrix object
+	 * @param input input matrix object
+	 * @param instName  the invoking instruction's name for record {@link Statistics}.
 	 * @return jcuda pointer
 	 * @throws DMLRuntimeException if error occurs while sparse to dense conversion
 	 */
-	private static Pointer getDensePointer(GPUContext gCtx, MatrixObject image, String instName) throws DMLRuntimeException {
-		if(isInSparseFormat(gCtx, image)) {
-			image.getGPUObject(gCtx).sparseToDense(instName);
+	private static Pointer getDensePointer(GPUContext gCtx, MatrixObject input, String instName) throws DMLRuntimeException {
+		if(isInSparseFormat(gCtx, input)) {
+			input.getGPUObject(gCtx).sparseToDense(instName);
 		}
-		return image.getGPUObject(gCtx).getJcudaDenseMatrixPtr();
+		return input.getGPUObject(gCtx).getJcudaDenseMatrixPtr();
+	}
+
+	/**
+	 * Convenience method to get the sparse matrix pointer from a {@link MatrixObject}. Converts dense to sparse if necessary.
+	 * @param gCtx a valid {@link GPUContext}
+	 * @param input input matrix
+	 * @param instName the invoking instruction's name for record {@link Statistics}.
+	 * @return a sparse matrix pointer
+	 * @throws DMLRuntimeException if error occurs
+	 */
+	private static CSRPointer getSparsePointer(GPUContext gCtx, MatrixObject input, String instName) throws DMLRuntimeException {
+		if(!isInSparseFormat(gCtx, input)) {
+			input.getGPUObject(gCtx).denseToSparse();
+		}
+		return input.getGPUObject(gCtx).getJcudaSparseMatrixPtr();
 	}
 	
 	/**
@@ -2960,6 +2981,102 @@ public class LibMatrixCUDA {
 					A, B, constant, C, rlenA, clenA, rlenB, clenB);
 			if (GPUStatistics.DISPLAY_STATISTICS) GPUStatistics.maintainCPMiscTimes(instName, GPUInstruction.MISC_TIMER_DAXPY_MV_KERNEL, System.nanoTime() - t1);
 		}
+	}
+
+
+	/**
+	 * Implements the "solve" function for systemml Ax = B (A is of size m*n, B is of size m*1, x is of size n*1)
+	 * @param ec a valid {@link ExecutionContext}
+	 * @param gCtx a valid {@link GPUContext}
+	 * @param instName the invoking instruction's name for record {@link Statistics}.
+	 * @param in1 input matrix A
+	 * @param in2 input matrix B
+	 * @param outputName name of the output matrix
+	 * @throws DMLRuntimeException if an error occurs
+	 */
+	public static void solve(ExecutionContext ec, GPUContext gCtx, String instName, MatrixObject in1, MatrixObject in2, String outputName) throws DMLRuntimeException {
+		if (ec.getGPUContext() != gCtx)
+			throw new DMLRuntimeException("GPU : Invalid internal state, the GPUContext set with the ExecutionContext is not the same used to run this LibMatrixCUDA function");
+
+		// x = solve(A, b)
+
+		// Both Sparse
+		if(!isInSparseFormat(gCtx, in1) && !isInSparseFormat(gCtx, in2)) {	// Both dense
+			GPUObject Aobj = in1.getGPUObject(gCtx);
+			GPUObject bobj = in2.getGPUObject(gCtx);
+			int m = (int)in1.getNumRows();
+			int n = (int)in1.getNumColumns();
+			if ((int)in2.getNumRows() != m)
+				throw new DMLRuntimeException("GPU : Incorrect input for solve(), rows in A should be the same as rows in B");
+			if ((int)in2.getNumColumns() != 1)
+				throw new DMLRuntimeException("GPU : Incorrect input for solve(), columns in B should be 1");
+
+
+			// Copy over matrices and
+			// convert dense matrices to row major
+			// Operation in cuSolver and cuBlas are for column major dense matrices
+			// and are destructive to the original input
+			GPUObject ATobj = (GPUObject)Aobj.clone();
+			ATobj.denseRowMajorToColumnMajor();
+			Pointer A = ATobj.getJcudaDenseMatrixPtr();
+
+			GPUObject bTobj = (GPUObject)bobj.clone();
+			bTobj.denseRowMajorToColumnMajor();
+			Pointer b = bTobj.getJcudaDenseMatrixPtr();
+
+			// The following set of operations is done following the example in the cusolver documentation
+			// http://docs.nvidia.com/cuda/cusolver/#ormqr-example1
+
+			// step 3: query working space of geqrf and ormqr
+			int[] lwork = {0};
+			JCusolverDn.cusolverDnDgeqrf_bufferSize(gCtx.getCusolverDnHandle(), m, n, A, m, lwork);
+
+			// step 4: compute QR factorization
+			Pointer work = gCtx.allocate(lwork[0] * Sizeof.DOUBLE);
+			Pointer tau = gCtx.allocate(Math.max(m, m) * Sizeof.DOUBLE);
+			Pointer devInfo = gCtx.allocate(Sizeof.INT);
+			JCusolverDn.cusolverDnDgeqrf(gCtx.getCusolverDnHandle(), m, n, A, m, tau, work, lwork[0], devInfo);
+
+			int[] qrError = {-1};
+			cudaMemcpy(Pointer.to(qrError), devInfo, Sizeof.INT, cudaMemcpyDeviceToHost);
+			if (qrError[0] != 0){
+				throw new DMLRuntimeException("GPU : Error in call to geqrf (QR factorization) as part of solve, argument " + qrError[0] + " was wrong");
+			}
+
+			// step 5: compute Q^T*B
+			JCusolverDn.cusolverDnDormqr(gCtx.getCusolverDnHandle(), cublasSideMode.CUBLAS_SIDE_LEFT, cublasOperation.CUBLAS_OP_T, m, 1, n, A, m, tau, b, m, work, lwork[0], devInfo);
+			cudaMemcpy(Pointer.to(qrError), devInfo, Sizeof.INT, cudaMemcpyDeviceToHost);
+			if (qrError[0] != 0){
+				throw new DMLRuntimeException("GPU : Error in call to ormqr (to compuete Q^T*B after QR factorization) as part of solve, argument " + qrError[0] + " was wrong");
+			}
+
+			// step 6: compute x = R \ Q^T*B
+			JCublas2.cublasDtrsm(gCtx.getCublasHandle(),
+							cublasSideMode.CUBLAS_SIDE_LEFT, cublasFillMode.CUBLAS_FILL_MODE_UPPER, cublasOperation.CUBLAS_OP_N, cublasDiagType.CUBLAS_DIAG_NON_UNIT,
+							n, 1, pointerTo(1.0), A, m, b, m);
+
+			gCtx.cudaFreeHelper(work);
+			gCtx.cudaFreeHelper(tau);
+			gCtx.cudaFreeHelper(tau);
+			ATobj.clearData();
+
+			bTobj.denseColumnMajorToRowMajor();
+
+			MatrixObject out = ec.getMatrixObject(outputName);
+			out.setGPUObject(gCtx, bTobj);
+
+
+		} else if (isInSparseFormat(gCtx, in1) && isInSparseFormat(gCtx, in2)) { // Both sparse
+			throw new DMLRuntimeException("GPU : solve on sparse inputs not supported");
+		} else if (!isInSparseFormat(gCtx, in1) && isInSparseFormat(gCtx, in2)) { // A is dense, b is sparse
+			// Pointer A = getDensePointer(gCtx, in1, instName);
+			// Pointer B = getDensePointer(gCtx, in2, instName);
+			throw new DMLRuntimeException("GPU : solve on sparse inputs not supported");
+		} else if (isInSparseFormat(gCtx, in1) && !isInSparseFormat(gCtx, in2)) { // A is sparse, b is dense
+			throw new DMLRuntimeException("GPU : solve on sparse inputs not supported");
+		}
+
+
 	}
 
 	//********************************************************************/


### PR DESCRIPTION
Implemented the GPU `solve()` function.
Ping @niketanpansare, @bertholdreinwald, @dusenberrymw 

@iyounus - can you please try this out? (and also check for correctness?, I've checked on smaller data)

This will benefit us in some sense. I see it being used in these algorithms (based on a simple grep search):
- ALS-DS.dml
- CsplineDS.dml
- LinearRegDS.dml
- StepLinearRegDS

For me, I seem to get a 30x speedup in an example that I tried on my own machine (core i7 quad core, 32gb ram, GTX1070).

Program:
```r
m = 12345
n = 4321

A = rand(rows=m, cols=n)
B = rand(rows=m, cols=1)

x = solve(A,B)
write(x, "xout")%                     
```

Output
```
➜  incubator-systemml git:(gpu_solve) ✗ bin/systemml solve.dml -gpu force -stats
================================================================================
Output dir: /home/njindal/git/incubator-systemml/temp
================================================================================
17/04/28 00:14:42 INFO api.DMLScript: BEGIN DML run 04/28/2017 00:14:42
17/04/28 00:14:42 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
17/04/28 00:14:42 INFO context.GPUContext: Initializing CUDA
17/04/28 00:14:43 INFO context.GPUContext:  GPU memory - Total: 8506.769408 MB, Available: 6889.2098559999995 MB on GPUContext{deviceNum=0}
17/04/28 00:14:43 INFO context.GPUContext: Total number of GPUs on the machine: 1
17/04/28 00:14:46 INFO api.DMLScript: SystemML Statistics:
Total elapsed time:		4.561 sec.
Total compilation time:		0.348 sec.
Total execution time:		4.213 sec.
Number of compiled MR Jobs:	0.
Number of executed MR Jobs:	0.
CUDA/CuLibraries init time:	0.660/0.514 sec.
Number of executed GPU inst:	1.
GPU mem tx time  (alloc/dealloc/set0/toDev/fromDev):	0.004/0.000/0.000/0.051/0.000 sec.
GPU mem tx count (alloc/dealloc/set0/toDev/fromDev/evict):	10/0/11/0/2/1/0.
GPU conversion time  (sparseConv/sp2dense/dense2sp):	0.000/0.000/0.000 sec.
GPU conversion count (sparseConv/sp2dense/dense2sp):	0/0/0.
Cache hits (Mem, WB, FS, HDFS):	2/0/0/0.
Cache writes (WB, FS, HDFS):	3/0/1.
Cache times (ACQr/m, RLS, EXP):	0.000/0.000/0.001/0.040 sec.
HOP DAGs recompiled (PRED, SB):	0/0.
HOP DAGs recompile time:	0.000 sec.
Total JIT compile time:		0.577 sec.
Total JVM GC count:		0.
Total JVM GC time:		0.0 sec.
Heavy hitter instructions (name, time, count):
-- 1) 	gpu_solve 	3.118 sec 	1	
-- 2) 	rand 	0.392 sec 	2	
-- 3) 	write 	0.040 sec 	1	
-- 4) 	createvar 	0.001 sec 	3	
-- 5) 	rmvar 	0.000 sec 	3	

17/04/28 00:14:46 INFO api.DMLScript: END DML run 04/28/2017 00:14:46
➜  incubator-systemml git:(gpu_solve) ✗ bin/systemml solve.dml  -stats       
================================================================================
Output dir: /home/njindal/git/incubator-systemml/temp
================================================================================
17/04/28 00:14:53 INFO api.DMLScript: BEGIN DML run 04/28/2017 00:14:53
17/04/28 00:14:53 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
17/04/28 00:17:06 INFO api.DMLScript: SystemML Statistics:
Total elapsed time:		132.744 sec.
Total compilation time:		0.345 sec.
Total execution time:		132.398 sec.
Number of compiled MR Jobs:	0.
Number of executed MR Jobs:	0.
Cache hits (Mem, WB, FS, HDFS):	2/0/0/0.
Cache writes (WB, FS, HDFS):	3/0/1.
Cache times (ACQr/m, RLS, EXP):	0.000/0.000/0.001/0.031 sec.
HOP DAGs recompiled (PRED, SB):	0/0.
HOP DAGs recompile time:	0.000 sec.
Total JIT compile time:		1.233 sec.
Total JVM GC count:		2.
Total JVM GC time:		0.448 sec.
Heavy hitter instructions (name, time, count):
-- 1) 	solve 	131.950 sec 	1	
-- 2) 	rand 	0.413 sec 	2	
-- 3) 	write 	0.031 sec 	1	
-- 4) 	createvar 	0.001 sec 	3	
-- 5) 	rmvar 	0.000 sec 	3	

17/04/28 00:17:06 INFO api.DMLScript: END DML run 04/28/2017 00:17:06

```