### PR TITLE
[SYSTEMML-1622] Remove incubator from email references

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 # SystemML
 
 **Documentation:** [SystemML Documentation](http://apache.github.io/incubator-systemml/)<br/>
-**Mailing List:** [Dev Mailing List](mailto:dev@systemml.incubator.apache.org)<br/>
+**Mailing List:** [Dev Mailing List](mailto:dev@systemml.apache.org)<br/>
 **Build Status:** [![Build Status](https://sparktc.ibmcloud.com/jenkins/job/SystemML-DailyTest/badge/icon)](https://sparktc.ibmcloud.com/jenkins/job/SystemML-DailyTest)<br/>
 **Issue Tracker:** [JIRA](https://issues.apache.org/jira/browse/SYSTEMML)<br/>
 **Download:** [Download SystemML](http://systemml.apache.org/download.html)<br/>

--- a/docs/contributing-to-systemml.md
+++ b/docs/contributing-to-systemml.md
@@ -34,28 +34,28 @@ There are many ways to become involved with SystemML:
 ### Development Mailing List
 
 Perhaps the easiest way to obtain help and contribute to SystemML is to join the SystemML Development
-mailing list (dev@systemml.incubator.apache.org). You can subscribe to this list by sending an email to
-[dev-subscribe@systemml.incubator.apache.org](mailto:dev-subscribe@systemml.incubator.apache.org).
-You can unsubscribe from this list by sending an email to [dev-unsubscribe@systemml.incubator.apache.org](mailto:dev-unsubscribe@systemml.incubator.apache.org). The dev mailing list archive can be found
-[here](http://mail-archives.apache.org/mod_mbox/incubator-systemml-dev/).
+mailing list (dev@systemml.apache.org). You can subscribe to this list by sending an email to
+[dev-subscribe@systemml.apache.org](mailto:dev-subscribe@systemml.apache.org).
+You can unsubscribe from this list by sending an email to [dev-unsubscribe@systemml.apache.org](mailto:dev-unsubscribe@systemml.apache.org). The dev mailing list archive can be found
+[here](http://mail-archives.apache.org/mod_mbox/systemml-dev/).
 
 ### Issues Mailing List
 
 The issues mailing list archive can be found
-[here](http://mail-archives.apache.org/mod_mbox/incubator-systemml-issues/).
+[here](http://mail-archives.apache.org/mod_mbox/systemml-issues/).
 To subscribe to the issues list, send an email to
-[issues-subscribe@systemml.incubator.apache.org](mailto:issues-subscribe@systemml.incubator.apache.org).
+[issues-subscribe@systemml.apache.org](mailto:issues-subscribe@systemml.apache.org).
 To unsubscribe from the issues list, send an email to
-[issues-unsubscribe@systemml.incubator.apache.org](mailto:issues-unsubscribe@systemml.incubator.apache.org).
+[issues-unsubscribe@systemml.apache.org](mailto:issues-unsubscribe@systemml.apache.org).
 
 ### Commits Mailing List
 
 The commits mailing list archive can be found
-[here](http://mail-archives.apache.org/mod_mbox/incubator-systemml-commits/).
+[here](http://mail-archives.apache.org/mod_mbox/systemml-commits/).
 To subscribe to the issues list, send an email to
-[commits-subscribe@systemml.incubator.apache.org](mailto:commits-subscribe@systemml.incubator.apache.org).
+[commits-subscribe@systemml.apache.org](mailto:commits-subscribe@systemml.apache.org).
 To unsubscribe from the issues list, send an email to
-[commits-unsubscribe@systemml.incubator.apache.org](mailto:commits-unsubscribe@systemml.incubator.apache.org).
+[commits-unsubscribe@systemml.apache.org](mailto:commits-unsubscribe@systemml.apache.org).
 
 
 ## Issue Tracker

--- a/pom.xml
+++ b/pom.xml
@@ -50,15 +50,15 @@
 	<mailingLists>
 		<mailingList>
 			<name>Dev Mailing List</name>
-			<post>dev@systemml.incubator.apache.org</post>
-			<subscribe>dev-subscribe@systemml.incubator.apache.org</subscribe>
-			<unsubscribe>dev-unsubscribe@systemml.incubator.apache.org</unsubscribe>
+			<post>dev@systemml.apache.org</post>
+			<subscribe>dev-subscribe@systemml.apache.org</subscribe>
+			<unsubscribe>dev-unsubscribe@systemml.apache.org</unsubscribe>
 		</mailingList>
 		<mailingList>
 			<name>Commits Mailing List</name>
-			<post>commits@systemml.incubator.apache.org</post>
-			<subscribe>commits-subscribe@systemml.incubator.apache.org</subscribe>
-			<unsubscribe>commits-unsubscribe@systemml.incubator.apache.org</unsubscribe>
+			<post>commits@systemml.apache.org</post>
+			<subscribe>commits-subscribe@systemml.apache.org</subscribe>
+			<unsubscribe>commits-unsubscribe@systemml.apache.org</unsubscribe>
 		</mailingList>
 	</mailingLists>
 

--- a/src/main/standalone/README.txt
+++ b/src/main/standalone/README.txt
@@ -17,7 +17,7 @@ limitations under the License.
 # Apache SystemML
 
 **Documentation:** [SystemML Documentation](http://apache.github.io/incubator-systemml/)
-**Mailing List:** [Dev Mailing List](mailto:dev@systemml.incubator.apache.org)
+**Mailing List:** [Dev Mailing List](mailto:dev@systemml.apache.org)
 **Build Status:** [![Build Status](https://sparktc.ibmcloud.com/jenkins/job/SystemML-DailyTest/badge/icon)](https://sparktc.ibmcloud.com/jenkins/job/SystemML-DailyTest)
 **Issue Tracker:** [JIRA](https://issues.apache.org/jira/browse/SYSTEMML)
 **Download:** [Download SystemML](http://systemml.apache.org/download.html)


### PR DESCRIPTION
Updated email addresses to systemml.apache.org (removed incubator) in pom, md, readme files.