### PR TITLE
[SYSTEMML-1634] Add SystemML.jar to root of bin artifacts

### DIFF
--- a/src/assembly/bin.xml
+++ b/src/assembly/bin.xml
@@ -122,4 +122,12 @@
 			<scope>compile</scope>
 		</dependencySet>
 	</dependencySets>
+
+	<files>
+		<file>
+			<source>target/${artifactId}-${project.version}.jar</source>
+			<outputDirectory>.</outputDirectory>
+			<destName>SystemML.jar</destName>
+		</file>
+	</files>
 </assembly>


### PR DESCRIPTION
In terms of documentation and understandability, having SystemML.jar at the root of the -bin.tgz/-bin.zip artifacts is useful. It is common practice on our project to describe using "SystemML.jar" (such as in the 'distrib' artifacts), but in the -bin artifacts, there is no "SystemML.jar" at the root, and the SystemML jar is located in the lib directory with a name such as lib/systemml-1.0.0-SNAPSHOT.jar.

Therefore, add SystemML.jar to the root of the -bin artifacts (and also keep the existing versioned jar in the lib directory).