### PR TITLE
[Doc] Change PCA scale value

### DIFF
--- a/docs/algorithms-matrix-factorization.md
+++ b/docs/algorithms-matrix-factorization.md
@@ -113,7 +113,7 @@ SystemML Language Reference for details.
                             -nvargs INPUT=/user/ml/input.mtx
                                     K=10
                                     CENTER=1
-                                    SCALE=1O
+                                    SCALE=1
                                     FMT=csv
                                     PROJDATA=1
                                     OUTPUT=/user/ml/pca_output/
@@ -129,7 +129,7 @@ SystemML Language Reference for details.
                                  -nvargs INPUT=/user/ml/input.mtx
                                          K=10
                                          CENTER=1
-                                         SCALE=1O
+                                         SCALE=1
                                          FMT=csv
                                          PROJDATA=1
                                          OUTPUT=/user/ml/pca_output/
@@ -142,7 +142,7 @@ SystemML Language Reference for details.
                             -nvargs INPUT=/user/ml/test_input.mtx
                                     K=10
                                     CENTER=1
-                                    SCALE=1O
+                                    SCALE=1
                                     FMT=csv
                                     PROJDATA=1
                                     MODEL=/user/ml/pca_output/
@@ -159,7 +159,7 @@ SystemML Language Reference for details.
                                  -nvargs INPUT=/user/ml/test_input.mtx
                                          K=10
                                          CENTER=1
-                                         SCALE=1O
+                                         SCALE=1
                                          FMT=csv
                                          PROJDATA=1
                                          MODEL=/user/ml/pca_output/


### PR DESCRIPTION
Currently in the matrix factorisation docs the value of scale is 10. 
This value can be either `0` or `1`.

