### PR TITLE
[SYSTEMML-1562] Remove history from MLContext

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
@@ -21,9 +21,6 @@ package org.apache.sysml.api.mlcontext;
 
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
@@ -68,9 +65,9 @@ public class MLContext {
 	private SparkSession spark = null;
 
 	/**
-	 * Reference to the currently executing script.
+	 * Reference to the current script.
 	 */
-	private Script executingScript = null;
+	private Script executionScript = null;
 
 	/**
 	 * The currently active MLContext.
@@ -98,7 +95,7 @@ public class MLContext {
 	 * Whether or not GPU mode should be enabled
 	 */
 	private boolean gpu = false;
-	
+
 	/**
 	 * Whether or not GPU mode should be force
 	 */
@@ -122,8 +119,11 @@ public class MLContext {
 	 */
 	private boolean maintainSymbolTable = false;
 
-	private List<String> scriptHistoryStrings = new ArrayList<String>();
-	private Map<String, Script> scripts = new LinkedHashMap<String, Script>();
+	/**
+	 * Whether or not the default ScriptExecutor should be initialized before
+	 * execution. See {@link ScriptExecutor#init(boolean)}.
+	 */
+	private boolean initBeforeExecution = true;
 
 	/**
 	 * The different explain levels supported by SystemML.
@@ -172,7 +172,7 @@ public class MLContext {
 	/**
 	 * Create an MLContext based on a SparkSession for interaction with SystemML
 	 * on Spark.
-	 * 
+	 *
 	 * @param spark SparkSession
 	 */
 	public MLContext(SparkSession spark) {
@@ -265,7 +265,7 @@ public class MLContext {
 			throw new MLContextException(e);
 		}
 	}
-	
+
 	/**
 	 * Execute a DML or PYDML Script.
 	 *
@@ -281,7 +281,10 @@ public class MLContext {
 		scriptExecutor.setForceGPU(forceGPU);
 		scriptExecutor.setStatistics(statistics);
 		scriptExecutor.setStatisticsMaxHeavyHitters(statisticsMaxHeavyHitters);
-		scriptExecutor.setInit(scriptHistoryStrings.isEmpty());
+		scriptExecutor.setInit(initBeforeExecution);
+		if (initBeforeExecution) {
+			initBeforeExecution = false;
+		}
 		scriptExecutor.setMaintainSymbolTable(maintainSymbolTable);
 		return execute(script, scriptExecutor);
 	}
@@ -299,7 +302,7 @@ public class MLContext {
 	 */
 	public MLResults execute(Script script, ScriptExecutor scriptExecutor) {
 		try {
-			executingScript = script;
+			executionScript = script;
 
 			Long time = new Long((new Date()).getTime());
 			if ((script.getName() == null) || (script.getName().equals(""))) {
@@ -307,10 +310,6 @@ public class MLContext {
 			}
 
 			MLResults results = scriptExecutor.execute(script);
-
-			String history = MLContextUtil.createHistoryForScript(script, time);
-			scriptHistoryStrings.add(history);
-			scripts.put(script.getName(), script);
 
 			return results;
 		} catch (RuntimeException e) {
@@ -364,7 +363,7 @@ public class MLContext {
 	/**
 	 * Obtain whether or not all values should be maintained in the symbol table
 	 * after execution.
-	 * 
+	 *
 	 * @return {@code true} if all values should be maintained in the symbol
 	 *         table, {@code false} otherwise
 	 */
@@ -375,7 +374,7 @@ public class MLContext {
 	/**
 	 * Set whether or not all values should be maintained in the symbol table
 	 * after execution.
-	 * 
+	 *
 	 * @param maintainSymbolTable
 	 *            {@code true} if all values should be maintained in the symbol
 	 *            table, {@code false} otherwise
@@ -425,7 +424,7 @@ public class MLContext {
 	public void setGPU(boolean enable) {
 		this.gpu = enable;
 	}
-	
+
 	/**
 	 * Whether or not to explicitly "force" the usage of GPU.
 	 * If a GPU is not available, and the GPU mode is set or if available memory on GPU is less, SystemML will crash when the program is run.
@@ -513,8 +512,8 @@ public class MLContext {
 		}
 
 		private boolean isRegisteredAsInput(String parameterName) {
-			if (executingScript != null) {
-				Set<String> inputVariableNames = executingScript.getInputVariables();
+			if (executionScript != null) {
+				Set<String> inputVariableNames = executionScript.getInputVariables();
 				if (inputVariableNames != null) {
 					return inputVariableNames.contains(parameterName);
 				}
@@ -523,8 +522,8 @@ public class MLContext {
 		}
 
 		private MatrixObject getMatrixObject(String parameterName) {
-			if (executingScript != null) {
-				LocalVariableMap symbolTable = executingScript.getSymbolTable();
+			if (executionScript != null) {
+				LocalVariableMap symbolTable = executionScript.getSymbolTable();
 				if (symbolTable != null) {
 					Data data = symbolTable.get(parameterName);
 					if (data instanceof MatrixObject) {
@@ -540,10 +539,10 @@ public class MLContext {
 		}
 
 		public ArrayList<Instruction> performCleanupAfterRecompilation(ArrayList<Instruction> instructions) {
-			if (executingScript == null || executingScript.getOutputVariables() == null)
+			if (executionScript == null || executionScript.getOutputVariables() == null)
 				return instructions;
 
-			Set<String> outputVariableNames = executingScript.getOutputVariables();
+			Set<String> outputVariableNames = executionScript.getOutputVariables();
 			return JMLCUtils.cleanupRuntimeInstructions(instructions, outputVariableNames.toArray(new String[0]));
 		}
 	}
@@ -594,39 +593,6 @@ public class MLContext {
 	}
 
 	/**
-	 * Obtain a map of the scripts that have executed.
-	 *
-	 * @return a map of the scripts that have executed
-	 */
-	public Map<String, Script> getScripts() {
-		return scripts;
-	}
-
-	/**
-	 * Obtain a script that has executed by name.
-	 *
-	 * @param name
-	 *            the name of the script
-	 * @return the script corresponding to the name
-	 */
-	public Script getScriptByName(String name) {
-		Script script = scripts.get(name);
-		if (script == null) {
-			throw new MLContextException("Script with name '" + name + "' not found.");
-		}
-		return script;
-	}
-
-	/**
-	 * Display the history of scripts that have executed.
-	 *
-	 * @return the history of scripts that have executed
-	 */
-	public String history() {
-		return MLContextUtil.displayScriptHistory(scriptHistoryStrings);
-	}
-
-	/**
 	 * Closes the mlcontext, which includes the cleanup of static and local
 	 * state as well as scratch space and buffer pool cleanup. Note that the
 	 * spark context is not explicitly closed to allow external reuse.
@@ -646,10 +612,7 @@ public class MLContext {
 
 		// clear local status, but do not stop sc as it
 		// may be used or stopped externally
-		for (Script script : scripts.values())
-			script.clearAll();
-		scripts.clear();
-		scriptHistoryStrings.clear();
+		executionScript.clearAll();
 		resetConfig();
 		spark = null;
 	}
@@ -657,7 +620,7 @@ public class MLContext {
 	/**
 	 * Obtain information about the project such as version and build time from
 	 * the manifest in the SystemML jar file.
-	 * 
+	 *
 	 * @return information about the project
 	 */
 	public ProjectInfo info() {
@@ -672,7 +635,7 @@ public class MLContext {
 
 	/**
 	 * Obtain the SystemML version number.
-	 * 
+	 *
 	 * @return the SystemML version number
 	 */
 	public String version() {
@@ -684,7 +647,7 @@ public class MLContext {
 
 	/**
 	 * Obtain the SystemML jar file build time.
-	 * 
+	 *
 	 * @return the SystemML jar file build time
 	 */
 	public String buildTime() {
@@ -697,10 +660,34 @@ public class MLContext {
 	/**
 	 * Obtain the maximum number of heavy hitters that are printed out as part
 	 * of the statistics.
-	 * 
+	 *
 	 * @return maximum number of heavy hitters to print
 	 */
 	public int getStatisticsMaxHeavyHitters() {
 		return statisticsMaxHeavyHitters;
 	}
+
+	/**
+	 * Whether or not the default ScriptExecutor should be initialized before
+	 * execution.
+	 *
+	 * @return {@code true} if ScriptExecutor should be initialized before
+	 *         execution, {@code false} otherwise
+	 */
+	public boolean isInitBeforeExecution() {
+		return initBeforeExecution;
+	}
+
+	/**
+	 * Whether or not the default ScriptExecutor should be initialized before
+	 * execution.
+	 *
+	 * @param initBeforeExecution
+	 *            {@code true} if ScriptExecutor should be initialized before
+	 *            execution, {@code false} otherwise
+	 */
+	public void setInitBeforeExecution(boolean initBeforeExecution) {
+		this.initBeforeExecution = initBeforeExecution;
+	}
+
 }

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,12 +22,8 @@ package org.apache.sysml.api.mlcontext;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URL;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Scanner;
@@ -111,7 +107,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Compare two version strings (ie, "1.4.0" and "1.4.1").
-	 * 
+	 *
 	 * @param versionStr1
 	 *            First version string.
 	 * @param versionStr2
@@ -157,7 +153,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Determine whether the Spark version is supported.
-	 * 
+	 *
 	 * @param sparkVersion
 	 *            Spark version string (ie, "1.5.0").
 	 * @param minimumRecommendedSparkVersion
@@ -171,7 +167,7 @@ public final class MLContextUtil {
 	/**
 	 * Check that the Spark version is supported. If it isn't supported, throw
 	 * an MLContextException.
-	 * 
+	 *
 	 * @param spark
 	 *            SparkSession
 	 * @throws MLContextException
@@ -203,7 +199,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Obtain minimum recommended Spark version from the pom.xml file.
-	 * 
+	 *
 	 * @return the minimum recommended Spark version from XML parsing of the pom file (during development).
 	 */
 	static String getMinimumRecommendedSparkVersionFromPom() {
@@ -213,7 +209,7 @@ public final class MLContextUtil {
 	/**
 	 * Obtain the text associated with an XML element from the pom.xml file. In this implementation,
 	 * the element should be uniquely named, or results will be unpredicable.
-	 * 
+	 *
 	 * @param property unique property (element) from the pom.xml file
 	 * @return the text value associated with the given property
 	 */
@@ -249,7 +245,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Set SystemML configuration properties based on a configuration file.
-	 * 
+	 *
 	 * @param configFilePath
 	 *            Path to configuration file.
 	 * @throws MLContextException
@@ -281,7 +277,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Verify that the types of input values are supported.
-	 * 
+	 *
 	 * @param inputs
 	 *            Map of String/Object pairs
 	 * @throws MLContextException
@@ -295,7 +291,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Verify that the type of input value is supported.
-	 * 
+	 *
 	 * @param name
 	 *            The name of the input
 	 * @param value
@@ -329,7 +325,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Verify that the type of input parameter value is supported.
-	 * 
+	 *
 	 * @param parameterName
 	 *            The name of the input parameter
 	 * @param parameterValue
@@ -367,7 +363,7 @@ public final class MLContextUtil {
 	/**
 	 * Is the object one of the supported basic data types? (Integer, Boolean,
 	 * Double, String)
-	 * 
+	 *
 	 * @param object
 	 *            the object type to be examined
 	 * @return {@code true} if type is a basic data type; otherwise
@@ -387,7 +383,7 @@ public final class MLContextUtil {
 	/**
 	 * Obtain the SystemML scalar value type string equivalent of an accepted
 	 * basic type (Integer, Boolean, Double, String)
-	 * 
+	 *
 	 * @param object
 	 *            the object type to be examined
 	 * @return a String representing the type as a SystemML scalar value type
@@ -413,7 +409,7 @@ public final class MLContextUtil {
 	/**
 	 * Is the object one of the supported complex data types? (JavaRDD, RDD,
 	 * DataFrame, BinaryBlockMatrix, Matrix, double[][], MatrixBlock, URL)
-	 * 
+	 *
 	 * @param object
 	 *            the object type to be examined
 	 * @return {@code true} if type is a complex data type; otherwise
@@ -433,7 +429,7 @@ public final class MLContextUtil {
 	/**
 	 * Converts non-string basic input parameter values to strings to pass to
 	 * the parser.
-	 * 
+	 *
 	 * @param basicInputParameterMap
 	 *            map of input parameters
 	 * @param scriptType
@@ -475,7 +471,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Convert input types to internal SystemML representations
-	 * 
+	 *
 	 * @param parameterName
 	 *            The name of the input parameter
 	 * @param parameterValue
@@ -488,7 +484,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Convert input types to internal SystemML representations
-	 * 
+	 *
 	 * @param parameterName
 	 *            The name of the input parameter
 	 * @param parameterValue
@@ -626,7 +622,7 @@ public final class MLContextUtil {
 	/**
 	 * If no metadata is supplied for an RDD or JavaRDD, this method can be used
 	 * to determine whether the data appears to be matrix (or a frame)
-	 * 
+	 *
 	 * @param line
 	 *            a line of the RDD
 	 * @return {@code true} if all the csv-separated values are numbers,
@@ -651,7 +647,7 @@ public final class MLContextUtil {
 	/**
 	 * Examine the DataFrame schema to determine whether the data appears to be
 	 * a matrix.
-	 * 
+	 *
 	 * @param df
 	 *            the DataFrame
 	 * @return {@code true} if the DataFrame appears to be a matrix,
@@ -684,7 +680,7 @@ public final class MLContextUtil {
 	/**
 	 * Return a double-quoted string with inner single and double quotes
 	 * escaped.
-	 * 
+	 *
 	 * @param str
 	 *            the original string
 	 * @return double-quoted string with inner single and double quotes escaped
@@ -714,7 +710,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Display the keys and values in a Map
-	 * 
+	 *
 	 * @param mapName
 	 *            the name of the map
 	 * @param map
@@ -745,7 +741,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Display the values in a Set
-	 * 
+	 *
 	 * @param setName
 	 *            the name of the Set
 	 * @param set
@@ -773,7 +769,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Display the keys and values in the symbol table
-	 * 
+	 *
 	 * @param name
 	 *            the name of the symbol table
 	 * @param symbolTable
@@ -790,7 +786,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Display the keys and values in the symbol table
-	 * 
+	 *
 	 * @param symbolTable
 	 *            the LocalVariableMap
 	 * @return the keys and values in the symbol table as a String
@@ -823,7 +819,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Obtain a symbol table output type as a String
-	 * 
+	 *
 	 * @param symbolTable
 	 *            the symbol table
 	 * @param outputName
@@ -850,7 +846,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Obtain a display of script inputs.
-	 * 
+	 *
 	 * @param name
 	 *            the title to display for the inputs
 	 * @param map
@@ -896,9 +892,9 @@ public final class MLContextUtil {
 				 String str = null;
 				 if(object instanceof MatrixBlock) {
 					 MatrixBlock mb = (MatrixBlock) object;
-					 str = "MatrixBlock [sparse? = " + mb.isInSparseFormat() + ", nonzeros = " + mb.getNonZeros() + ", size: " + mb.getNumRows() + " X " + mb.getNumColumns() + "]";  
+					 str = "MatrixBlock [sparse? = " + mb.isInSparseFormat() + ", nonzeros = " + mb.getNonZeros() + ", size: " + mb.getNumRows() + " X " + mb.getNumColumns() + "]";
 				 }
-				 else 
+				 else
 					 str = object.toString(); // TODO: Deal with OOM for other objects such as Frame, etc
 				 str = StringUtils.abbreviate(str, 100);
 				 sb.append(str);
@@ -910,7 +906,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Obtain a display of the script outputs.
-	 * 
+	 *
 	 * @param name
 	 *            the title to display for the outputs
 	 * @param outputNames
@@ -918,7 +914,7 @@ public final class MLContextUtil {
 	 * @param symbolTable
 	 *            the symbol table
 	 * @return the script outputs represented as a String
-	 * 
+	 *
 	 */
 	public static String displayOutputs(String name, Set<String> outputNames, LocalVariableMap symbolTable) {
 		StringBuilder sb = new StringBuilder();
@@ -930,13 +926,13 @@ public final class MLContextUtil {
 
 	/**
 	 * Obtain a display of the script outputs.
-	 * 
+	 *
 	 * @param outputNames
 	 *            the names of the output variables
 	 * @param symbolTable
 	 *            the symbol table
 	 * @return the script outputs represented as a String
-	 * 
+	 *
 	 */
 	public static String displayOutputs(Set<String> outputNames, LocalVariableMap symbolTable) {
 		StringBuilder sb = new StringBuilder();
@@ -970,7 +966,7 @@ public final class MLContextUtil {
 
 	/**
 	 * The SystemML welcome message
-	 * 
+	 *
 	 * @return the SystemML welcome message
 	 */
 	public static String welcomeMessage() {
@@ -988,50 +984,8 @@ public final class MLContextUtil {
 	}
 
 	/**
-	 * Generate a String history entry for a script.
-	 * 
-	 * @param script
-	 *            the script
-	 * @param when
-	 *            when the script was executed
-	 * @return a script history entry as a String
-	 */
-	public static String createHistoryForScript(Script script, long when) {
-		DateFormat dateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss.SSS");
-		StringBuilder sb = new StringBuilder();
-		sb.append("Script Name: " + script.getName() + "\n");
-		sb.append("When: " + dateFormat.format(new Date(when)) + "\n");
-		sb.append(script.displayInputs());
-		sb.append(script.displayOutputs());
-		sb.append(script.displaySymbolTable());
-		return sb.toString();
-	}
-
-	/**
-	 * Generate a String listing of the script execution history.
-	 * 
-	 * @param scriptHistory
-	 *            the list of script history entries
-	 * @return the listing of the script execution history as a String
-	 */
-	public static String displayScriptHistory(List<String> scriptHistory) {
-		StringBuilder sb = new StringBuilder();
-		sb.append("MLContext Script History:\n");
-		if (scriptHistory.isEmpty()) {
-			sb.append("None");
-		}
-		int i = 1;
-		for (String history : scriptHistory) {
-			sb.append("--------------------------------------------\n");
-			sb.append("#" + (i++) + ":\n");
-			sb.append(history);
-		}
-		return sb.toString();
-	}
-
-	/**
 	 * Obtain the Spark Context
-	 * 
+	 *
 	 * @param mlContext
 	 *            the SystemML MLContext
 	 * @return the Spark Context
@@ -1042,7 +996,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Obtain the Java Spark Context
-	 * 
+	 *
 	 * @param mlContext
 	 *            the SystemML MLContext
 	 * @return the Java Spark Context
@@ -1053,7 +1007,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Obtain the Spark Context from the MLContextProxy
-	 * 
+	 *
 	 * @return the Spark Context
 	 */
 	public static SparkContext getSparkContextFromProxy() {
@@ -1064,7 +1018,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Obtain the Java Spark Context from the MLContextProxy
-	 * 
+	 *
 	 * @return the Java Spark Context
 	 */
 	public static JavaSparkContext getJavaSparkContextFromProxy() {
@@ -1075,7 +1029,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Obtain the Spark Session from the MLContextProxy
-	 * 
+	 *
 	 * @return the Spark Session
 	 */
 	public static SparkSession getSparkSessionFromProxy() {
@@ -1085,7 +1039,7 @@ public final class MLContextUtil {
 	/**
 	 * Determine if the symbol table contains a FrameObject with the given
 	 * variable name.
-	 * 
+	 *
 	 * @param symbolTable
 	 *            the LocalVariableMap
 	 * @param variableName
@@ -1101,7 +1055,7 @@ public final class MLContextUtil {
 	/**
 	 * Determine if the symbol table contains a MatrixObject with the given
 	 * variable name.
-	 * 
+	 *
 	 * @param symbolTable
 	 *            the LocalVariableMap
 	 * @param variableName
@@ -1116,7 +1070,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Delete the 'remove variable' instructions from a runtime program.
-	 * 
+	 *
 	 * @param progam
 	 *            runtime program
 	 */
@@ -1139,7 +1093,7 @@ public final class MLContextUtil {
 	/**
 	 * Recursively traverse program block to delete 'remove variable'
 	 * instructions.
-	 * 
+	 *
 	 * @param pb
 	 *            Program block
 	 */
@@ -1166,7 +1120,7 @@ public final class MLContextUtil {
 
 	/**
 	 * Delete 'remove variable' instructions.
-	 * 
+	 *
 	 * @param instructions
 	 *            list of instructions
 	 */


### PR DESCRIPTION
Remove Script history from MLContext for multiple reasons:
1) Reduce number of object references
2) In environments such as Spark Shell, a user typically already
   has references to the Script objects
3) History implementation can lead to confusing behavior since the
   LinkedHashMap values can point to the same Script object, which
   can change over time.