### PR TITLE
[SYSTEMML-1614] Updated python pre_setup and classloader for TLP jar …

### DIFF
--- a/src/main/python/pre_setup.py
+++ b/src/main/python/pre_setup.py
@@ -30,9 +30,11 @@ if os.path.exists(java_dir_full_path):
 os.mkdir(java_dir_full_path)
 root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.getcwd())))
 for file in os.listdir(os.path.join(root_dir, 'target')):
-    if fnmatch.fnmatch(file, 'systemml-*-incubating-SNAPSHOT.jar') or fnmatch.fnmatch(file, 'systemml-*-incubating.jar'):
+    if (fnmatch.fnmatch(file, 'systemml-*-SNAPSHOT.jar') or fnmatch.fnmatch(file, 'systemml-*.jar')
+            and not (fnmatch.fnmatch(file, 'systemml-*javadoc.jar')
+                  or fnmatch.fnmatch(file, 'systemml-*sources.jar'))):
         shutil.copyfile(os.path.join(root_dir, 'target', file),
                         os.path.join(java_dir_full_path, file))
-    if fnmatch.fnmatch(file, 'systemml-*-incubating-SNAPSHOT-extra.jar') or fnmatch.fnmatch(file, 'systemml-*-incubating-extra.jar'):
+    if fnmatch.fnmatch(file, 'systemml-*-SNAPSHOT-extra.jar') or fnmatch.fnmatch(file, 'systemml-*-extra.jar'):
         shutil.copyfile(os.path.join(root_dir, 'target', file),
                         os.path.join(java_dir_full_path, file))

--- a/src/main/python/systemml/classloader.py
+++ b/src/main/python/systemml/classloader.py
@@ -43,7 +43,7 @@ def _getJarFileName(sc, suffix):
     jar_file_name = '_ignore.jar'
     java_dir = os.path.join(imp.find_module("systemml")[1], "systemml-java")
     for file in os.listdir(java_dir):
-        if fnmatch.fnmatch(file, 'systemml-*-incubating-SNAPSHOT' + suffix + '.jar') or fnmatch.fnmatch(file, 'systemml-*-incubating' + suffix + '.jar'):
+        if fnmatch.fnmatch(file, 'systemml-*-SNAPSHOT' + suffix + '.jar') or fnmatch.fnmatch(file, 'systemml-*' + suffix + '.jar'):
             jar_file_name = os.path.join(java_dir, file)
     return jar_file_name
 


### PR DESCRIPTION
…names

Removed '-incubating' from file pattern matching expression for python pre_setup and classloader.  Added conditional to prevent javadoc and sources jars from being inadvertently bundled into python artifact.