### PR TITLE
[SYSTEMML-1620] Remove incubation from python package info

### DIFF
--- a/src/main/python/setup.py
+++ b/src/main/python/setup.py
@@ -63,12 +63,6 @@ setup(
     description='Apache SystemML is a distributed and declarative machine learning platform.',
     long_description='''
 
-    Apache SystemML is an effort undergoing incubation at the Apache Software Foundation (ASF),
-    sponsored by the Apache Incubator PMC.
-    While incubation status is not necessarily a reflection of the completeness
-    or stability of the code, it does indicate that the project has yet to be
-    fully endorsed by the ASF.
-
     Apache SystemML provides declarative large-scale machine learning (ML) that aims at
     flexible specification of ML algorithms and automatic generation of hybrid runtime
     plans ranging from single-node, in-memory computations, to distributed computations on Apache
@@ -76,7 +70,7 @@ setup(
     ''',
     url='http://systemml.apache.org/',
     author='Apache SystemML',
-    author_email='dev@systemml.incubator.apache.org',
+    author_email='dev@systemml.apache.org',
     packages=find_packages(),
     install_requires=REQUIRED_PACKAGES,
     include_package_data=True,


### PR DESCRIPTION
As part of top level project updates, removed incubation disclaimer from description text in setup.py used for generating pkg-info.  Also updated email address.