### PR TITLE
[SYSTEMML-1609] Update dmlFromResource to not require initial slash

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/ScriptFactory.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/ScriptFactory.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -42,7 +42,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a DML Script object based on a string path to a file.
-	 * 
+	 *
 	 * @param scriptFilePath
 	 *            path to DML script file (local or HDFS)
 	 * @return DML Script object
@@ -53,7 +53,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a DML Script object based on an input stream.
-	 * 
+	 *
 	 * @param inputStream
 	 *            input stream to DML
 	 * @return DML Script object
@@ -66,7 +66,7 @@ public class ScriptFactory {
 	 * Creates a DML Script object based on a file in the local file system. To
 	 * create a DML Script object from a local file or HDFS, please use
 	 * {@link #dmlFromFile(String)}.
-	 * 
+	 *
 	 * @param localScriptFile
 	 *            the local DML file
 	 * @return DML Script object
@@ -77,7 +77,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a DML Script object based on a string.
-	 * 
+	 *
 	 * @param scriptString
 	 *            string of DML
 	 * @return DML Script object
@@ -88,7 +88,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a DML Script object based on a URL path.
-	 * 
+	 *
 	 * @param scriptUrlPath
 	 *            URL path to DML script
 	 * @return DML Script object
@@ -99,7 +99,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a DML Script object based on a URL.
-	 * 
+	 *
 	 * @param scriptUrl
 	 *            URL to DML script
 	 * @return DML Script object
@@ -110,7 +110,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a DML Script object based on a resource path.
-	 * 
+	 *
 	 * @param resourcePath
 	 *            path to a resource on the classpath
 	 * @return DML Script object
@@ -121,7 +121,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a PYDML Script object based on a string path to a file.
-	 * 
+	 *
 	 * @param scriptFilePath
 	 *            path to PYDML script file (local or HDFS)
 	 * @return PYDML Script object
@@ -132,7 +132,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a PYDML Script object based on an input stream.
-	 * 
+	 *
 	 * @param inputStream
 	 *            input stream to PYDML
 	 * @return PYDML Script object
@@ -145,7 +145,7 @@ public class ScriptFactory {
 	 * Creates a PYDML Script object based on a file in the local file system.
 	 * To create a PYDML Script object from a local file or HDFS, please use
 	 * {@link #pydmlFromFile(String)}.
-	 * 
+	 *
 	 * @param localScriptFile
 	 *            the local PYDML file
 	 * @return PYDML Script object
@@ -156,7 +156,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a PYDML Script object based on a string.
-	 * 
+	 *
 	 * @param scriptString
 	 *            string of PYDML
 	 * @return PYDML Script object
@@ -167,7 +167,7 @@ public class ScriptFactory {
 
 	/**
 	 * Creat a PYDML Script object based on a URL path.
-	 * 
+	 *
 	 * @param scriptUrlPath
 	 *            URL path to PYDML script
 	 * @return PYDML Script object
@@ -178,7 +178,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a PYDML Script object based on a URL.
-	 * 
+	 *
 	 * @param scriptUrl
 	 *            URL to PYDML script
 	 * @return PYDML Script object
@@ -189,7 +189,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a PYDML Script object based on a resource path.
-	 * 
+	 *
 	 * @param resourcePath
 	 *            path to a resource on the classpath
 	 * @return PYDML Script object
@@ -200,7 +200,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a DML or PYDML Script object based on a string path to a file.
-	 * 
+	 *
 	 * @param scriptFilePath
 	 *            path to DML or PYDML script file (local or HDFS)
 	 * @param scriptType
@@ -214,7 +214,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a DML or PYDML Script object based on an input stream.
-	 * 
+	 *
 	 * @param inputStream
 	 *            input stream to DML or PYDML
 	 * @param scriptType
@@ -230,7 +230,7 @@ public class ScriptFactory {
 	 * Creates a DML or PYDML Script object based on a file in the local file
 	 * system. To create a Script object from a local file or HDFS, please use
 	 * {@link scriptFromFile(String, ScriptType)}.
-	 * 
+	 *
 	 * @param localScriptFile
 	 *            The local DML or PYDML file
 	 * @param scriptType
@@ -244,7 +244,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a DML or PYDML Script object based on a string.
-	 * 
+	 *
 	 * @param scriptString
 	 *            string of DML or PYDML
 	 * @param scriptType
@@ -257,7 +257,7 @@ public class ScriptFactory {
 
 	/**
 	 * Creat a DML or PYDML Script object based on a URL path.
-	 * 
+	 *
 	 * @param scriptUrlPath
 	 *            URL path to DML or PYDML script
 	 * @param scriptType
@@ -271,7 +271,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a DML or PYDML Script object based on a URL.
-	 * 
+	 *
 	 * @param scriptUrl
 	 *            URL to DML or PYDML script
 	 * @param scriptType
@@ -285,7 +285,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a DML or PYDML Script object based on a resource path.
-	 * 
+	 *
 	 * @param resourcePath
 	 *            path to a resource on the classpath
 	 * @param scriptType
@@ -293,13 +293,19 @@ public class ScriptFactory {
 	 * @return DML or PYDML Script object
 	 */
 	private static Script scriptFromResource(String resourcePath, ScriptType scriptType) {
+		if (resourcePath == null) {
+			return null;
+		}
+		if (!resourcePath.startsWith("/")) {
+			resourcePath = "/" + resourcePath;
+		}
 		InputStream inputStream = ScriptFactory.class.getResourceAsStream(resourcePath);
 		return scriptFromInputStream(inputStream, scriptType).setName(resourcePath);
 	}
 
 	/**
 	 * Create a DML Script object based on a string.
-	 * 
+	 *
 	 * @param scriptString
 	 *            string of DML
 	 * @return DML Script object
@@ -312,7 +318,7 @@ public class ScriptFactory {
 	 * Obtain a script string from a file in the local file system. To obtain a
 	 * script string from a file in HDFS, please use
 	 * getScriptStringFromFile(String scriptFilePath).
-	 * 
+	 *
 	 * @param file
 	 *            The script file.
 	 * @return The script string.
@@ -339,7 +345,7 @@ public class ScriptFactory {
 
 	/**
 	 * Obtain a script string from a file.
-	 * 
+	 *
 	 * @param scriptFilePath
 	 *            The file path to the script file (either local file system or
 	 *            HDFS)
@@ -376,7 +382,7 @@ public class ScriptFactory {
 
 	/**
 	 * Obtain a script string from an InputStream.
-	 * 
+	 *
 	 * @param inputStream
 	 *            The InputStream from which to read the script string
 	 * @return The script string
@@ -396,7 +402,7 @@ public class ScriptFactory {
 
 	/**
 	 * Obtain a script string from a URL.
-	 * 
+	 *
 	 * @param scriptUrlPath
 	 *            The URL path to the script file
 	 * @return The script string
@@ -417,7 +423,7 @@ public class ScriptFactory {
 
 	/**
 	 * Obtain a script string from a URL.
-	 * 
+	 *
 	 * @param url
 	 *            The script URL
 	 * @return The script string
@@ -442,7 +448,7 @@ public class ScriptFactory {
 
 	/**
 	 * Create a PYDML script object based on a string.
-	 * 
+	 *
 	 * @param scriptString
 	 *            string of PYDML
 	 * @return PYDML Script object


### PR DESCRIPTION
Update ScriptFactory so that dmlFromResource and pydmlFromResource
resource paths do not require an initial slash.